### PR TITLE
fix: run schema migrations after loading offset DB from storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/offset_store/sqlite.rs
+++ b/crates/kafka-backup-core/src/offset_store/sqlite.rs
@@ -285,6 +285,11 @@ impl OffsetStore for SqliteOffsetStore {
             *pool = new_pool;
         }
 
+        // Run schema migrations on the loaded database. The stored DB may have
+        // been created by an older version that is missing tables added later
+        // (e.g. backup_jobs). All DDL uses IF NOT EXISTS so this is idempotent.
+        self.initialize_schema().await?;
+
         info!("Loaded offset database from storage: {}", s3_key);
         Ok(true)
     }

--- a/tests/reproduce-bug3/docker-compose.yml
+++ b/tests/reproduce-bug3/docker-compose.yml
@@ -1,0 +1,37 @@
+# Single-broker KRaft cluster for reproducing logic bugs (PR #86 Fixes 1, 3, 4).
+#
+# Port exposed to host: localhost:19092
+#
+# Usage:
+#   docker compose -f docker-compose-1broker.yml up -d
+#   docker compose -f docker-compose-1broker.yml down -v
+
+networks:
+  kafka-1broker:
+    driver: bridge
+
+services:
+  kafka:
+    image: apache/kafka:3.7.1
+    hostname: kafka
+    container_name: pr86-kafka-single
+    networks:
+      - kafka-1broker
+    ports:
+      - "19092:19092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_LISTENERS: CONTROLLER://0.0.0.0:9093,PLAINTEXT://0.0.0.0:19094,EXTERNAL://0.0.0.0:19092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:19094,EXTERNAL://localhost:19092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_LOG_DIRS: /tmp/kafka-logs
+      AUTO_CREATE_TOPICS_ENABLE: "false"

--- a/tests/reproduce-bug3/run-test.sh
+++ b/tests/reproduce-bug3/run-test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Reproduce & verify fix for Bug 3: Schema migration missing after offset DB load
+#
+# Bug: load_from_storage() downloads offsets.db from object storage and replaces
+# the SQLite pool, but does NOT call initialize_schema() on the new database.
+# If the stored DB was created by an older version (missing the backup_jobs
+# table), the next query crashes: "no such table: backup_jobs"
+#
+# Fix: call self.initialize_schema().await? after pool replacement in
+# load_from_storage(). All DDL uses CREATE TABLE IF NOT EXISTS, so it's
+# idempotent on up-to-date databases.
+#
+# This test:
+#   1. Creates an old-format SQLite DB (offsets table only, no backup_jobs)
+#   2. Places it in the storage path
+#   3. Runs backup (which loads the old DB from storage)
+#   4. Verifies backup does NOT crash (schema migration ran)
+#
+# Requires: Docker, sqlite3
+# Usage: ./run-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+BOOTSTRAP="localhost:19092"
+WORK_DIR=$(mktemp -d)
+PASS=0
+FAIL=0
+
+trap cleanup EXIT
+cleanup() {
+    echo ""
+    echo "=== Cleanup ==="
+    docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    rm -rf "$WORK_DIR"
+}
+
+assert_contains() {
+    local label="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected to find: $pattern)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  FAIL: $label (should NOT contain: $pattern)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║  Bug 3 test: Schema migration after loading offset DB          ║"
+echo "╚══════════════════════════════════════════════════════════════════╝"
+echo ""
+
+if ! command -v sqlite3 &>/dev/null; then
+    echo "ERROR: sqlite3 CLI required. Install with: brew install sqlite3"
+    exit 1
+fi
+
+# Build
+echo "=== Building kafka-backup CLI ==="
+cargo build -p kafka-backup-cli --release 2>&1 | tail -3
+CLI="$PROJECT_ROOT/target/release/kafka-backup"
+
+# Start Kafka
+echo ""
+echo "=== Starting Kafka ==="
+docker compose -f "$COMPOSE_FILE" up -d
+for i in $(seq 1 30); do
+    docker exec pr86-kafka-single /opt/kafka/bin/kafka-topics.sh \
+        --bootstrap-server kafka:19094 --list 2>/dev/null && break
+    [ "$i" -eq 30 ] && { echo "ERROR: Kafka not ready"; exit 1; }
+    sleep 1
+done
+echo "Kafka is ready."
+
+# Create topic and data
+echo ""
+echo "=== Creating topic and data ==="
+docker exec pr86-kafka-single /opt/kafka/bin/kafka-topics.sh \
+    --create --if-not-exists --bootstrap-server kafka:19094 \
+    --partitions 3 --replication-factor 1 --topic orders 2>&1
+for i in $(seq 1 50); do echo "key-$i:value-$i"; done | \
+    docker exec -i pr86-kafka-single /opt/kafka/bin/kafka-console-producer.sh \
+    --bootstrap-server kafka:19094 --topic orders \
+    --property parse.key=true --property key.separator=: 2>&1
+echo "50 records produced."
+
+# Create old-format offsets.db (missing backup_jobs table)
+echo ""
+echo "=== Creating old-format offsets.db (no backup_jobs table) ==="
+BACKUP_ID="bug3-test"
+STORAGE_DIR="$WORK_DIR/storage"
+mkdir -p "$STORAGE_DIR/$BACKUP_ID"
+
+OLD_DB="$STORAGE_DIR/$BACKUP_ID/offsets.db"
+sqlite3 "$OLD_DB" <<'SQL'
+CREATE TABLE offsets (
+    backup_id TEXT NOT NULL,
+    topic TEXT NOT NULL,
+    partition INTEGER NOT NULL,
+    last_offset INTEGER NOT NULL,
+    checkpoint_ts INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+    PRIMARY KEY (backup_id, topic, partition)
+);
+CREATE INDEX idx_offsets_backup ON offsets(backup_id);
+INSERT INTO offsets (backup_id, topic, partition, last_offset)
+VALUES ('bug3-test', 'orders', 0, 5);
+SQL
+
+echo "Tables in old DB:"
+sqlite3 "$OLD_DB" ".tables"
+echo "(backup_jobs is MISSING — simulates DB from older version)"
+
+# Clean stale temp DB from previous runs (the engine defaults to /tmp/{backup_id}-offsets.db)
+rm -f "/tmp/${BACKUP_ID}-offsets.db"
+
+# Run backup in continuous mode (triggers offset store load from storage)
+echo ""
+echo "=== Running backup (loads old DB → schema migration should run) ==="
+
+LOCAL_DB="$WORK_DIR/local-offsets.db"
+cat > "$WORK_DIR/backup.yaml" <<EOF
+mode: backup
+backup_id: "$BACKUP_ID"
+source:
+  bootstrap_servers: ["$BOOTSTRAP"]
+  topics:
+    include: ["orders"]
+storage:
+  backend: filesystem
+  path: "$STORAGE_DIR"
+offset_storage:
+  db_path: "$LOCAL_DB"
+backup:
+  compression: zstd
+  segment_max_bytes: 1048576
+  continuous: true
+  checkpoint_interval_secs: 5
+EOF
+
+# Run backup for a few seconds then kill it — we just need to see if it crashes
+LOG_FILE="$WORK_DIR/backup.log"
+RUST_LOG=info $CLI backup --config "$WORK_DIR/backup.yaml" > "$LOG_FILE" 2>&1 &
+PID=$!
+sleep 10
+kill $PID 2>/dev/null
+wait $PID 2>/dev/null || true
+OUTPUT=$(cat "$LOG_FILE")
+
+echo ""
+echo "=== Assertions ==="
+assert_contains \
+    "Old DB was loaded from storage" \
+    "$OUTPUT" \
+    "Loaded offset database from storage"
+
+assert_not_contains \
+    "No 'no such table: backup_jobs' crash" \
+    "$OUTPUT" \
+    "no such table: backup_jobs"
+
+assert_contains \
+    "Backup started successfully (schema migration worked)" \
+    "$OUTPUT" \
+    "Connected to Kafka cluster"
+
+# Summary
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "  SOME TESTS FAILED"
+    exit 1
+else
+    echo "  ALL TESTS PASSED"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- `load_from_storage()` downloads `offsets.db` from object storage and replaces the SQLite pool, but did **not** call `initialize_schema()` on the newly loaded database
- If the stored DB was created by an older binary (before the `backup_jobs` table was added), the next startup crashed: `no such table: backup_jobs`
- The pod would restart in a loop until the outdated `offsets.db` was manually removed from storage

## Root cause

`SqliteOffsetStore::new()` calls `initialize_schema()` at construction (line 44), which creates both `offsets` and `backup_jobs` tables. But `load_from_storage()` (line 254) replaces the entire DB file and pool — the schema from the initial `new()` call is lost, replaced by whatever the stored DB had.

```
new() → initialize_schema() → both tables ✓
load_from_storage() → replaces pool with old DB → backup_jobs missing ✗
get_or_create_job() → INSERT INTO backup_jobs → CRASH
```

## Fix

One line: call `self.initialize_schema().await?` after pool replacement in `load_from_storage()`. All DDL uses `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`, making it idempotent on up-to-date databases.

## Test evidence

`tests/reproduce-bug3/run-test.sh` — creates an old-format SQLite DB (offsets table only, no backup_jobs), places it in storage, and runs backup:

```
=== Creating old-format offsets.db (no backup_jobs table) ===
Tables in old DB: offsets
(backup_jobs is MISSING — simulates DB from older version)

=== Assertions ===
  PASS: Old DB was loaded from storage
  PASS: No 'no such table: backup_jobs' crash
  PASS: Backup started successfully (schema migration worked)

Results: 3 passed, 0 failed — ALL TESTS PASSED
```

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — all pass
- [x] `tests/reproduce-bug3/run-test.sh` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)