### PR TITLE
fix: resolve Docker glibc version mismatch (issue #5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,7 +74,26 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Smoke test: verify the binary actually runs in the container
+      # This catches glibc mismatches and other runtime issues before pushing
+      - name: Smoke test - verify binary runs
+        run: |
+          echo "Testing container startup..."
+          docker run --rm ${{ env.IMAGE_NAME }}:test --version
+          echo "Testing help command..."
+          docker run --rm ${{ env.IMAGE_NAME }}:test --help
+          echo "Smoke test passed!"
+
+      - name: Push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'Dockerfile'
       - '.github/workflows/test.yml'
   pull_request:
     branches: [main]
@@ -14,6 +15,7 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'Dockerfile'
       - '.github/workflows/test.yml'
 
 env:
@@ -233,18 +235,51 @@ jobs:
         run: cargo audit
         continue-on-error: true
 
+  # Docker build validation - ensures the image builds and runs correctly
+  docker-build:
+    name: Docker Build & Smoke Test
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: kafka-backup:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Smoke test: verify glibc compatibility and binary execution
+      # This catches issues like rust:latest using newer glibc than runtime image
+      - name: Smoke test - verify binary runs
+        run: |
+          echo "Verifying glibc version in runtime image..."
+          docker run --rm --entrypoint ldd kafka-backup:test --version
+          echo ""
+          echo "Testing binary execution..."
+          docker run --rm kafka-backup:test --version
+          docker run --rm kafka-backup:test --help > /dev/null
+          echo "Docker smoke test passed!"
+
   # Summary job for branch protection
   tests-complete:
     name: Tests Complete
     runs-on: ubuntu-latest
-    needs: [check, unit-tests, integration-tests]
+    needs: [check, unit-tests, integration-tests, docker-build]
     if: always()
     steps:
       - name: Check all tests passed
         run: |
           if [ "${{ needs.check.result }}" != "success" ] || \
              [ "${{ needs.unit-tests.result }}" != "success" ] || \
-             [ "${{ needs.integration-tests.result }}" != "success" ]; then
+             [ "${{ needs.integration-tests.result }}" != "success" ] || \
+             [ "${{ needs.docker-build.result }}" != "success" ]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # ============================================================================
 # STAGE 1: Builder (compile Rust application)
 # ============================================================================
-FROM rust:latest AS builder
+# IMPORTANT: Use rust:bookworm to match the runtime stage's Debian version.
+# Using rust:latest can cause glibc version mismatches since it may use a newer
+# Debian version (e.g., Trixie with glibc 2.41) while the runtime uses Bookworm
+# (glibc 2.36). Binaries compiled against newer glibc won't run on older versions.
+# See: https://github.com/osodevops/kafka-backup/issues/5
+FROM rust:bookworm AS builder
 
 WORKDIR /app
 
@@ -24,6 +29,8 @@ RUN cargo build --release --bin kafka-backup && \
 # ============================================================================
 # STAGE 2: Runtime (minimal image for production)
 # ============================================================================
+# NOTE: This must use the same Debian version as the builder stage (bookworm).
+# If you upgrade the runtime image, also update the builder stage to match.
 FROM debian:bookworm-slim AS runtime
 
 # Create non-root user for security


### PR DESCRIPTION
## Summary

- Pin Docker builder image from `rust:latest` to `rust:bookworm` to match runtime's Debian version
- Add smoke tests to CI to catch runtime issues before publishing
- Add Docker build validation to PR workflow

## Root Cause

The `rust:latest` image recently upgraded from Debian 12 (Bookworm) to Debian 13 (Trixie), which ships with glibc 2.41. The runtime image `debian:bookworm-slim` only has glibc 2.36. Since glibc is only forward-compatible (not backward), binaries compiled against 2.41 fail with:

```
kafka-backup: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Pin builder to `rust:bookworm`, add explanatory comments |
| `docker-publish.yml` | Add smoke test before pushing to Docker Hub |
| `test.yml` | Add `Dockerfile` to trigger paths, new `docker-build` job |

## Testing

- [x] Built Docker image locally with `docker build -t kafka-backup:test .`
- [x] Verified binary runs: `docker run --rm kafka-backup:test --version` → `kafka-backup 0.4.0`
- [x] Verified glibc matches: `docker run --rm --entrypoint ldd kafka-backup:test --version` → `glibc 2.36`

## After Merge

A new release tag will be needed to publish the fixed Docker image to Docker Hub.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)