### PR TITLE
fix: validation NOT_LEADER_FOR_PARTITION on multi-broker clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/src/commands/validation.rs
+++ b/crates/kafka-backup-cli/src/commands/validation.rs
@@ -7,12 +7,11 @@ use chrono::Utc;
 use tracing::info;
 use uuid::Uuid;
 
-use kafka_backup_core::config::KafkaConfig;
 use kafka_backup_core::evidence::report::{
     hex_encode, BackupInfo, EvidenceReport, IntegrityInfo, RestoreInfo, ToolInfo,
 };
 use kafka_backup_core::evidence::{pdf, signing, storage as evidence_storage};
-use kafka_backup_core::kafka::KafkaClient;
+use kafka_backup_core::kafka::PartitionLeaderRouter;
 use kafka_backup_core::manifest::BackupManifest;
 use kafka_backup_core::notification::pagerduty::PagerDutyNotifier;
 use kafka_backup_core::notification::slack::SlackNotifier;
@@ -66,14 +65,17 @@ pub async fn run(config_path: &str, pitr: Option<i64>, triggered_by: Option<&str
         "Manifest loaded"
     );
 
-    // Connect to restored Kafka cluster
-    let target_client = create_kafka_client(&config.target).await?;
+    // Connect to restored Kafka cluster via PartitionLeaderRouter so that
+    // ListOffsets requests are routed to the leader of each partition.
+    let target_router = PartitionLeaderRouter::new(config.target.clone())
+        .await
+        .with_context(|| "Failed to connect to target Kafka cluster")?;
 
     // Build validation context
     let ctx = ValidationContext {
         backup_id: config.backup_id.clone(),
         backup_manifest: manifest.clone(),
-        target_client: Arc::new(target_client),
+        target_client: Arc::new(target_router),
         storage: storage.clone(),
         pitr_timestamp: config.pitr_timestamp,
         http_client: reqwest::Client::new(),
@@ -351,15 +353,6 @@ pub async fn evidence_verify(
 
     println!("\nEvidence report integrity: VERIFIED");
     Ok(())
-}
-
-async fn create_kafka_client(config: &KafkaConfig) -> Result<KafkaClient> {
-    let client = KafkaClient::new(config.clone());
-    client
-        .connect()
-        .await
-        .with_context(|| "Failed to connect to target Kafka cluster")?;
-    Ok(client)
 }
 
 fn build_notification_senders(

--- a/crates/kafka-backup-core/src/validation/consumer_group.rs
+++ b/crates/kafka-backup-core/src/validation/consumer_group.rs
@@ -35,8 +35,10 @@ impl ValidationCheck for ConsumerGroupOffsetCheck {
     async fn run(&self, ctx: &ValidationContext) -> Result<ValidationResult> {
         let start = Instant::now();
 
-        // List all consumer groups on the restored cluster
-        let groups = consumer_groups::list_groups(&ctx.target_client).await?;
+        // List all consumer groups on the restored cluster.
+        // ListGroups/OffsetFetch are forwarded by the broker to the group
+        // coordinator, so partition-leader routing is not needed here.
+        let groups = consumer_groups::list_groups(ctx.target_client.bootstrap_client()).await?;
 
         let group_ids: Vec<String> =
             if self.config.verify_all_groups || self.config.groups.is_empty() {
@@ -64,7 +66,13 @@ impl ValidationCheck for ConsumerGroupOffsetCheck {
         let mut issues: Vec<serde_json::Value> = Vec::new();
 
         for group_id in &group_ids {
-            match consumer_groups::fetch_offsets(&ctx.target_client, group_id, None).await {
+            match consumer_groups::fetch_offsets(
+                ctx.target_client.bootstrap_client(),
+                group_id,
+                None,
+            )
+            .await
+            {
                 Ok(offsets) => {
                     groups_verified += 1;
                     let offset_count = offsets.len() as u64;

--- a/crates/kafka-backup-core/src/validation/context.rs
+++ b/crates/kafka-backup-core/src/validation/context.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::kafka::KafkaClient;
+use crate::kafka::PartitionLeaderRouter;
 use crate::manifest::BackupManifest;
 use crate::storage::StorageBackend;
 
@@ -14,8 +14,11 @@ pub struct ValidationContext {
     /// The backup manifest loaded from object storage.
     pub backup_manifest: BackupManifest,
 
-    /// Kafka client connected to the restored (target) cluster.
-    pub target_client: Arc<KafkaClient>,
+    /// Partition-leader-aware Kafka client connected to the restored (target)
+    /// cluster. Uses `PartitionLeaderRouter` so that `ListOffsets` requests are
+    /// routed to the correct broker for each partition, preventing
+    /// `NOT_LEADER_FOR_PARTITION` errors on multi-broker clusters.
+    pub target_client: Arc<PartitionLeaderRouter>,
 
     /// Storage backend for reading backup data / uploading evidence.
     pub storage: Arc<dyn StorageBackend>,

--- a/crates/kafka-backup-core/tests/integration_suite/validation.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/validation.rs
@@ -144,16 +144,20 @@ async fn run_validation(
         path: storage_path.to_path_buf(),
     };
     let storage = create_backend(&storage_config)?;
-    let client = cluster.create_client();
-    client
-        .connect()
+    let kafka_config = kafka_backup_core::config::KafkaConfig {
+        bootstrap_servers: vec![cluster.bootstrap_servers.clone()],
+        security: kafka_backup_core::config::SecurityConfig::default(),
+        topics: kafka_backup_core::config::TopicSelection::default(),
+        connection: Default::default(),
+    };
+    let router = kafka_backup_core::kafka::PartitionLeaderRouter::new(kafka_config)
         .await
         .map_err(|e| anyhow::anyhow!("Connect failed: {e}"))?;
 
     let ctx = ValidationContext {
         backup_id: backup_id.to_string(),
         backup_manifest: manifest,
-        target_client: Arc::new(client),
+        target_client: Arc::new(router),
         storage,
         pitr_timestamp: None,
         http_client: reqwest::Client::new(),

--- a/tests/reproduce-bug2/docker-compose-12broker.yml
+++ b/tests/reproduce-bug2/docker-compose-12broker.yml
@@ -1,0 +1,164 @@
+# 12-broker KRaft cluster for stress-testing partition leader routing.
+#
+# Ports exposed to host: localhost:29092 through localhost:29103
+#
+# With 12 brokers, a topic with 36 partitions (RF=3) distributes leadership
+# across all brokers. Before the fix, only ~8% of partitions (those led by
+# the bootstrap broker) would pass validation.
+
+networks:
+  kafka-12broker:
+    driver: bridge
+
+x-kafka-common: &kafka-common
+  image: apache/kafka:3.7.1
+  networks:
+    - kafka-12broker
+  environment: &kafka-env
+    KAFKA_PROCESS_ROLES: controller,broker
+    KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+    KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+    KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9093,3@kafka3:9093,4@kafka4:9093,5@kafka5:9093,6@kafka6:9093,7@kafka7:9093,8@kafka8:9093,9@kafka9:9093,10@kafka10:9093,11@kafka11:9093,12@kafka12:9093
+    KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+    KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+    KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 12
+    KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+    KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+    KAFKA_MIN_INSYNC_REPLICAS: 1
+    KAFKA_NUM_PARTITIONS: 12
+    KAFKA_LOG_DIRS: /tmp/kafka-logs
+    CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g
+
+services:
+  kafka1:
+    <<: *kafka-common
+    hostname: kafka1
+    container_name: bug2-kafka1
+    ports: ["29092:29092"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19092,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:19092,EXTERNAL://localhost:29092
+
+  kafka2:
+    <<: *kafka-common
+    hostname: kafka2
+    container_name: bug2-kafka2
+    ports: ["29093:29093"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 2
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19093,EXTERNAL://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:19093,EXTERNAL://localhost:29093
+
+  kafka3:
+    <<: *kafka-common
+    hostname: kafka3
+    container_name: bug2-kafka3
+    ports: ["29094:29094"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 3
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19094,EXTERNAL://0.0.0.0:29094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:19094,EXTERNAL://localhost:29094
+
+  kafka4:
+    <<: *kafka-common
+    hostname: kafka4
+    container_name: bug2-kafka4
+    ports: ["29095:29095"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 4
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19095,EXTERNAL://0.0.0.0:29095
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka4:19095,EXTERNAL://localhost:29095
+
+  kafka5:
+    <<: *kafka-common
+    hostname: kafka5
+    container_name: bug2-kafka5
+    ports: ["29096:29096"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 5
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19096,EXTERNAL://0.0.0.0:29096
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka5:19096,EXTERNAL://localhost:29096
+
+  kafka6:
+    <<: *kafka-common
+    hostname: kafka6
+    container_name: bug2-kafka6
+    ports: ["29097:29097"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 6
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19097,EXTERNAL://0.0.0.0:29097
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka6:19097,EXTERNAL://localhost:29097
+
+  kafka7:
+    <<: *kafka-common
+    hostname: kafka7
+    container_name: bug2-kafka7
+    ports: ["29098:29098"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 7
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19098,EXTERNAL://0.0.0.0:29098
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka7:19098,EXTERNAL://localhost:29098
+
+  kafka8:
+    <<: *kafka-common
+    hostname: kafka8
+    container_name: bug2-kafka8
+    ports: ["29099:29099"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 8
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19099,EXTERNAL://0.0.0.0:29099
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka8:19099,EXTERNAL://localhost:29099
+
+  kafka9:
+    <<: *kafka-common
+    hostname: kafka9
+    container_name: bug2-kafka9
+    ports: ["29100:29100"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 9
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19100,EXTERNAL://0.0.0.0:29100
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka9:19100,EXTERNAL://localhost:29100
+
+  kafka10:
+    <<: *kafka-common
+    hostname: kafka10
+    container_name: bug2-kafka10
+    ports: ["29101:29101"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 10
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19101,EXTERNAL://0.0.0.0:29101
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka10:19101,EXTERNAL://localhost:29101
+
+  kafka11:
+    <<: *kafka-common
+    hostname: kafka11
+    container_name: bug2-kafka11
+    ports: ["29102:29102"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 11
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19102,EXTERNAL://0.0.0.0:29102
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka11:19102,EXTERNAL://localhost:29102
+
+  kafka12:
+    <<: *kafka-common
+    hostname: kafka12
+    container_name: bug2-kafka12
+    ports: ["29103:29103"]
+    environment:
+      <<: *kafka-env
+      KAFKA_NODE_ID: 12
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19103,EXTERNAL://0.0.0.0:29103
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka12:19103,EXTERNAL://localhost:29103

--- a/tests/reproduce-bug2/docker-compose.yml
+++ b/tests/reproduce-bug2/docker-compose.yml
@@ -1,0 +1,99 @@
+# 3-broker KRaft cluster for reproducing multi-broker bugs (PR #86 Fixes 2, 5).
+#
+# Ports exposed to host:
+#   kafka1: localhost:29092
+#   kafka2: localhost:29093
+#   kafka3: localhost:29094
+#
+# __consumer_offsets is configured with 3 partitions (1 per broker) so that
+# consumer group coordinator assignment is evenly distributed and predictable.
+#
+# Usage:
+#   docker compose -f docker-compose-3broker.yml up -d
+#   docker compose -f docker-compose-3broker.yml down -v
+
+networks:
+  kafka-3broker:
+    driver: bridge
+
+services:
+  kafka1:
+    image: apache/kafka:3.7.1
+    hostname: kafka1
+    container_name: pr86-kafka1
+    networks:
+      - kafka-3broker
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19092,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:19092,EXTERNAL://localhost:29092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9093,3@kafka3:9093
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_NUM_PARTITIONS: 6
+      KAFKA_LOG_DIRS: /tmp/kafka-logs
+      CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g
+
+  kafka2:
+    image: apache/kafka:3.7.1
+    hostname: kafka2
+    container_name: pr86-kafka2
+    networks:
+      - kafka-3broker
+    ports:
+      - "29093:29093"
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19093,EXTERNAL://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:19093,EXTERNAL://localhost:29093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9093,3@kafka3:9093
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_NUM_PARTITIONS: 6
+      KAFKA_LOG_DIRS: /tmp/kafka-logs
+      CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g
+
+  kafka3:
+    image: apache/kafka:3.7.1
+    hostname: kafka3
+    container_name: pr86-kafka3
+    networks:
+      - kafka-3broker
+    ports:
+      - "29094:29094"
+    environment:
+      KAFKA_NODE_ID: 3
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19094,EXTERNAL://0.0.0.0:29094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:19094,EXTERNAL://localhost:29094
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:9093,2@kafka2:9093,3@kafka3:9093
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 3
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_NUM_PARTITIONS: 6
+      KAFKA_LOG_DIRS: /tmp/kafka-logs
+      CLUSTER_ID: xtzWWN4bTjitpL3kfd9s5g

--- a/tests/reproduce-bug2/run-test-12broker.sh
+++ b/tests/reproduce-bug2/run-test-12broker.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Stress test for Bug 2 fix on a 12-broker KRaft cluster.
+#
+# With 12 brokers and 36 partitions per topic (RF=3), leadership is spread
+# across all 12 brokers. Before the fix, only ~8% of partitions (those led
+# by the bootstrap broker) would pass validation. This test verifies that
+# PartitionLeaderRouter correctly routes ListOffsets to all 12 leaders.
+#
+# Requires: Docker (spins up 12 Kafka containers)
+# Usage: ./run-test-12broker.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose-12broker.yml"
+BOOTSTRAP="localhost:29092"
+WORK_DIR=$(mktemp -d)
+PASS=0
+FAIL=0
+
+trap cleanup EXIT
+cleanup() {
+    echo ""
+    echo "=== Cleanup ==="
+    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    rm -rf "$WORK_DIR"
+}
+
+assert_contains() {
+    local label="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected to find: $pattern)"
+        echo "  Actual output:"
+        echo "$output" | grep -E "(PASS|FAIL|Overall)" | head -5
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║  Bug 2 stress test: 12-broker KRaft cluster                    ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Build
+echo "=== Building kafka-backup CLI ==="
+cargo build -p kafka-backup-cli --release 2>&1 | tail -3
+CLI="$PROJECT_ROOT/target/release/kafka-backup"
+
+# Start 12-broker cluster
+echo ""
+echo "=== Starting 12-broker KRaft cluster ==="
+docker compose -f "$COMPOSE_FILE" up -d
+echo "Waiting for cluster (12 brokers may take a moment)..."
+for i in $(seq 1 90); do
+    docker exec bug2-kafka1 /opt/kafka/bin/kafka-topics.sh \
+        --bootstrap-server kafka1:19092 --list 2>/dev/null && break
+    [ "$i" -eq 90 ] && { echo "ERROR: Cluster not ready"; exit 1; }
+    sleep 2
+done
+# Extra wait for all 12 brokers to join
+sleep 10
+echo "Cluster is ready."
+
+# Create topics with 36 partitions (3 per broker), RF=3
+echo ""
+echo "=== Creating topics (36 partitions, RF=3) ==="
+for topic in orders payments events inventory users sessions; do
+    docker exec bug2-kafka1 /opt/kafka/bin/kafka-topics.sh \
+        --create --if-not-exists --bootstrap-server kafka1:19092 \
+        --partitions 36 --replication-factor 3 --topic "$topic" 2>&1
+done
+
+# Show leader distribution for one topic
+echo ""
+echo "=== Leader distribution for 'orders' (expect all 12 brokers) ==="
+docker exec bug2-kafka1 /opt/kafka/bin/kafka-topics.sh \
+    --describe --bootstrap-server kafka1:19092 --topic orders 2>/dev/null | \
+    awk '{for(i=1;i<=NF;i++) if($i=="Leader:") print $(i+1)}' | sort | uniq -c | sort -rn
+echo "(count of partitions per broker leader)"
+
+# Produce data
+echo ""
+echo "=== Producing data (500 records per topic, 6 topics) ==="
+for topic in orders payments events inventory users sessions; do
+    for i in $(seq 1 500); do echo "key-$i:value-$i"; done | \
+        docker exec -i bug2-kafka1 /opt/kafka/bin/kafka-console-producer.sh \
+        --bootstrap-server kafka1:19092 --topic "$topic" \
+        --property parse.key=true --property key.separator=: 2>&1
+    echo "  $topic: 500 records"
+done
+
+# Backup
+echo ""
+echo "=== Running backup ==="
+BACKUP_ID="bug2-12broker-test"
+STORAGE_DIR="$WORK_DIR/storage"
+mkdir -p "$STORAGE_DIR"
+
+cat > "$WORK_DIR/backup.yaml" <<EOF
+mode: backup
+backup_id: "$BACKUP_ID"
+source:
+  bootstrap_servers: ["$BOOTSTRAP"]
+  topics:
+    include: ["orders", "payments", "events", "inventory", "users", "sessions"]
+storage:
+  backend: filesystem
+  path: "$STORAGE_DIR"
+backup:
+  compression: zstd
+  segment_max_bytes: 1048576
+  stop_at_current_offsets: true
+EOF
+
+$CLI backup --config "$WORK_DIR/backup.yaml" 2>&1 | grep -q "Backup completed" && \
+    echo "Backup complete." || { echo "ERROR: Backup failed"; exit 1; }
+
+# Signing keys
+SIGNING_KEY_DIR=$(mktemp -d)
+openssl ecparam -genkey -name prime256v1 -noout -out "$SIGNING_KEY_DIR/private.pem" 2>/dev/null
+openssl ec -in "$SIGNING_KEY_DIR/private.pem" -pubout -out "$SIGNING_KEY_DIR/public.pem" 2>/dev/null
+openssl pkcs8 -topk8 -nocrypt -in "$SIGNING_KEY_DIR/private.pem" -out "$SIGNING_KEY_DIR/private-pkcs8.pem" 2>/dev/null
+
+# Validation
+echo ""
+echo "=== Running validation (bootstrap=$BOOTSTRAP = broker 1 of 12) ==="
+echo "(Before fix: only ~3/36 partitions per topic would pass = 8%)"
+echo ""
+
+cat > "$WORK_DIR/validation.yaml" <<EOF
+backup_id: "$BACKUP_ID"
+storage:
+  backend: filesystem
+  path: "$STORAGE_DIR"
+target:
+  bootstrap_servers: ["$BOOTSTRAP"]
+checks:
+  message_count:
+    enabled: true
+    mode: exact
+  offset_range:
+    enabled: true
+  consumer_group_offsets:
+    enabled: false
+evidence:
+  formats: [json]
+  signing:
+    enabled: true
+    private_key_path: "$SIGNING_KEY_DIR/private-pkcs8.pem"
+  storage:
+    prefix: "evidence/"
+    retention_days: 1
+EOF
+
+OUTPUT=$(RUST_LOG=info $CLI validation run --config "$WORK_DIR/validation.yaml" 2>&1 || true)
+echo "$OUTPUT" | grep -E "(PASS|FAIL|Overall|Checks:)"
+
+rm -rf "$SIGNING_KEY_DIR"
+
+# Assertions
+echo ""
+echo "=== Assertions ==="
+assert_contains \
+    "MessageCountCheck passes on 12-broker cluster" \
+    "$OUTPUT" \
+    "PASSED.*MessageCountCheck"
+
+assert_contains \
+    "OffsetRangeCheck passes on 12-broker cluster" \
+    "$OUTPUT" \
+    "PASSED.*OffsetRangeCheck"
+
+assert_contains \
+    "All 3000 records accounted for (6 topics x 500)" \
+    "$OUTPUT" \
+    "3000 messages expected, 3000 restored"
+
+assert_contains \
+    "All 216 partitions pass (6 topics x 36 partitions)" \
+    "$OUTPUT" \
+    "216 partitions checked; 216 passed"
+
+# Summary
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Results: $PASS passed, $FAIL failed"
+echo "  Cluster: 12 brokers, 6 topics, 216 partitions total"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "  SOME TESTS FAILED"
+    exit 1
+else
+    echo "  ALL TESTS PASSED"
+    exit 0
+fi

--- a/tests/reproduce-bug2/run-test.sh
+++ b/tests/reproduce-bug2/run-test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Reproduce & verify fix for Bug 2: Validation NOT_LEADER_FOR_PARTITION
+#
+# Bug: ValidationContext held a single KafkaClient (one TCP connection to the
+# bootstrap broker). ListOffsets requests for partitions whose leader is on a
+# different broker received error code 6 (NOT_LEADER_FOR_PARTITION), causing
+# MessageCountCheck and OffsetRangeCheck to fail on multi-broker clusters.
+#
+# On a 3-broker cluster with balanced leadership, ~67% of partitions fail.
+#
+# Fix: Replace Arc<KafkaClient> with Arc<PartitionLeaderRouter> in
+# ValidationContext. PartitionLeaderRouter routes ListOffsets to the correct
+# partition leader with automatic retry on NOT_LEADER_FOR_PARTITION.
+#
+# This test verifies:
+#   1. Backup succeeds on a 3-broker cluster
+#   2. Validation MessageCountCheck passes (all partitions counted)
+#   3. Validation OffsetRangeCheck passes (all partitions verified)
+#
+# Requires: Docker (for 3-broker KRaft cluster)
+# Usage: ./run-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+BOOTSTRAP="localhost:29092"
+WORK_DIR=$(mktemp -d)
+PASS=0
+FAIL=0
+
+trap cleanup EXIT
+cleanup() {
+    echo ""
+    echo "=== Cleanup ==="
+    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    rm -rf "$WORK_DIR"
+}
+
+assert_contains() {
+    local label="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected to find: $pattern)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  FAIL: $label (should NOT contain: $pattern)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║  Bug 2 test: Validation NOT_LEADER_FOR_PARTITION (3-broker)    ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Build
+echo "=== Building kafka-backup CLI ==="
+cargo build -p kafka-backup-cli --release 2>&1 | tail -3
+CLI="$PROJECT_ROOT/target/release/kafka-backup"
+
+# Start 3-broker cluster
+echo ""
+echo "=== Starting 3-broker KRaft cluster ==="
+docker compose -f "$COMPOSE_FILE" up -d
+for i in $(seq 1 45); do
+    docker exec pr86-kafka1 /opt/kafka/bin/kafka-topics.sh \
+        --bootstrap-server kafka1:19092 --list 2>/dev/null && break
+    [ "$i" -eq 45 ] && { echo "ERROR: Cluster not ready"; exit 1; }
+    sleep 2
+done
+echo "Cluster is ready."
+
+# Create topics with RF=3, 6 partitions → leaders distributed across 3 brokers
+echo ""
+echo "=== Creating topics (RF=3, 6 partitions each) ==="
+for topic in orders payments events; do
+    docker exec pr86-kafka1 /opt/kafka/bin/kafka-topics.sh \
+        --create --if-not-exists --bootstrap-server kafka1:19092 \
+        --partitions 6 --replication-factor 3 --topic "$topic" 2>&1
+done
+
+echo ""
+echo "=== Partition leader distribution ==="
+for topic in orders payments events; do
+    docker exec pr86-kafka1 /opt/kafka/bin/kafka-topics.sh \
+        --describe --bootstrap-server kafka1:19092 --topic "$topic" 2>/dev/null
+done
+
+# Produce data
+echo ""
+echo "=== Producing data ==="
+for topic in orders payments events; do
+    for i in $(seq 1 200); do echo "key-$i:value-$i"; done | \
+        docker exec -i pr86-kafka1 /opt/kafka/bin/kafka-console-producer.sh \
+        --bootstrap-server kafka1:19092 --topic "$topic" \
+        --property parse.key=true --property key.separator=: 2>&1
+    echo "  $topic: 200 records"
+done
+
+# Backup
+echo ""
+echo "=== Running backup ==="
+BACKUP_ID="bug2-test"
+STORAGE_DIR="$WORK_DIR/storage"
+mkdir -p "$STORAGE_DIR"
+
+cat > "$WORK_DIR/backup.yaml" <<EOF
+mode: backup
+backup_id: "$BACKUP_ID"
+source:
+  bootstrap_servers: ["$BOOTSTRAP"]
+  topics:
+    include: ["orders", "payments", "events"]
+storage:
+  backend: filesystem
+  path: "$STORAGE_DIR"
+backup:
+  compression: zstd
+  segment_max_bytes: 1048576
+  stop_at_current_offsets: true
+EOF
+
+$CLI backup --config "$WORK_DIR/backup.yaml" 2>&1 | grep -q "Backup completed" && \
+    echo "Backup complete." || { echo "ERROR: Backup failed"; exit 1; }
+
+# Generate signing keys
+SIGNING_KEY_DIR=$(mktemp -d)
+openssl ecparam -genkey -name prime256v1 -noout -out "$SIGNING_KEY_DIR/private.pem" 2>/dev/null
+openssl ec -in "$SIGNING_KEY_DIR/private.pem" -pubout -out "$SIGNING_KEY_DIR/public.pem" 2>/dev/null
+openssl pkcs8 -topk8 -nocrypt -in "$SIGNING_KEY_DIR/private.pem" -out "$SIGNING_KEY_DIR/private-pkcs8.pem" 2>/dev/null
+
+# Run validation
+echo ""
+echo "=== Running validation (bootstrap=$BOOTSTRAP = broker 1) ==="
+echo "(Before fix: ~67% of partitions would fail with NOT_LEADER_FOR_PARTITION)"
+echo ""
+
+cat > "$WORK_DIR/validation.yaml" <<EOF
+backup_id: "$BACKUP_ID"
+storage:
+  backend: filesystem
+  path: "$STORAGE_DIR"
+target:
+  bootstrap_servers: ["$BOOTSTRAP"]
+checks:
+  message_count:
+    enabled: true
+    mode: exact
+  offset_range:
+    enabled: true
+  consumer_group_offsets:
+    enabled: false
+evidence:
+  formats: [json]
+  signing:
+    enabled: true
+    private_key_path: "$SIGNING_KEY_DIR/private-pkcs8.pem"
+  storage:
+    prefix: "evidence/"
+    retention_days: 1
+EOF
+
+OUTPUT=$(RUST_LOG=info $CLI validation run --config "$WORK_DIR/validation.yaml" 2>&1 || true)
+echo "$OUTPUT" | grep -E "(PASS|FAIL|Overall|Checks:)"
+
+rm -rf "$SIGNING_KEY_DIR"
+
+# Assertions
+echo ""
+echo "=== Assertions ==="
+assert_contains \
+    "MessageCountCheck passes" \
+    "$OUTPUT" \
+    "PASSED.*MessageCountCheck"
+
+assert_contains \
+    "OffsetRangeCheck passes" \
+    "$OUTPUT" \
+    "PASSED.*OffsetRangeCheck"
+
+assert_not_contains \
+    "No NOT_LEADER_FOR_PARTITION failures" \
+    "$OUTPUT" \
+    "FAILED.*MessageCountCheck"
+
+assert_contains \
+    "All 600 records accounted for" \
+    "$OUTPUT" \
+    "600 messages expected, 600 restored"
+
+assert_contains \
+    "All 18 partitions pass offset check" \
+    "$OUTPUT" \
+    "18 partitions checked; 18 passed"
+
+# Summary
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "  SOME TESTS FAILED"
+    exit 1
+else
+    echo "  ALL TESTS PASSED"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- Validation `MessageCountCheck` and `OffsetRangeCheck` failed on multi-broker clusters because `ListOffsets` was always sent to the bootstrap broker
- Partitions whose leader is on a different broker received error code 6 (`NOT_LEADER_FOR_PARTITION`)
- On a 3-broker cluster with balanced leadership, **~67% of partitions failed** — producing false `FAILED` results even after a perfectly successful restore

## Evidence (before fix)

From our local reproduction against a 3-broker KRaft cluster:
```
[FAILED] MessageCountCheck — 3 topics; 600 messages expected, 207 restored; 12 discrepancies
[FAILED] OffsetRangeCheck  — 18 partitions checked; 6 passed; 12 issues
```
Only 6/18 partitions passed = exactly the partitions led by broker 1 (the bootstrap broker). The other 12 led by brokers 2 and 3 returned `NOT_LEADER_FOR_PARTITION`.

## Root cause

`ValidationContext` held `Arc<KafkaClient>` — a single TCP connection to one bootstrap broker. Both `MessageCountCheck` and `OffsetRangeCheck` called `ctx.target_client.get_offsets(topic, partition)`, which sent `ListOffsets` to that single broker. Kafka does NOT forward `ListOffsets` to the correct leader — it rejects with error code 6.

## Fix

| File | Change |
|------|--------|
| `validation/context.rs` | `target_client: Arc<PartitionLeaderRouter>` (was `Arc<KafkaClient>`) |
| `commands/validation.rs` | Create `PartitionLeaderRouter::new()` instead of `KafkaClient`; remove `create_kafka_client` helper |
| `validation/consumer_group.rs` | Use `ctx.target_client.bootstrap_client()` for `ListGroups`/`OffsetFetch` (coordinator-routed, not partition-routed) |
| `integration_suite/validation.rs` | Updated to construct `PartitionLeaderRouter` |

`PartitionLeaderRouter::get_offsets()` has the same signature as `KafkaClient::get_offsets()`, so `message_count.rs` and `offset_range.rs` are unchanged.

Kafka protocol behaviour (`NOT_LEADER_FOR_PARTITION` error 6 on `ListOffsets` to wrong broker) is consistent across Kafka 2.x, 3.x, and 4.x.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — all pass
- [x] Reproduction test: `tests/reproduce-bug2/run-test.sh` (3-broker KRaft cluster, verifies all 18 partitions pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)