### PR TITLE
Added SASL/GSSAPI (Kerberos) authentication support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ rustls-pemfile = "2"
 webpki-roots = "1.0"
 ring = "0.17"
 
+# GSSAPI
+libgssapi = "0.9"
+
 # Database
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
 

--- a/crates/kafka-backup-core/Cargo.toml
+++ b/crates/kafka-backup-core/Cargo.toml
@@ -55,6 +55,9 @@ rustls-pemfile.workspace = true
 ring.workspace = true
 webpki-roots.workspace = true
 
+# GSSAPI
+libgssapi.workspace = true
+
 # Database
 sqlx.workspace = true
 

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -207,6 +207,18 @@ pub struct SecurityConfig {
     /// Path to client key file (for mTLS)
     #[serde(default)]
     pub ssl_key_location: Option<PathBuf>,
+
+    /// Must match broker sasl.kerberos.service.name, default 'kafka' (only used with sasl_mechanism: GSSAPI)
+    #[serde(default)]
+    pub sasl_kerberos_service_name: Option<String>,
+
+    /// Path to a Kerberos keytab file, use this if preferred to the default credentials cache (kinit)
+    #[serde(default)]
+    pub sasl_keytab_path: Option<PathBuf>,
+
+    /// Path to a Kerberos configuration file (krb5.conf), defaults to /etc/krb5.conf
+    #[serde(default)]
+    pub sasl_krb5_config_path: Option<PathBuf>,
 }
 
 /// Security protocol
@@ -273,6 +285,7 @@ pub enum SaslMechanism {
     Plain,
     ScramSha256,
     ScramSha512,
+    Gssapi,
 }
 
 /// Topic selection configuration

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -8,6 +8,7 @@ use socket2::{SockRef, TcpKeepalive};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
+use std::path::Path;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -85,6 +86,7 @@ struct BrokerConnection {
     stream: ConnectionStream,
     #[allow(dead_code)]
     broker_id: i32,
+    hostname: String,
 }
 
 impl KafkaClient {
@@ -106,9 +108,15 @@ impl KafkaClient {
             match self.try_connect(server).await {
                 Ok(stream) => {
                     let mut conn = self.connection.lock().await;
+                    let hostname = server
+                    .split(':')
+                    .next()
+                    .unwrap_or(server)
+                    .to_string();
                     *conn = Some(BrokerConnection {
                         stream,
                         broker_id: -1, // Unknown until metadata fetch
+                        hostname,
                     });
 
                     // Perform SASL authentication if configured
@@ -239,6 +247,25 @@ impl KafkaClient {
                     security.sasl_username.as_deref().unwrap_or(""),
                     security.sasl_password.as_deref().unwrap_or(""),
                     mechanism,
+                )
+                .await
+            }
+            Some(SaslMechanism::Gssapi) => {
+            let service_name = security
+                .sasl_kerberos_service_name
+                .as_deref()
+                .unwrap_or("kafka");
+            let hostname = {
+                let conn = self.connection.lock().await;
+                    conn.as_ref()
+                        .map(|c| c.hostname.clone())
+                        .unwrap_or_default()
+                };
+                self.sasl_gssapi_auth(
+                    service_name,
+                    &hostname,
+                    security.sasl_keytab_path.as_deref(),
+                    security.sasl_krb5_config_path.as_deref(),
                 )
                 .await
             }
@@ -431,9 +458,15 @@ impl KafkaClient {
             match self.try_connect(server).await {
                 Ok(stream) => {
                     let mut conn = self.connection.lock().await;
+                    let hostname = server
+                        .split(':')
+                        .next()
+                        .unwrap_or(server)
+                        .to_string();
                     *conn = Some(BrokerConnection {
                         stream,
                         broker_id: -1,
+                        hostname,
                     });
 
                     // Re-authenticate if needed, using send_raw_request directly
@@ -476,6 +509,25 @@ impl KafkaClient {
                     security.sasl_username.as_deref().unwrap_or(""),
                     security.sasl_password.as_deref().unwrap_or(""),
                     mechanism,
+                )
+                .await
+            }
+            Some(SaslMechanism::Gssapi) => {
+                let service_name = security
+                    .sasl_kerberos_service_name
+                    .as_deref()
+                    .unwrap_or("kafka");
+                let hostname = {
+                    let conn = self.connection.lock().await;
+                    conn.as_ref()
+                        .map(|c| c.hostname.clone())
+                        .unwrap_or_default()
+                };
+                self.sasl_gssapi_auth_raw(
+                    service_name,
+                    &hostname,
+                    security.sasl_keytab_path.as_deref(),
+                    security.sasl_krb5_config_path.as_deref(),
                 )
                 .await
             }
@@ -591,6 +643,194 @@ impl KafkaClient {
         debug!(
             "SASL {} re-authentication successful",
             algorithm.mechanism_name()
+        );
+        Ok(())
+    }
+
+    /// SASL GSSAPI/Kerberos auth using send_request (initial connection path).
+    ///
+    /// Mirrors the structure of `sasl_scram_auth`: uses `send_request` which
+    /// has auto-reconnect logic, and is called only during the first connect.
+    async fn sasl_gssapi_auth(
+        &self,
+        service_name: &str,
+        broker_host: &str,
+        keytab_path: Option<&Path>,
+        krb5_config_path: Option<&Path>,
+    ) -> Result<()> {
+        use super::gssapi::GssapiClient;
+        use kafka_protocol::messages::{SaslAuthenticateRequest, SaslHandshakeRequest};
+
+        // Step 1: announce the mechanism.
+        let handshake = SaslHandshakeRequest::default().with_mechanism("GSSAPI".into());
+        let _: kafka_protocol::messages::SaslHandshakeResponse =
+            self.send_request(ApiKey::SaslHandshake, handshake).await?;
+
+        let mut gss = GssapiClient::new(service_name, broker_host, keytab_path, krb5_config_path)?;
+
+        // Phase 1: GSS context establishment (one or more round-trips).
+        let first_token = gss
+            .initial_token()?
+            .ok_or_else(|| {
+                crate::Error::Authentication(
+                    "GSSAPI: initial_token() returned None — expected a non-empty token"
+                        .to_string(),
+                )
+            })?;
+
+        let mut client_token = first_token;
+        let mut context_established = false;
+
+        loop {
+            let req = SaslAuthenticateRequest::default()
+                .with_auth_bytes(Bytes::from(client_token));
+            let resp: kafka_protocol::messages::SaslAuthenticateResponse =
+                self.send_request(ApiKey::SaslAuthenticate, req).await?;
+
+            if resp.error_code != 0 {
+                return Err(crate::Error::Authentication(format!(
+                    "GSSAPI: broker rejected token (Phase 1): {}",
+                    resp.error_message
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("error code {}", resp.error_code))
+                )));
+            }
+
+            if context_established {
+                // The broker's response in the first post-establishment
+                // round-trip is the Phase 2 security-layer proposal.
+                if !resp.auth_bytes.is_empty() {
+                    let wrapped_reply = gss.handle_security_layer(&resp.auth_bytes, "")?;
+                    let req = SaslAuthenticateRequest::default()
+                        .with_auth_bytes(Bytes::from(wrapped_reply));
+                    let final_resp: kafka_protocol::messages::SaslAuthenticateResponse =
+                        self.send_request(ApiKey::SaslAuthenticate, req).await?;
+                    if final_resp.error_code != 0 {
+                        return Err(crate::Error::Authentication(format!(
+                            "GSSAPI: broker rejected security-layer reply (Phase 2): \
+                             error code {}",
+                            final_resp.error_code
+                        )));
+                    }
+                }
+                break;
+            }
+
+            if resp.auth_bytes.is_empty() {
+                return Err(crate::Error::Authentication(
+                    "GSSAPI: broker sent an empty token before context was established"
+                        .to_string(),
+                ));
+            }
+
+            // Advance the context with the server's token.
+            match gss.step(&resp.auth_bytes)? {
+                Some(next_token) => {
+                    client_token = next_token;
+                }
+                None => {
+                    // Context is fully established.  Send an empty authenticate
+                    // to prompt the Phase 2 security-layer message from the broker.
+                    context_established = true;
+                    client_token = Vec::new();
+                }
+            }
+        }
+
+        debug!("SASL GSSAPI authentication successful (broker: {})", broker_host);
+        Ok(())
+    }
+
+    /// SASL GSSAPI/Kerberos auth using raw requests (reconnect path).
+    ///
+    /// Mirrors `sasl_scram_auth_raw`: uses `send_raw_request` directly to
+    /// avoid the reconnect → authenticate → send_request recursion.
+    async fn sasl_gssapi_auth_raw(
+        &self,
+        service_name: &str,
+        broker_host: &str,
+        keytab_path: Option<&Path>,
+        krb5_config_path: Option<&Path>,
+    ) -> Result<()> {
+        use super::gssapi::GssapiClient;
+        use kafka_protocol::messages::{SaslAuthenticateRequest, SaslHandshakeRequest};
+
+        // Step 1: SASL Handshake.
+        let handshake = SaslHandshakeRequest::default().with_mechanism("GSSAPI".into());
+        let buf = self.encode_request(ApiKey::SaslHandshake, &handshake)?;
+        let _: kafka_protocol::messages::SaslHandshakeResponse =
+            self.send_raw_request(ApiKey::SaslHandshake, &buf).await?;
+
+        let mut gss = GssapiClient::new(service_name, broker_host, keytab_path, krb5_config_path)?;
+
+        // Phase 1: GSS context establishment.
+        let first_token = gss
+            .initial_token()?
+            .ok_or_else(|| {
+                crate::Error::Authentication(
+                    "GSSAPI: initial_token() returned None".to_string(),
+                )
+            })?;
+
+        let mut client_token = first_token;
+        let mut context_established = false;
+
+        loop {
+            let req = SaslAuthenticateRequest::default()
+                .with_auth_bytes(Bytes::from(client_token));
+            let buf = self.encode_request(ApiKey::SaslAuthenticate, &req)?;
+            let resp: kafka_protocol::messages::SaslAuthenticateResponse =
+                self.send_raw_request(ApiKey::SaslAuthenticate, &buf).await?;
+
+            if resp.error_code != 0 {
+                return Err(crate::Error::Authentication(format!(
+                    "GSSAPI: broker rejected token (Phase 1): {}",
+                    resp.error_message
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("error code {}", resp.error_code))
+                )));
+            }
+
+            if context_established {
+                if !resp.auth_bytes.is_empty() {
+                    let wrapped_reply = gss.handle_security_layer(&resp.auth_bytes, "")?;
+                    let req = SaslAuthenticateRequest::default()
+                        .with_auth_bytes(Bytes::from(wrapped_reply));
+                    let buf = self.encode_request(ApiKey::SaslAuthenticate, &req)?;
+                    let final_resp: kafka_protocol::messages::SaslAuthenticateResponse =
+                        self.send_raw_request(ApiKey::SaslAuthenticate, &buf).await?;
+                    if final_resp.error_code != 0 {
+                        return Err(crate::Error::Authentication(format!(
+                            "GSSAPI: broker rejected security-layer reply (Phase 2): \
+                             error code {}",
+                            final_resp.error_code
+                        )));
+                    }
+                }
+                break;
+            }
+
+            if resp.auth_bytes.is_empty() {
+                return Err(crate::Error::Authentication(
+                    "GSSAPI: broker sent an empty token before context was established"
+                        .to_string(),
+                ));
+            }
+
+            match gss.step(&resp.auth_bytes)? {
+                Some(next_token) => {
+                    client_token = next_token;
+                }
+                None => {
+                    context_established = true;
+                    client_token = Vec::new();
+                }
+            }
+        }
+
+        debug!(
+            "SASL GSSAPI re-authentication successful (broker: {})",
+            broker_host
         );
         Ok(())
     }

--- a/crates/kafka-backup-core/src/kafka/gssapi.rs
+++ b/crates/kafka-backup-core/src/kafka/gssapi.rs
@@ -1,0 +1,305 @@
+//! GSSAPI/Kerberos SASL authentication for Kafka (RFC 4752).
+//!
+//! This module delegates all Kerberos operations to the OS GSSAPI library
+//! (MIT Kerberos / `libgssapi_krb5` on Linux, Heimdal on macOS/BSD).
+//!
+//! Kerberos credentials are resolved in the following order:
+//!   1. `keytab_path` from the security config       → applied as `KRB5_KTNAME`
+//!   2. `krb5_config_path` from the security config  → applied as `KRB5_CONFIG`
+//!   3. OS defaults: the credential cache populated by `kinit`, the system
+//!      `/etc/krb5.conf`, and any keytab referenced there.
+//!
+//! This module is always compiled, exactly like `scram.rs`. When
+//! `sasl_mechanism` is not `GSSAPI` the code is never called; the linker
+//! includes `libgssapi_krb5` but it stays dormant.
+//!
+//! The Kafka SASL/GSSAPI wire protocol follows RFC 4752 §3.1:
+//!   Phase 1 — GSS context establishment (one or more SaslAuthenticate
+//!              round-trips until `gss_init_sec_context` returns complete)
+//!   Phase 2 — Security-layer negotiation (one final SaslAuthenticate
+//!              round-trip; kafka-backup always selects "no security layer")
+//!
+//! # libgssapi version
+//! Written against libgssapi 0.9.1. The key API points used are:
+//!   - `OidSet::new()` / `OidSet::add()` to build the desired-mechs set
+//!   - `Cred::acquire(name, time_req, usage, Option<&OidSet>)`
+//!   - `ClientCtx::new(Option<Cred>, Name, CtxFlags, Option<&'static Oid>)`
+//!   - `ClientCtx::step(Option<&[u8]>, Option<&[u8]>)` → `Result<Option<Buf>>`
+//!   - `SecurityContext::wrap(bool, &[u8])` / `SecurityContext::unwrap(&[u8])`
+
+use libgssapi::{
+    context::{ClientCtx, CtxFlags, SecurityContext},
+    credential::{Cred, CredUsage},
+    name::Name,
+    oid::{OidSet, GSS_MECH_KRB5, GSS_NT_HOSTBASED_SERVICE},
+};
+use tracing::debug;
+use std::path::Path;
+
+
+/// GSSAPI client state machine for a single broker connection.
+///
+/// Create a fresh `GssapiClient` for each connection (or reconnection).
+/// GSS security contexts are bound to one TCP connection and must not be
+/// reused after a reconnect.
+///
+/// # Typical call sequence (mirrors the logic in `client.rs`)
+///
+/// ```ignore
+/// let mut gss = GssapiClient::new(
+///     "kafka",                            // service_name
+///     "broker1.corp.example.com",         // broker_host (no port)
+///     Some("/etc/kafka/kafka.keytab"),    // keytab_path from config
+///     Some("/etc/kafka/krb5.conf"),       // krb5_config_path from config
+/// )?;
+///
+/// // Phase 1 — GSS context establishment (1+ round trips)
+/// let mut token = gss.initial_token()?.expect("initial token is always Some");
+/// loop {
+///     // send token → SaslAuthenticate → receive server_token
+///     match gss.step(&server_token)? {
+///         Some(next_token) => token = next_token,
+///         None => break, // context fully established, nothing more to send
+///     }
+/// }
+///
+/// // Phase 2 — security-layer negotiation (1 round trip)
+/// // broker sends a GSSAPI-wrapped 4-byte proposal; we reply with layer=1
+/// let reply = gss.handle_security_layer(&server_wrapped, "")?;
+/// // send reply → SaslAuthenticate → done
+/// ```
+pub(crate) struct GssapiClient {
+    ctx: ClientCtx,
+}
+
+impl GssapiClient {
+    /// Create a new GSSAPI client targeting a specific Kafka broker.
+    ///
+    /// # Parameters
+    ///
+    /// - `service_name` — Kerberos service name; must match the broker's
+    ///   `sasl.kerberos.service.name` property (Kafka default: `"kafka"`).
+    ///
+    /// - `broker_host` — Hostname of the broker, **without the port**.
+    ///   Combined with `service_name` to form the GSS target principal
+    ///   `service_name@broker_host`, which the library resolves to
+    ///   `service_name/broker_host@REALM` via the host-based service OID
+    ///   (RFC 2743 §4.1).
+    ///
+    /// - `keytab_path` — Optional path to a Kerberos keytab file.  When
+    ///   `Some`, it is set as the `KRB5_CLIENT_KTNAME` environment variable before
+    ///   credential acquisition, causing the library to use the keytab
+    ///   instead of the default credential cache.  Corresponds to
+    ///   `security.sasl_keytab_path` in `backup.yaml`.
+    ///
+    /// - `krb5_config_path` — Optional path to a `krb5.conf` file.  When
+    ///   `Some`, it is set as the `KRB5_CONFIG` environment variable before
+    ///   credential acquisition, overriding the system-wide `/etc/krb5.conf`.
+    ///   Corresponds to `security.sasl_krb5_config_path` in `backup.yaml`.
+    pub fn new(
+        service_name: &str,
+        broker_host: &str,
+        keytab_path: Option<&Path>,
+        krb5_config_path: Option<&Path>,
+    ) -> Result<Self, crate::Error> {
+        // Apply file-path overrides from the kafka-backup configuration before
+        // any GSSAPI call.  These environment variables are the standard MIT
+        // Kerberos mechanism for directing the library to specific files.
+        //
+        // Thread-safety note: `set_var` is not guaranteed safe when other
+        // threads are reading the environment concurrently.  This is acceptable
+        // here because:
+        //   a) kafka-backup calls connect() from a single async task per
+        //      KafkaClient instance, so there is no intra-client race.
+        //   b) Both variables are only ever written, never deleted, so if two
+        //      clients race at startup they write the same configured value.
+        //   c) The Rust stdlib documents this limitation; we accept it for the
+        //      same reasons other Rust GSSAPI integrations do when configuring
+        //      Kerberos via environment variables.
+        if let Some(path) = krb5_config_path {
+            // SAFETY: see thread-safety note above
+            unsafe { std::env::set_var("KRB5_CONFIG", path) };
+            debug!("GSSAPI: KRB5_CONFIG={}", path.display());
+        }
+        if let Some(path) = keytab_path {
+            // SAFETY: see thread-safety note above
+            unsafe { std::env::set_var("KRB5_CLIENT_KTNAME", path) };
+            debug!("GSSAPI: KRB5_CLIENT_KTNAME={}", path.display());
+        }
+
+        // Build the GSS target name as a host-based service name.
+        // The format "service@host" is the RFC 2743 §4.1 host-based syntax.
+        let target_str = format!("{}@{}", service_name, broker_host);
+        let target_name =
+            Name::new(target_str.as_bytes(), Some(&GSS_NT_HOSTBASED_SERVICE)).map_err(|e| {
+                crate::Error::Authentication(format!(
+                    "GSSAPI: failed to construct target name '{}': {}",
+                    target_str, e
+                ))
+            })?;
+
+        // Build an OidSet containing only the Kerberos 5 mechanism.
+        // libgssapi 0.9.1 requires Cred::acquire to receive Option<&OidSet>
+        // rather than a plain slice of OIDs — this is the correct API call.
+        let desired_mechs = {
+            let mut s = OidSet::new().map_err(|e| {
+                crate::Error::Authentication(format!(
+                    "GSSAPI: failed to create OidSet: {}",
+                    e
+                ))
+            })?;
+            s.add(&GSS_MECH_KRB5).map_err(|e| {
+                crate::Error::Authentication(format!(
+                    "GSSAPI: failed to add KRB5 to OidSet: {}",
+                    e
+                ))
+            })?;
+            s
+        };
+
+        // Acquire initiator credentials from the OS credential cache or keytab.
+        // Passing `None` for the name lets the library choose the default
+        // principal (the principal from `kinit`, or the first key in the keytab
+        // when KRB5_CLIENT_KTNAME is set above).
+        // Passing `None` for time_req requests the maximum available lifetime.
+        let cred =
+            Cred::acquire(None, None, CredUsage::Initiate, Some(&desired_mechs)).map_err(
+                |e| {
+                    crate::Error::Authentication(format!(
+                        "GSSAPI: failed to acquire Kerberos credentials: {}. \
+                         Check that either a valid ticket-granting ticket exists \
+                         (run `kinit`) or that `sasl_keytab_path` in the security \
+                         configuration points to a readable keytab file.",
+                        e
+                    ))
+                },
+            )?;
+
+        // Request mutual authentication and sequence-number protection.
+        // Both flags are mandatory for the Kafka SASL/GSSAPI profile (RFC 4752).
+        // bitflags 2.0 (used by libgssapi 0.9.1) supports the | operator.
+        let flags = CtxFlags::GSS_C_MUTUAL_FLAG | CtxFlags::GSS_C_SEQUENCE_FLAG;
+
+        // ClientCtx::new stores parameters; it does not perform I/O or produce
+        // tokens yet.  Tokens are generated lazily in step().
+        // Signature in 0.9.1: new(cred: Option<Cred>, target: Name,
+        //                         flags: CtxFlags, mech: Option<&'static Oid>)
+        let ctx = ClientCtx::new(Some(cred), target_name, flags, Some(&GSS_MECH_KRB5));
+
+        Ok(Self { ctx })
+    }
+
+    /// Produce the **initial** GSSAPI token, the first bytes sent to the broker
+    /// in Phase 1.
+    ///
+    /// Returns `Ok(Some(token))`.  For Kerberos the initial token is never
+    /// empty, so `None` here would indicate a library bug.
+    pub fn initial_token(&mut self) -> Result<Option<Vec<u8>>, crate::Error> {
+        self.step_inner(None)
+    }
+
+    /// Advance the GSS context with a token received from the broker.
+    ///
+    /// Returns:
+    /// - `Ok(Some(token))` — send `token` to the broker; context not yet done
+    /// - `Ok(None)`        — context is fully established; Phase 1 complete
+    /// - `Err(_)`          — unrecoverable GSSAPI error
+    pub fn step(&mut self, server_token: &[u8]) -> Result<Option<Vec<u8>>, crate::Error> {
+        self.step_inner(Some(server_token))
+    }
+
+    // Internal: drive ClientCtx::step with optional input.
+    // Signature in 0.9.1: step(&mut self, tok: Option<&[u8]>,
+    //                           channel_bindings: Option<&[u8]>)
+    //                    -> Result<Option<Buf>, Error>
+    // Buf implements Deref<Target=[u8]>, so .to_vec() works correctly.
+    fn step_inner(&mut self, input: Option<&[u8]>) -> Result<Option<Vec<u8>>, crate::Error> {
+        match self.ctx.step(input, None) {
+            Ok(Some(buf)) => Ok(Some(buf.to_vec())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(crate::Error::Authentication(format!(
+                "GSSAPI: context establishment step failed: {}",
+                e
+            ))),
+        }
+    }
+
+    /// Handle the RFC 4752 §3.1 Phase 2 security-layer negotiation.
+    ///
+    /// After Phase 1 the broker sends a GSSAPI-wrapped 4-byte proposal:
+    ///
+    /// ```text
+    /// byte  0    : bitmask of supported security layers
+    ///                0x01 = no security layer  (always required)
+    ///                0x02 = integrity only
+    ///                0x04 = confidentiality + integrity
+    /// bytes 1..3 : maximum message size the broker accepts (big-endian u24)
+    /// ```
+    ///
+    /// This method unwraps the proposal, asserts that "no security layer"
+    /// (0x01) is offered, and returns a GSSAPI-wrapped reply selecting it:
+    ///
+    /// ```text
+    /// byte  0    : 0x01              (select no security layer)
+    /// bytes 1..3 : 0x00 0x00 0x00   (max message size; unused for layer 1)
+    /// bytes 4..  : authz_id as UTF-8 (empty = use the authenticated identity)
+    /// ```
+    ///
+    /// The reply is wrapped without encryption (integrity-only, `conf_req=false`)
+    /// and returned as bytes ready for a `SaslAuthenticateRequest`.
+    ///
+    /// `wrap` and `unwrap` are provided by the `SecurityContext` trait impl on
+    /// `ClientCtx` in libgssapi 0.9.1 — no API changes there.
+    pub fn handle_security_layer(
+        &mut self,
+        server_wrapped: &[u8],
+        authz_id: &str,
+    ) -> Result<Vec<u8>, crate::Error> {
+        let unwrapped = self.ctx.unwrap(server_wrapped).map_err(|e| {
+            crate::Error::Authentication(format!(
+                "GSSAPI: failed to unwrap broker security-layer proposal: {}",
+                e
+            ))
+        })?;
+
+        if unwrapped.len() < 4 {
+            return Err(crate::Error::Authentication(format!(
+                "GSSAPI: broker security-layer message too short \
+                 ({} bytes, expected ≥4)",
+                unwrapped.len()
+            )));
+        }
+
+        let server_layers = unwrapped[0];
+        if server_layers & 0x01 == 0 {
+            // kafka-backup does not implement per-message GSSAPI
+            // integrity/confidentiality wrapping of Kafka protocol frames.
+            // Only the authentication handshake itself uses GSSAPI wrapping.
+            return Err(crate::Error::Authentication(format!(
+                "GSSAPI: broker security-layer bitmask (0x{:02x}) does not \
+                 include no-security-layer (0x01). kafka-backup requires \
+                 security layer 1 (authentication only, no per-message wrap).",
+                server_layers
+            )));
+        }
+
+        // Build the client response: choose layer 1, size=0, optional authz_id.
+        let mut response_plain = vec![0x01u8, 0x00, 0x00, 0x00];
+        response_plain.extend_from_slice(authz_id.as_bytes());
+
+        // Wrap without encryption (conf_req = false → integrity-only wrap).
+        let wrapped = self.ctx.wrap(false, &response_plain).map_err(|e| {
+            crate::Error::Authentication(format!(
+                "GSSAPI: failed to wrap security-layer response: {}",
+                e
+            ))
+        })?;
+
+        debug!(
+            "GSSAPI: Phase 2 complete (server_layers=0x{:02x}, authz_id={:?})",
+            server_layers, authz_id
+        );
+
+        Ok(wrapped.to_vec())
+    }
+}

--- a/crates/kafka-backup-core/src/kafka/mod.rs
+++ b/crates/kafka-backup-core/src/kafka/mod.rs
@@ -8,6 +8,7 @@ mod metadata;
 mod partition_router;
 mod produce;
 mod scram;
+mod gssapi;
 pub mod tls;
 
 pub use admin::{create_topics, delete_records, CreateTopicResult, TopicToCreate};


### PR DESCRIPTION
## Summary

This PR adds GSSAPI/Kerberos authentication to `kafka-backup-core`, enabling
backup and restore operations against Kafka clusters secured with Kerberos, a
common requirement in enterprise environments. The implementation follows the
same always-compiled, configuration-driven pattern as the existing SCRAM and
PLAIN authentication methods: if `sasl_mechanism` is not set to `GSSAPI`, the
new code paths are never reached and behaviour is completely unchanged.

---

## Motivation

Many organisations use Kerberos to secure their Kafka infrastructure.
`kafka-backup` previously supported `PLAIN` and `SCRAM-SHA-256/512` but had no
path for Kerberos users, making it unusable in those environments without
workarounds. This change closes that gap.

---

## Changes

### New file: `crates/kafka-backup-core/src/kafka/gssapi.rs`

Implements the `GssapiClient` struct, which drives the two-phase Kafka
SASL/GSSAPI wire protocol (RFC 4752 §3.1):

- **Phase 1** — GSS context establishment via one or more `SaslAuthenticate`
  round-trips until `gss_init_sec_context` signals completion.
- **Phase 2** — Security-layer negotiation; always selects layer `0x01`
  (no per-message wrapping), which is the only layer Kafka requires.

Uses [`libgssapi`](https://crates.io/crates/libgssapi) `0.9.1` — a safe Rust
binding over the OS GSSAPI library (`libgssapi_krb5` on Linux, Heimdal on
macOS/BSD). No pure-Rust Kerberos implementation is used; all KDC
communication, ticket management, and keytab handling are delegated to the OS
library, which is the standard approach and is how the Java, Python, and 
C Kafka clients work).

### Modified: `crates/kafka-backup-core/src/kafka/client.rs`

- Added `hostname: String` field to `BrokerConnection` (extracted from the
  broker address at connect time) so the GSSAPI client can build the correct
  GSS target principal without re-parsing the address string.
- Added `Gssapi` arms to `authenticate()` and `authenticate_raw()`, passing the
  four GSSAPI parameters (service name, broker host, keytab path, krb5 config
  path) to the new `GssapiClient`.
- Added `sasl_gssapi_auth()` (uses `send_request`, for initial connections) and
  `sasl_gssapi_auth_raw()` (uses `send_raw_request`, for reconnects), mirroring
  the existing SCRAM method split that prevents async recursion.

### Modified: `crates/kafka-backup-core/src/config.rs`

Added `Gssapi` variant to `SaslMechanism` and three new optional fields to
`SecurityConfig`:

| Field | Type | Default | Description |
|---|---|---|---|
| `sasl_kerberos_service_name` | `Option<String>` | `None` → `"kafka"` | Must match broker's `sasl.kerberos.service.name` |
| `sasl_keytab_path` | `Option<PathBuf>` | `None` | Path to keytab; sets `KRB5_CLIENT_KTNAME` |
| `sasl_krb5_config_path` | `Option<PathBuf>` | `None` | Path to `krb5.conf`; sets `KRB5_CONFIG` |

All three fields are optional. When `None`, the OS Kerberos library uses its
own resolution order (`$KRB5_CLIENT_KTNAME` / `$KRB5_CONFIG` env vars, then
`/etc/krb5.conf`, then the system credential cache). Existing configurations
that do not set these fields are completely unaffected.

### Modified: `crates/kafka-backup-core/src/kafka/mod.rs`

Added `mod gssapi;`.

### Modified: `crates/kafka-backup-cli/src/commands/offset_reset.rs`, `offset_reset_bulk.rs`, `offset_rollback.rs`

These files construct `SecurityConfig` struct literals by field name. The three
new fields were added explicitly as `None` to fix compilation. Full GSSAPI
support for the offset-reset commands (reading keytab/krb5 config from the
YAML or CLI flags) is left for a possible future PR (see **Known limitations**).

### Modified: `crates/kafka-backup-core/Cargo.toml`

Added `libgssapi = "0.9"` as a regular (non-optional) dependency, consistent
with how `ring` is included regardless of which auth mechanism is configured.

---

## Configuration

Below is a complete example for a SASL_SSL + GSSAPI setup. All three
GSSAPI-specific fields are optional.

```yaml
source:                               # or `target:` for restore
  bootstrap_servers:
    - broker1.corp.com:6668
    - broker2.corp.com:6668
  security:
    security_protocol: SASL_SSL
    sasl_mechanism: GSSAPI

    # Must match sasl.kerberos.service.name on the broker (default: "kafka")
    sasl_kerberos_service_name: kafka

    # Path to a keytab file for unattended / service-account use.
    # Remove or comment out to use the OS credential cache (kinit).
    sasl_keytab_path: /etc/security/keytabs/kafka-backup.keytab

    # Path to a custom krb5.conf. Remove or comment out to use /etc/krb5.conf.
    sasl_krb5_config_path: /etc/kafka/krb5.conf

    # TLS CA certificate (required when security_protocol: SASL_SSL)
    ssl_ca_location: /var/ssl/private/ca.crt
```

**Minimum viable config** (relying on `kinit`/OS cache and system `krb5.conf`):

```yaml
  security:
    security_protocol: SASL_SSL
    sasl_mechanism: GSSAPI
    ssl_ca_location: /var/ssl/private/ca.crt
```

---

## Build requirements

The system GSSAPI development library must be present on the **build** host.
The runtime host needs only the runtime library (usually installed by default).

| Distribution | Build | Runtime |
|---|---|---|
| RHEL / CentOS / Rocky | `sudo dnf install krb5-devel` | `krb5-libs` (default) |
| Debian / Ubuntu | `sudo apt install libkrb5-dev` | `libkrb5-3` (default) |
| macOS (Homebrew) | `brew install krb5` + set `PKG_CONFIG_PATH` | bundled |

For CI (GitHub Actions Linux runner), add:

```yaml
- name: Install Kerberos development libraries
  run: sudo apt-get install -y libkrb5-dev
```

---

## Testing

Tested on **Red Hat Enterprise Linux 9.7** (bare metal VM) against a
multi-broker Kafka cluster with SASL_SSL + GSSAPI:

| Scenario | Result |
|---|---|
| `kinit` credential cache, no keytab config | ✅ |
| Keytab file via `sasl_keytab_path`, custom `krb5.conf` | ✅ |
| Keytab file via `sasl_keytab_path`, OS default `krb5.conf` | ✅ |
| Valid keytab, user not authorised on Kafka | ✅ 0 topics backupped |
| Invalid / unreadable keytab, no ticket in cache | ✅ clear error |
| Valid keytab, invalid `krb5.conf` path | ✅ clear error |
| Backup operation end-to-end | ✅ |
| Restore operation end-to-end | ✅ |
| `cargo test` passed | ✅ |

Testing in Docker / Kubernetes environments would be appreciated. A
`docker-compose` setup with a Kerberized Kafka and a KDC container would be a
valuable addition to the `kafka-backup-demos` repository.

---

## Example log output

Successful authentication with keytab:

```
2026-04-20T21:36:23.802996Z DEBUG kafka_backup_core::kafka::gssapi: GSSAPI: KRB5_CONFIG=/etc/kafka/krb5.conf
2026-04-20T21:36:23.803055Z DEBUG kafka_backup_core::kafka::gssapi: GSSAPI: KRB5_CLIENT_KTNAME=/etc/security/keytabs/kafka-backup.keytab
2026-04-20T21:36:23.813211Z DEBUG kafka_backup_core::kafka::gssapi: GSSAPI: Phase 2 complete (server_layers=0x01, authz_id="")
2026-04-20T21:36:23.813724Z DEBUG kafka_backup_core::kafka::client: SASL GSSAPI authentication successful (broker: broker1.corp.com)
```

Invalid keytab with no ticket in the OS cache:

```
2026-04-20T21:31:38.105568Z WARN kafka_backup_core::health: Component kafka became Unhealthy:
  Some("Authentication error: GSSAPI: failed to acquire Kerberos credentials:
  No credentials were supplied, or the credentials were unavailable or inaccessible
  (No Kerberos credentials available (default cache: KCM:)).
  Check that either a valid ticket-granting ticket exists (run `kinit`) or that
  `sasl_keytab_path` in the security configuration points to a readable keytab file.")
```

---

## Known limitations

- **Offset-reset commands** (`offset-reset`, `offset-reset-bulk`,
  `offset-rollback`) currently default all GSSAPI fields to `None` in their
  `parse_security_config` helper. These commands will work with `kinit`
  credential cache but do not yet read `sasl_keytab_path` or
  `sasl_krb5_config_path` from YAML or CLI flags. Could be the focus of
  a future PR.

- This implementation has only been tested on Linux (RHEL 9.7).

---

## Checklist

- [x] Code follows the existing style and conventions of the project
- [x] New dependency (`libgssapi 0.9`) is justified and documented
- [x] No breaking changes to existing authentication methods or configurations
- [x] Behaviour is unchanged when `sasl_mechanism` is not `GSSAPI`
- [x] Error messages are descriptive and guide the user toward a resolution
- [ ] Unit tests for `gssapi.rs` (a full Kerberos handshake test requires a live KDC; contributions welcome)
- [ ] Integration test in Docker / Kubernetes with a Kerberized Kafka
- [ ] Offset-reset commands: full GSSAPI support (potential future PR)