### PR TITLE
PR with 5 fixes 

### DIFF
--- a/crates/kafka-backup-cli/src/commands/validation.rs
+++ b/crates/kafka-backup-cli/src/commands/validation.rs
@@ -7,12 +7,11 @@ use chrono::Utc;
 use tracing::info;
 use uuid::Uuid;
 
-use kafka_backup_core::config::KafkaConfig;
 use kafka_backup_core::evidence::report::{
     hex_encode, BackupInfo, EvidenceReport, IntegrityInfo, RestoreInfo, ToolInfo,
 };
 use kafka_backup_core::evidence::{pdf, signing, storage as evidence_storage};
-use kafka_backup_core::kafka::KafkaClient;
+use kafka_backup_core::kafka::PartitionLeaderRouter;
 use kafka_backup_core::manifest::BackupManifest;
 use kafka_backup_core::notification::pagerduty::PagerDutyNotifier;
 use kafka_backup_core::notification::slack::SlackNotifier;
@@ -66,14 +65,18 @@ pub async fn run(config_path: &str, pitr: Option<i64>, triggered_by: Option<&str
         "Manifest loaded"
     );
 
-    // Connect to restored Kafka cluster
-    let target_client = create_kafka_client(&config.target).await?;
+    // Connect to restored Kafka cluster via PartitionLeaderRouter so that
+    // ListOffsets requests are routed to the leader of each partition.
+    // This prevents NOT_LEADER_FOR_PARTITION errors (error code 6) on
+    // multi-broker clusters where leadership is distributed across brokers.
+    let target_router = PartitionLeaderRouter::new(config.target.clone()).await
+        .with_context(|| "Failed to connect to target Kafka cluster")?;
 
     // Build validation context
     let ctx = ValidationContext {
         backup_id: config.backup_id.clone(),
         backup_manifest: manifest.clone(),
-        target_client: Arc::new(target_client),
+        target_client: Arc::new(target_router),
         storage: storage.clone(),
         pitr_timestamp: config.pitr_timestamp,
         http_client: reqwest::Client::new(),
@@ -351,15 +354,6 @@ pub async fn evidence_verify(
 
     println!("\nEvidence report integrity: VERIFIED");
     Ok(())
-}
-
-async fn create_kafka_client(config: &KafkaConfig) -> Result<KafkaClient> {
-    let client = KafkaClient::new(config.clone());
-    client
-        .connect()
-        .await
-        .with_context(|| "Failed to connect to target Kafka cluster")?;
-    Ok(client)
 }
 
 fn build_notification_senders(

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -11,7 +11,7 @@ use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use crate::compression::extension;
 use crate::config::{BackupOptions, CompressionType, Config, Mode, StartOffset};
 use crate::health::HealthCheck;
-use crate::kafka::{consumer_groups::fetch_offsets, PartitionLeaderRouter, TopicMetadata};
+use crate::kafka::{PartitionLeaderRouter, TopicMetadata};
 use crate::manifest::{BackupManifest, BackupRecord, SegmentMetadata};
 use crate::metrics::{ErrorType, PerformanceMetrics, PrometheusMetrics};
 use crate::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
@@ -575,13 +575,6 @@ impl BackupEngine {
             return Ok(());
         }
 
-        // List groups from every broker (KRaft: each broker is coordinator for a subset)
-        let all_groups = self.router.list_groups_all_brokers().await?;
-        debug!(
-            "Consumer group snapshot: {} groups across all brokers",
-            all_groups.len()
-        );
-
         #[derive(serde::Serialize)]
         struct GroupEntry {
             group_id: String,
@@ -595,26 +588,19 @@ impl BackupEngine {
             groups: Vec<GroupEntry>,
         }
 
-        // Fetch offsets via bootstrap_client through the router
-        let bootstrap_client = self.router.bootstrap_client();
+        // Fetch offsets per coordinator broker: each broker handles OffsetFetch only
+        // for groups it coordinates. Using the bootstrap client for all groups causes
+        // NOT_COORDINATOR (error 16) responses for groups on other brokers, silently
+        // producing empty offset lists (Fix 5 — multi-broker coordinator routing).
+        let group_offsets = self.router.fetch_group_offsets_all_coordinators().await?;
+        debug!(
+            "Consumer group snapshot: {} groups with committed offsets across all coordinators",
+            group_offsets.len()
+        );
+
         let mut snapshot_groups: Vec<GroupEntry> = Vec::new();
 
-        for group in &all_groups {
-            let committed = match fetch_offsets(bootstrap_client, &group.group_id, None).await {
-                Ok(c) => c,
-                Err(e) => {
-                    debug!(
-                        "Could not fetch offsets for group {}: {}",
-                        group.group_id, e
-                    );
-                    continue;
-                }
-            };
-
-            if committed.is_empty() {
-                continue;
-            }
-
+        for (group_id, committed) in group_offsets {
             let mut offsets_by_topic: std::collections::HashMap<
                 String,
                 std::collections::HashMap<String, i64>,
@@ -630,7 +616,7 @@ impl BackupEngine {
 
             if !offsets_by_topic.is_empty() {
                 snapshot_groups.push(GroupEntry {
-                    group_id: group.group_id.clone(),
+                    group_id,
                     offsets: offsets_by_topic,
                 });
             }

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -636,6 +636,14 @@ impl BackupEngine {
             }
         }
 
+        // Do not overwrite an existing non-empty snapshot with an empty one.
+        // This protects against losing group offsets when kafka-backup restarts
+        // before the consuming applications have reconnected and committed offsets.
+        if snapshot_groups.is_empty() {
+            debug!("Consumer group snapshot: no groups with committed offsets on backed topics, keeping existing snapshot");
+            return Ok(());
+        }
+
         let snapshot = Snapshot {
             snapshot_time: chrono::Utc::now().timestamp_millis(),
             groups: snapshot_groups,

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -905,7 +905,7 @@ impl RestoreOptions {
         }
 
         // Validate consumer group offset reset
-        if self.reset_consumer_offsets && self.consumer_groups.is_empty() {
+        if self.reset_consumer_offsets && self.consumer_groups.is_empty() && !self.auto_consumer_groups {
             return Err(crate::Error::Config(
                 "consumer_groups must be specified when reset_consumer_offsets is true".to_string(),
             ));

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -81,6 +81,15 @@ impl PartitionLeaderRouter {
         Ok(router)
     }
 
+    /// Returns a reference to the bootstrap KafkaClient.
+    ///
+    /// Useful for operations that do not require partition-leader routing
+    /// (e.g. ListGroups, OffsetFetch for consumer groups) where any broker
+    /// will forward the request to the group coordinator.
+    pub fn client(&self) -> &KafkaClient {
+        &self.bootstrap_client
+    }
+
     /// Refresh cluster metadata and update partition leader mappings.
     ///
     /// This should be called periodically or when a NOT_LEADER_FOR_PARTITION

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -666,6 +666,81 @@ impl PartitionLeaderRouter {
         Ok(all_groups)
     }
 
+    /// Fetch committed offsets for all consumer groups, routing each `OffsetFetch`
+    /// to the broker that coordinates the group.
+    ///
+    /// In KRaft mode, each broker is group coordinator for a subset of consumer
+    /// groups. Sending `OffsetFetch` to the bootstrap broker only returns offsets
+    /// for groups whose coordinator happens to be that broker; all others return
+    /// `NOT_COORDINATOR` (error 16) or an empty response.
+    ///
+    /// This method lists groups per-broker and fetches their offsets from the same
+    /// broker, ensuring complete coverage of all coordinators.
+    ///
+    /// Returns a map: `group_id → Vec<CommittedOffset>`.
+    pub async fn fetch_group_offsets_all_coordinators(
+        &self,
+    ) -> Result<
+        std::collections::HashMap<String, Vec<super::consumer_groups::CommittedOffset>>,
+    > {
+        let broker_ids: Vec<i32> = {
+            let meta = self.broker_metadata.read().await;
+            meta.keys().copied().collect()
+        };
+
+        let mut all_offsets: std::collections::HashMap<
+            String,
+            Vec<super::consumer_groups::CommittedOffset>,
+        > = std::collections::HashMap::new();
+
+        for broker_id in broker_ids {
+            match self.get_broker_connection(broker_id).await {
+                Ok(client) => match super::consumer_groups::list_groups(&client).await {
+                    Ok(groups) => {
+                        for g in &groups {
+                            match super::consumer_groups::fetch_offsets(
+                                &client,
+                                &g.group_id,
+                                None,
+                            )
+                            .await
+                            {
+                                Ok(offsets) if !offsets.is_empty() => {
+                                    all_offsets.insert(g.group_id.clone(), offsets);
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    debug!(
+                                        "fetch_offsets for group {} on broker {}: {}",
+                                        g.group_id, broker_id, e
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "list_groups from broker {} for offset fetching: {}",
+                            broker_id, e
+                        );
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        "Failed to connect to broker {} for group offsets: {}",
+                        broker_id, e
+                    );
+                }
+            }
+        }
+
+        debug!(
+            "fetch_group_offsets_all_coordinators: {} groups with committed offsets",
+            all_offsets.len()
+        );
+        Ok(all_offsets)
+    }
+
     /// Delete records from a topic by advancing the log-start-offset to `before_offset`.
     ///
     /// Records with offset < `before_offset` become inaccessible. This empties a topic

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -378,6 +378,10 @@ pub struct RestoreReport {
 
     /// Offset mapping (for consumer group reset)
     pub offset_mapping: OffsetMapping,
+
+    /// Consumer groups resolved during restore (includes auto-loaded groups from snapshot)
+    #[serde(default)]
+    pub resolved_consumer_groups: Vec<String>,
 }
 
 /// Per-topic restore report

--- a/crates/kafka-backup-core/src/offset_store/sqlite.rs
+++ b/crates/kafka-backup-core/src/offset_store/sqlite.rs
@@ -285,6 +285,12 @@ impl OffsetStore for SqliteOffsetStore {
             *pool = new_pool;
         }
 
+        // Run schema migrations on the loaded database. The stored DB may have
+        // been created by an older version that is missing tables added later
+        // (e.g. backup_jobs). CREATE TABLE IF NOT EXISTS is idempotent so this
+        // is always safe to call.
+        self.initialize_schema().await?;
+
         info!("Loaded offset database from storage: {}", s3_key);
         Ok(true)
     }

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -472,6 +472,7 @@ impl RestoreEngine {
                 throughput_bytes_per_sec: 0.0,
                 errors: dry_run_report.errors,
                 offset_mapping: OffsetMapping::new(),
+                resolved_consumer_groups: Vec::new(),
             });
         }
 
@@ -527,6 +528,7 @@ impl RestoreEngine {
                 throughput_bytes_per_sec: 0.0,
                 errors: Vec::new(),
                 offset_mapping: OffsetMapping::new(),
+                resolved_consumer_groups: Vec::new(),
             });
         }
 
@@ -625,6 +627,7 @@ impl RestoreEngine {
             throughput_bytes_per_sec: 0.0,
             errors,
             offset_mapping,
+            resolved_consumer_groups: restore_options.consumer_groups.clone(),
         })
     }
 

--- a/crates/kafka-backup-core/src/restore/three_phase.rs
+++ b/crates/kafka-backup-core/src/restore/three_phase.rs
@@ -131,8 +131,16 @@ impl ThreePhaseRestore {
         }
 
         // Phase 3: Offset Reset (if consumer groups configured)
-        let (offset_reset_plan, offset_reset_report) = if restore_options.reset_consumer_offsets
-            && !restore_options.consumer_groups.is_empty()
+        // Use resolved_consumer_groups which includes auto-loaded groups from snapshot
+        let effective_consumer_groups = if !restore_report.resolved_consumer_groups.is_empty() {
+            restore_report.resolved_consumer_groups.clone()
+        } else {
+            restore_options.consumer_groups.clone()
+        };
+        let effective_reset = restore_options.reset_consumer_offsets
+            || (restore_options.auto_consumer_groups && !effective_consumer_groups.is_empty());
+        let (offset_reset_plan, offset_reset_report) = if effective_reset
+            && !effective_consumer_groups.is_empty()
         {
             info!("Phase 3: Generating and applying offset reset plan...");
 
@@ -144,7 +152,7 @@ impl ThreePhaseRestore {
             let plan = self
                 .generate_offset_reset_plan(
                     &restore_report.offset_mapping,
-                    &restore_options.consumer_groups,
+                    &effective_consumer_groups,
                     strategy,
                 )
                 .await?;
@@ -159,8 +167,9 @@ impl ThreePhaseRestore {
 
             (Some(plan), report)
         } else {
-            if !restore_options.consumer_groups.is_empty()
+            if !effective_consumer_groups.is_empty()
                 && !restore_options.reset_consumer_offsets
+                && !restore_options.auto_consumer_groups
             {
                 warnings.push(
                     "Consumer groups specified but reset_consumer_offsets=false, skipping Phase 3"

--- a/crates/kafka-backup-core/src/validation/consumer_group.rs
+++ b/crates/kafka-backup-core/src/validation/consumer_group.rs
@@ -35,8 +35,11 @@ impl ValidationCheck for ConsumerGroupOffsetCheck {
     async fn run(&self, ctx: &ValidationContext) -> Result<ValidationResult> {
         let start = Instant::now();
 
-        // List all consumer groups on the restored cluster
-        let groups = consumer_groups::list_groups(&ctx.target_client).await?;
+        // List all consumer groups on the restored cluster.
+        // Uses the bootstrap KafkaClient from the router — ListGroups/OffsetFetch
+        // are forwarded by the broker to the group coordinator, so partition-leader
+        // routing is not needed here.
+        let groups = consumer_groups::list_groups(ctx.target_client.client()).await?;
 
         let group_ids: Vec<String> =
             if self.config.verify_all_groups || self.config.groups.is_empty() {
@@ -64,7 +67,7 @@ impl ValidationCheck for ConsumerGroupOffsetCheck {
         let mut issues: Vec<serde_json::Value> = Vec::new();
 
         for group_id in &group_ids {
-            match consumer_groups::fetch_offsets(&ctx.target_client, group_id, None).await {
+            match consumer_groups::fetch_offsets(ctx.target_client.client(), group_id, None).await {
                 Ok(offsets) => {
                     groups_verified += 1;
                     let offset_count = offsets.len() as u64;

--- a/crates/kafka-backup-core/src/validation/context.rs
+++ b/crates/kafka-backup-core/src/validation/context.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::kafka::KafkaClient;
+use crate::kafka::PartitionLeaderRouter;
 use crate::manifest::BackupManifest;
 use crate::storage::StorageBackend;
 
@@ -14,8 +14,11 @@ pub struct ValidationContext {
     /// The backup manifest loaded from object storage.
     pub backup_manifest: BackupManifest,
 
-    /// Kafka client connected to the restored (target) cluster.
-    pub target_client: Arc<KafkaClient>,
+    /// Partition-leader-aware Kafka client connected to the restored (target) cluster.
+    /// Uses PartitionLeaderRouter so that ListOffsets requests are routed to the
+    /// correct broker leader for each partition, avoiding NOT_LEADER_FOR_PARTITION
+    /// errors (error code 6) on multi-broker clusters.
+    pub target_client: Arc<PartitionLeaderRouter>,
 
     /// Storage backend for reading backup data / uploading evidence.
     pub storage: Arc<dyn StorageBackend>,

--- a/docs/Fork_fixes.md
+++ b/docs/Fork_fixes.md
@@ -142,3 +142,37 @@ The `ConsumerGroupOffsetCheck` uses `ListGroups` / `OffsetFetch` which are forwa
 [PASSED] MessageCountCheck — 39 topics; 3638 messages expected, 3637 restored; 0 discrepancies
 [PASSED] OffsetRangeCheck  — 45 partitions checked; 45 passed; 0 issues
 ```
+
+---
+
+## Fix 3 — SQLite schema migration not run after loading offset DB from storage
+
+**Status:** Implemented — commit on `fix/auto-consumer-groups-phase3`  
+**Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
+
+### Root cause
+
+`load_from_storage()` downloads `offsets.db` from object storage and replaces the SQLite connection pool. However, `initialize_schema()` was **not called** on the newly loaded database.
+
+If the stored DB was created by an older binary (before the `backup_jobs` table was added), or if backup data was wiped from object storage while `offsets.db` was left behind, the next startup would fail immediately:
+
+```
+Error: Storage error: Backend error: error returned from database: (code: 1) no such table: backup_jobs
+[kafka-backup] WARNING: kafka-backup exited with code 0, restarting in 10s...
+```
+
+The pod would restart in a loop until the outdated/incomplete `offsets.db` was manually removed from storage.
+
+### Fix
+
+Call `initialize_schema()` after the pool is replaced in `load_from_storage()`. All DDL statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`, making this call idempotent on up-to-date databases.
+
+#### File changed
+
+| File | Change |
+|------|--------|
+| `crates/kafka-backup-core/src/offset_store/sqlite.rs` | Call `self.initialize_schema().await?` after pool replacement in `load_from_storage()` |
+
+### Workaround (before rebuild)
+
+Delete `kafka-backup/offsets.db` from object storage when resetting backup data.

--- a/docs/Fork_fixes.md
+++ b/docs/Fork_fixes.md
@@ -214,7 +214,7 @@ self.storage.put(&key, ...).await?;
 
 // After (skip write if empty)
 if snapshot_groups.is_empty() {
-    debug!("No groups with committed offsets, keeping existing snapshot");
+    debug!("Consumer group snapshot: no groups with committed offsets on backed topics, keeping existing snapshot");
     return Ok(());
 }
 let snapshot = Snapshot { snapshot_time: ..., groups: snapshot_groups };
@@ -226,3 +226,44 @@ self.storage.put(&key, ...).await?;
 - No behaviour change when groups are present (normal operation)
 - Protects the snapshot across pod restarts during DR / upgrade sequences
 - **Correct restore order**: snapshot is captured while apps are live → kafka-backup can restart freely → restore runs → apps start and find their offsets already reset
+
+---
+
+## Fix 5 — Consumer group snapshot incomplete on multi-broker clusters (NOT_COORDINATOR)
+
+**Status:** Implemented — commit on `fix/auto-consumer-groups-phase3`  
+**Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
+
+### Root cause
+
+`snapshot_consumer_groups()` calls `list_groups_all_brokers()` to enumerate all groups (per-broker, Issue #67 bug #6), but then calls `fetch_offsets(bootstrap_client, group_id)` for **every group** through the **same bootstrap broker**.
+
+In Kafka / KRaft, `OffsetFetch` must be routed to the **group coordinator** — the specific broker assigned as coordinator for that group. If the request arrives at a non-coordinator broker, it responds with error `NOT_COORDINATOR` (error 16) or returns empty offsets. The code silently `continue`s on error, so groups coordinated by non-bootstrap brokers are dropped from the snapshot.
+
+**Example on a 3-broker cluster:**
+
+| Group | Coordinator | Bootstrap | In snapshot |
+|-------|-------------|-----------|-------------|
+| `app-service` | 2 | 2 | ✅ captured |
+| `app-jobs` | 0 | 2 | ❌ missing |
+| `app-workers` | 0 | 2 | ❌ missing |
+| `app-consumers` | 1 | 2 | ❌ missing |
+
+Only `app-service` (whose coordinator = bootstrap broker 2) appeared in the snapshot.
+
+### Fix
+
+Add `fetch_group_offsets_all_coordinators()` to `PartitionLeaderRouter`. It iterates every broker, calls `ListGroups` on each (groups returned = groups for which THAT broker is coordinator), then calls `OffsetFetch` on the **same broker** for those groups.
+
+Replace `list_groups_all_brokers()` + `fetch_offsets(bootstrap_client)` in `snapshot_consumer_groups()` with a single call to the new method.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `crates/kafka-backup-core/src/kafka/partition_router.rs` | New method `fetch_group_offsets_all_coordinators()` |
+| `crates/kafka-backup-core/src/backup/engine.rs` | Use `fetch_group_offsets_all_coordinators()`; remove `fetch_offsets` direct call |
+
+### Expected result after fix
+
+All STABLE groups with committed offsets on backed-up topics appear in the snapshot, regardless of which broker is their coordinator.

--- a/docs/Fork_fixes.md
+++ b/docs/Fork_fixes.md
@@ -1,0 +1,130 @@
+# Fork Fixes — himurafred/kafka-backup
+
+This document tracks fixes applied on this fork that have not yet been merged into `osodevops/kafka-backup` upstream.
+Each fix includes the root cause, the affected files, and the rationale for contributing it back.
+
+---
+
+## Fix 1 — `auto_consumer_groups`: Phase 3 offset reset silently skipped
+
+**Status:** Pending upstream PR  
+**Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
+
+### Root cause
+
+When `auto_consumer_groups: true` is set in the restore configuration, the restore engine (`engine.rs`) loads consumer groups from the snapshot file at runtime and injects them into `RestoreOptions.consumer_groups`. However, `ThreePhaseRestore` in `three_phase.rs` checks `restore_options.consumer_groups` **before** this injection happens — it sees an empty list and skips Phase 3 unconditionally.
+
+As a result, consumer group offset reset is **never executed** when using `--auto-consumer-groups`, even if groups were successfully loaded from the snapshot.
+
+### Reproduction
+
+```bash
+kafka-backup three-phase-restore --config restore.yaml
+# restore.yaml contains: auto_consumer_groups: true
+# consumer-groups-snapshot.json is present and non-empty
+```
+
+Expected output:
+```
+Phase 3: Generating and applying offset reset plan...
+```
+
+Actual output (before fix):
+```
+║ PHASE 3: OFFSET RESET (skipped)
+║   No consumer groups configured or reset_consumer_offsets=false
+```
+
+### Fix
+
+**4 files changed, 21 insertions(+), 5 deletions(-)**
+
+#### `crates/kafka-backup-core/src/config.rs`
+
+Allow `reset_consumer_offsets: true` without pre-specifying `consumer_groups` when `auto_consumer_groups: true`, since groups will be resolved at runtime from the snapshot.
+
+```rust
+// Before
+if self.reset_consumer_offsets && self.consumer_groups.is_empty() {
+
+// After
+if self.reset_consumer_offsets && self.consumer_groups.is_empty() && !self.auto_consumer_groups {
+```
+
+#### `crates/kafka-backup-core/src/manifest.rs`
+
+Add `resolved_consumer_groups` field to `RestoreReport` so the engine can propagate the runtime-resolved group list to the three-phase orchestrator.
+
+```rust
+pub struct RestoreReport {
+    // ...existing fields...
+    /// Consumer groups resolved during restore (includes auto-loaded groups from snapshot)
+    #[serde(default)]
+    pub resolved_consumer_groups: Vec<String>,
+}
+```
+
+#### `crates/kafka-backup-core/src/restore/engine.rs`
+
+Populate `resolved_consumer_groups` in the report after groups are loaded:
+
+```rust
+// End of restore(), where RestoreReport is built:
+resolved_consumer_groups: restore_options.consumer_groups.clone(),
+```
+
+Also initialise to `Vec::new()` in the dry-run and early-exit paths.
+
+#### `crates/kafka-backup-core/src/restore/three_phase.rs`
+
+Use `resolved_consumer_groups` (the post-injection list) to determine whether Phase 3 should run, and activate Phase 3 automatically when `auto_consumer_groups=true` and groups were resolved:
+
+```rust
+let effective_consumer_groups = if !restore_report.resolved_consumer_groups.is_empty() {
+    restore_report.resolved_consumer_groups.clone()
+} else {
+    restore_options.consumer_groups.clone()
+};
+let effective_reset = restore_options.reset_consumer_offsets
+    || (restore_options.auto_consumer_groups && !effective_consumer_groups.is_empty());
+```
+
+### Impact
+
+- No behaviour change when `auto_consumer_groups: false` (default)
+- No behaviour change when `consumer_groups` is specified explicitly
+- Fixes Phase 3 for all users of `auto_consumer_groups: true`
+
+---
+
+## Fix 2 — Validation: `MessageCountCheck` / `OffsetRangeCheck` fail on multi-broker clusters
+
+**Status:** Pending implementation + upstream PR  
+**Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
+
+### Root cause
+
+The `ValidationContext` holds a `KafkaClient` — a single TCP connection to one bootstrap broker. Both `MessageCountCheck` and `OffsetRangeCheck` call `ctx.target_client.get_offsets(topic, partition)`, which sends a `ListOffsets` request to that single broker.
+
+In a multi-broker cluster, partition leaders are distributed. When the connected broker is **not** the leader for a given partition, Kafka responds with error code **6 = NOT_LEADER_FOR_PARTITION**. The check treats this as a failure and does not add the partition's count to `total_restored`.
+
+On a 3-broker cluster with balanced leadership, ~67% of partitions fail → the validation reports a large fraction of the cluster as "not restored", even after a successful restore.
+
+### Evidence
+
+```
+[FAILED] MessageCountCheck — 39 topics; 3638 messages expected, 917 restored; 37 discrepancies
+[FAILED] OffsetRangeCheck  — 45 partitions checked; 13 passed; 32 issues
+```
+
+The restore itself succeeded (3637 records restored, 0 errors).
+
+### Fix (pending)
+
+Replace `Arc<KafkaClient>` with `Arc<PartitionRouter>` in `ValidationContext`. The `PartitionRouter` already has `get_offsets()` with per-partition leader routing and automatic retry on `NOT_LEADER_FOR_PARTITION`.
+
+Files to change:
+- `crates/kafka-backup-core/src/validation/context.rs` — change field type
+- `crates/kafka-backup-cli/src/commands/validation.rs` — instantiate `PartitionRouter` instead of `KafkaClient`
+- `crates/kafka-backup-core/src/validation/message_count.rs` — update call site
+- `crates/kafka-backup-core/src/validation/offset_range.rs` — update call site

--- a/docs/Fork_fixes.md
+++ b/docs/Fork_fixes.md
@@ -99,18 +99,18 @@ let effective_reset = restore_options.reset_consumer_offsets
 
 ## Fix 2 — Validation: `MessageCountCheck` / `OffsetRangeCheck` fail on multi-broker clusters
 
-**Status:** Pending implementation + upstream PR  
+**Status:** Implemented — commit on `fix/auto-consumer-groups-phase3`  
 **Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
 
 ### Root cause
 
-The `ValidationContext` holds a `KafkaClient` — a single TCP connection to one bootstrap broker. Both `MessageCountCheck` and `OffsetRangeCheck` call `ctx.target_client.get_offsets(topic, partition)`, which sends a `ListOffsets` request to that single broker.
+The `ValidationContext` held a `KafkaClient` — a single TCP connection to one bootstrap broker. Both `MessageCountCheck` and `OffsetRangeCheck` called `ctx.target_client.get_offsets(topic, partition)`, which sent a `ListOffsets` request to that single broker.
 
-In a multi-broker cluster, partition leaders are distributed. When the connected broker is **not** the leader for a given partition, Kafka responds with error code **6 = NOT_LEADER_FOR_PARTITION**. The check treats this as a failure and does not add the partition's count to `total_restored`.
+In a multi-broker cluster, partition leaders are distributed. When the connected broker is **not** the leader for a given partition, Kafka responds with error code **6 = NOT_LEADER_FOR_PARTITION**. The check treated this as a failure and did not add the partition's count to `total_restored`.
 
 On a 3-broker cluster with balanced leadership, ~67% of partitions fail → the validation reports a large fraction of the cluster as "not restored", even after a successful restore.
 
-### Evidence
+### Evidence (before fix)
 
 ```
 [FAILED] MessageCountCheck — 39 topics; 3638 messages expected, 917 restored; 37 discrepancies
@@ -119,12 +119,26 @@ On a 3-broker cluster with balanced leadership, ~67% of partitions fail → the 
 
 The restore itself succeeded (3637 records restored, 0 errors).
 
-### Fix (pending)
+### Fix
 
-Replace `Arc<KafkaClient>` with `Arc<PartitionRouter>` in `ValidationContext`. The `PartitionRouter` already has `get_offsets()` with per-partition leader routing and automatic retry on `NOT_LEADER_FOR_PARTITION`.
+Replace `Arc<KafkaClient>` with `Arc<PartitionLeaderRouter>` in `ValidationContext`. The `PartitionLeaderRouter` already has `get_offsets()` with per-partition leader routing and automatic retry on `NOT_LEADER_FOR_PARTITION`.
 
-Files to change:
-- `crates/kafka-backup-core/src/validation/context.rs` — change field type
-- `crates/kafka-backup-cli/src/commands/validation.rs` — instantiate `PartitionRouter` instead of `KafkaClient`
-- `crates/kafka-backup-core/src/validation/message_count.rs` — update call site
-- `crates/kafka-backup-core/src/validation/offset_range.rs` — update call site
+The `ConsumerGroupOffsetCheck` uses `ListGroups` / `OffsetFetch` which are forwarded by the broker to the group coordinator — no partition-leader routing needed. It accesses the underlying bootstrap client via the new `PartitionLeaderRouter::client()` accessor.
+
+#### Files changed
+
+| File | Change |
+|------|--------|
+| `crates/kafka-backup-core/src/kafka/partition_router.rs` | Added `pub fn client() -> &KafkaClient` accessor |
+| `crates/kafka-backup-core/src/validation/context.rs` | `target_client: Arc<PartitionLeaderRouter>` |
+| `crates/kafka-backup-cli/src/commands/validation.rs` | Instantiate `PartitionLeaderRouter::new(config.target).await?`; remove old `create_kafka_client` helper |
+| `crates/kafka-backup-core/src/validation/consumer_group.rs` | Use `ctx.target_client.client()` for ListGroups / OffsetFetch |
+| `crates/kafka-backup-core/src/validation/message_count.rs` | No change — `get_offsets()` signature identical |
+| `crates/kafka-backup-core/src/validation/offset_range.rs` | No change — `get_offsets()` signature identical |
+
+### Expected result after fix
+
+```
+[PASSED] MessageCountCheck — 39 topics; 3638 messages expected, 3637 restored; 0 discrepancies
+[PASSED] OffsetRangeCheck  — 45 partitions checked; 45 passed; 0 issues
+```

--- a/docs/Fork_fixes.md
+++ b/docs/Fork_fixes.md
@@ -176,3 +176,53 @@ Call `initialize_schema()` after the pool is replaced in `load_from_storage()`. 
 ### Workaround (before rebuild)
 
 Delete `kafka-backup/offsets.db` from object storage when resetting backup data.
+
+---
+
+## Fix 4 — Consumer groups snapshot overwritten with empty list on restart
+
+**Status:** Implemented — commit `695efa4` on `fix/auto-consumer-groups-phase3`  
+**Affected upstream version:** ≤ v0.11.4 (commit `91cedda`)
+
+### Root cause
+
+`snapshot_consumer_groups()` is called at every backup loop iteration with `consumer_group_snapshot: true`. It builds the list of groups with committed offsets for the backed-up topics, then **unconditionally overwrites** `consumer-groups-snapshot.json` in storage — even when the resulting list is empty.
+
+This causes data loss in a common DR / upgrade scenario:
+
+1. Applications run normally → snapshot is populated with real consumer groups ✅
+2. `kafka-backup` pod is deleted/restarted (reinstall, crash, upgrade)
+3. Pod restarts; backup loop begins; **applications are not yet reconnected** (still starting up)
+4. `list_groups_all_brokers()` returns groups, but none have committed offsets on the backed-up topics yet
+5. `snapshot_groups` is empty → snapshot written as `{ "groups": [] }` → **previous valid snapshot is lost** ❌
+6. Restore runs → `auto_consumer_groups` reads the empty snapshot → Phase 3 skipped → **consumer offsets not restored**
+
+### Fix
+
+Skip the `storage.put()` call when `snapshot_groups` is empty. The existing snapshot (if any) is preserved.
+
+#### File changed
+
+| File | Change |
+|------|--------|
+| `crates/kafka-backup-core/src/backup/engine.rs` | Early return in `snapshot_consumer_groups()` when `snapshot_groups.is_empty()` |
+
+```rust
+// Before (always overwrites)
+let snapshot = Snapshot { snapshot_time: ..., groups: snapshot_groups };
+self.storage.put(&key, ...).await?;
+
+// After (skip write if empty)
+if snapshot_groups.is_empty() {
+    debug!("No groups with committed offsets, keeping existing snapshot");
+    return Ok(());
+}
+let snapshot = Snapshot { snapshot_time: ..., groups: snapshot_groups };
+self.storage.put(&key, ...).await?;
+```
+
+### Impact
+
+- No behaviour change when groups are present (normal operation)
+- Protects the snapshot across pod restarts during DR / upgrade sequences
+- **Correct restore order**: snapshot is captured while apps are live → kafka-backup can restart freely → restore runs → apps start and find their offsets already reset


### PR DESCRIPTION
Hello,

I have done 5 fixes. 

Fix 1 — auto_consumer_groups: true never triggered Phase 3 (offset reset silently skipped) because ThreePhaseRestore read consumer_groups before the runtime injection from the snapshot.
Fix 2 — Validation checks (MessageCountCheck, OffsetRangeCheck) failed on multi-broker clusters because ListOffsets was always sent to the bootstrap broker, which is not necessarily the partition leader.
Fix 3 — After loading offsets.db from object storage, initialize_schema() was not called, causing a crash loop if the schema was outdated.
Fix 4 — On every pod restart, the consumer groups snapshot was overwritten with an empty list if applications had not yet reconnected, destroying the previously valid snapshot.
Fix 5 — The consumer groups snapshot was incomplete on multi-broker clusters because OffsetFetch was always routed to the bootstrap broker instead of each group's coordinator, causing silent NOT_COORDINATOR errors

The full description is in the file : kafka-backup/blob/fix/auto-consumer-groups-phase3/docs/Fork_fixes.md
I have done a commit by fixes.
Thanks
