### PR TITLE
ci: dispatch release workflow after automated tag

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -1,6 +1,7 @@
 name: Release Tagger
 
 permissions:
+  actions: write
   contents: write
 
 on:
@@ -37,30 +38,84 @@ jobs:
             --mode tagger \
             --event-name "${{ github.event_name }}"
 
-      - name: Create release tag
+      - name: Create or verify release tag
         if: ${{ env.VERSION_CHANGED == 'true' }}
         shell: bash
-        env:
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           set -euo pipefail
 
           if git rev-parse --verify --quiet "refs/tags/${RELEASE_TAG}" > /dev/null; then
             TAG_COMMIT="$(git rev-list -n 1 "${RELEASE_TAG}")"
             if [[ "$TAG_COMMIT" == "${GITHUB_SHA}" ]]; then
-              echo "${RELEASE_TAG} already points at ${GITHUB_SHA}; nothing to do."
+              echo "${RELEASE_TAG} already points at ${GITHUB_SHA}; continuing to release dispatch."
+            else
+              echo "::error::${RELEASE_TAG} already exists at ${TAG_COMMIT}; refusing to retag ${GITHUB_SHA}."
+              exit 1
+            fi
+          else
+            git tag "${RELEASE_TAG}" "${GITHUB_SHA}"
+            git push origin "refs/tags/${RELEASE_TAG}"
+          fi
+
+      - name: Dispatch release workflow
+        if: ${{ env.VERSION_CHANGED == 'true' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Tag pushes created by a workflow are not a reliable trigger for a second workflow.
+          # Dispatch the Release workflow explicitly and fail if the run never appears.
+
+          TAG_COMMIT="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if [[ "$TAG_COMMIT" != "${GITHUB_SHA}" ]]; then
+            echo "::error::${RELEASE_TAG} points at ${TAG_COMMIT}; expected ${GITHUB_SHA}."
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" > /dev/null 2>&1; then
+            echo "${RELEASE_TAG} already has a GitHub Release; no dispatch needed."
+            exit 0
+          fi
+
+          existing_run="$(
+            gh run list \
+              --workflow release.yml \
+              --event workflow_dispatch \
+              --commit "${GITHUB_SHA}" \
+              --limit 50 \
+              --json status,url \
+              --jq '.[] | select(.status != "completed") | .url' \
+              | head -n 1
+          )"
+          if [[ -n "$existing_run" ]]; then
+            echo "Release workflow is already running for ${RELEASE_TAG}: ${existing_run}"
+            exit 0
+          fi
+
+          dispatch_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh workflow run release.yml --ref "${RELEASE_TAG}"
+
+          for attempt in {1..30}; do
+            run_url="$(
+              gh run list \
+                --workflow release.yml \
+                --event workflow_dispatch \
+                --commit "${GITHUB_SHA}" \
+                --limit 50 \
+                --json createdAt,url \
+                --jq ".[] | select(.createdAt >= \"${dispatch_started_at}\") | .url" \
+                | head -n 1
+            )"
+
+            if [[ -n "$run_url" ]]; then
+              echo "Release workflow dispatched for ${RELEASE_TAG}: ${run_url}"
               exit 0
             fi
 
-            echo "::error::${RELEASE_TAG} already exists at ${TAG_COMMIT}; refusing to retag ${GITHUB_SHA}."
-            exit 1
-          fi
+            sleep 5
+          done
 
-          if [[ -z "${RELEASE_PAT}" ]]; then
-            echo "::error::RELEASE_PAT is required so the tag push triggers the Release workflow."
-            exit 1
-          fi
-
-          git tag "${RELEASE_TAG}" "${GITHUB_SHA}"
-          git remote set-url origin "https://x-access-token:${RELEASE_PAT}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "refs/tags/${RELEASE_TAG}"
+          echo "::error::Release workflow dispatch for ${RELEASE_TAG} did not appear in GitHub Actions."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  workflow_dispatch:
   pull_request:
   push:
     tags:
@@ -96,9 +97,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ !github.event.pull_request && github.ref_type == 'tag' && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && github.ref_type == 'tag' && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ !github.event.pull_request && github.ref_type == 'tag' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -123,7 +124,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (!github.event.pull_request && github.ref_type == 'tag' && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add workflow_dispatch to the Release workflow so it can be triggered explicitly for a tag
- Make Release publishing only happen for tag refs, preventing accidental manual branch releases
- Update Release Tagger to create/verify the tag, dispatch release.yml explicitly, and fail if a release run is not observed
- Stop relying on tag-push workflow fan-out from inside GitHub Actions

## Verification
- YAML parsed with Ruby for release.yml and release-tagger.yml
- git diff --check
- gh run list --workflow release.yml --event workflow_dispatch --commit 784b31c7c450fc4256965a82f3e38e618f19c314 --limit 1 --json createdAt,url