### PR TITLE
fix(sasl): bind auth plugins to connected broker endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -235,12 +235,12 @@ pub struct SecurityConfig {
     /// config.
     ///
     /// The factory is invoked once per `KafkaClient` in
-    /// `KafkaClient::authenticate`, with the broker endpoint from
-    /// `bootstrap_servers[0]`. The `PartitionLeaderRouter` rewrites that
-    /// field to the advertised per-broker `host:port` before spawning
-    /// pooled clients, so stateful mechanisms (GSSAPI) receive the
-    /// correct SPN hostname and stateless mechanisms (PLAIN,
-    /// OAUTHBEARER) can ignore the argument via [`SharedPluginFactory`].
+    /// `KafkaClient::authenticate`, with the broker endpoint that was
+    /// successfully dialed. The `PartitionLeaderRouter` rewrites
+    /// `bootstrap_servers` to the advertised per-broker `host:port` before
+    /// spawning pooled clients, so stateful mechanisms (GSSAPI) receive the
+    /// correct SPN hostname and stateless mechanisms (PLAIN, OAUTHBEARER)
+    /// can ignore the argument via [`SharedPluginFactory`].
     ///
     /// [`SharedPluginFactory`]: crate::kafka::SharedPluginFactory
     #[serde(skip)]

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -118,7 +118,7 @@ impl KafkaClient {
                         || self.config.security.security_protocol == SecurityProtocol::SaslSsl
                     {
                         drop(conn);
-                        self.authenticate().await?;
+                        self.authenticate(server).await?;
                     }
 
                     debug!("Connected to Kafka broker: {}", server);
@@ -224,26 +224,15 @@ impl KafkaClient {
         Ok(())
     }
 
-    async fn authenticate(&self) -> Result<()> {
+    async fn authenticate(&self, broker_endpoint: &str) -> Result<()> {
         let security = &self.config.security;
 
         if let Some(factory) = security.sasl_mechanism_plugin_factory.clone() {
-            // PartitionLeaderRouter rewrites `bootstrap_servers` to a
-            // single entry — the advertised broker `host:port` — before
-            // spawning a pooled client. For the bootstrap client, this
-            // is the user-configured endpoint. Either way, element 0 is
-            // the endpoint this client will dial.
-            let entry = self
-                .config
-                .bootstrap_servers
-                .first()
-                .ok_or_else(|| {
-                    crate::Error::Config(
-                        "bootstrap_servers is empty; cannot build SASL plugin".to_string(),
-                    )
-                })?
-                .as_str();
-            let (host, port) = parse_broker_endpoint(entry);
+            // Use the endpoint that `try_connect` actually dialed. The
+            // bootstrap client may skip earlier configured entries if they
+            // are down; GSSAPI and MSK IAM both need the successful broker
+            // host/port when constructing mechanism-specific payloads.
+            let (host, port) = parse_broker_endpoint(broker_endpoint);
             let plugin = factory.build(&host, port).map_err(|e| {
                 crate::Error::Authentication(format!(
                     "SASL plugin factory failed for broker {host}:{port}: {e}"
@@ -547,7 +536,7 @@ impl KafkaClient {
                         || self.config.security.security_protocol == SecurityProtocol::SaslSsl
                     {
                         drop(conn);
-                        Box::pin(self.authenticate()).await?;
+                        Box::pin(self.authenticate(server)).await?;
                     }
 
                     debug!("Reconnected to Kafka broker: {}", server);

--- a/crates/kafka-backup-core/src/kafka/sasl/gssapi.rs
+++ b/crates/kafka-backup-core/src/kafka/sasl/gssapi.rs
@@ -36,7 +36,8 @@
 //! that lands in a future `libgssapi` release, switch to it and delete
 //! the mutex.
 
-use std::path::PathBuf;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -54,6 +55,60 @@ use super::plugin::{SaslAuthOutcome, SaslMechanismPlugin, SaslPluginError};
 /// Process-wide serialization point for the `KRB5_*` env-var mutation +
 /// `Cred::acquire` call. See module docs.
 static KRB5_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[derive(Debug)]
+struct EnvVarRestore {
+    name: &'static str,
+    original: Option<OsString>,
+}
+
+/// Restores process-global Kerberos environment overrides before the
+/// acquisition lock is released.
+#[derive(Debug, Default)]
+struct Krb5EnvGuard {
+    vars: Vec<EnvVarRestore>,
+}
+
+impl Krb5EnvGuard {
+    fn apply(
+        keytab_path: Option<&Path>,
+        krb5_config_path: Option<&Path>,
+        ccache: Option<&str>,
+    ) -> Self {
+        let mut guard = Self::default();
+        if let Some(path) = keytab_path {
+            guard.set("KRB5_CLIENT_KTNAME", path.as_os_str());
+        }
+        if let Some(ccache) = ccache {
+            guard.set("KRB5CCNAME", OsStr::new(ccache));
+        }
+        if let Some(path) = krb5_config_path {
+            guard.set("KRB5_CONFIG", path.as_os_str());
+        }
+        guard
+    }
+
+    fn set(&mut self, name: &'static str, value: &OsStr) {
+        let original = std::env::var_os(name);
+        self.vars.push(EnvVarRestore { name, original });
+        unsafe {
+            std::env::set_var(name, value);
+        }
+    }
+}
+
+impl Drop for Krb5EnvGuard {
+    fn drop(&mut self) {
+        for var in self.vars.iter().rev() {
+            unsafe {
+                match &var.original {
+                    Some(value) => std::env::set_var(var.name, value),
+                    None => std::env::remove_var(var.name),
+                }
+            }
+        }
+    }
+}
 
 /// Errors specific to [`GssapiPlugin`]. Carried inside
 /// [`SaslPluginError::PayloadFailed`] when surfaced through the trait.
@@ -185,35 +240,27 @@ impl GssapiPlugin {
 
         let _guard = KRB5_ENV_LOCK.lock().await;
 
-        // SAFETY: `std::env::set_var` is unsafe in edition 2024 because
-        // it's not thread-safe w.r.t. other getenv callers. We
-        // serialize via KRB5_ENV_LOCK — only one GSSAPI acquisition
-        // mutates these variables at a time. Non-GSSAPI code does not
-        // read `KRB5_CLIENT_KTNAME`, `KRB5_CONFIG`, or `KRB5CCNAME`.
-        if let Some(path) = &keytab {
-            unsafe {
-                std::env::set_var("KRB5_CLIENT_KTNAME", path.as_os_str());
-            }
-            // Isolate from the OS credential cache. Without this, if the
-            // operator has stale tickets in the default ccache (common on
-            // macOS where API:<uuid> caches persist across logins), MIT
-            // Kerberos prefers them over a fresh TGT from the keytab.
-            // Stale tickets encrypted with an old service key cause the
-            // broker to reject the AP-REQ with "invalid credentials".
-            //
-            // `MEMORY:<addr>` gives this plugin a private in-process
-            // cache keyed by heap address — cheap, per-instance, and
-            // cleaned up with the plugin.
-            let ccache = format!("MEMORY:{:p}", self as *const Self);
-            unsafe {
-                std::env::set_var("KRB5CCNAME", ccache);
-            }
-        }
-        if let Some(path) = &krb5_config {
-            unsafe {
-                std::env::set_var("KRB5_CONFIG", path.as_os_str());
-            }
-        }
+        // Isolate from the OS credential cache when using a keytab.
+        // Without this, if the operator has stale tickets in the default
+        // ccache (common on macOS where API:<uuid> caches persist across
+        // logins), MIT Kerberos prefers them over a fresh TGT from the
+        // keytab. Stale tickets encrypted with an old service key cause
+        // the broker to reject the AP-REQ with "invalid credentials".
+        //
+        // `MEMORY:<addr>` gives this plugin a private in-process cache
+        // keyed by heap address — cheap, per-instance, and cleaned up
+        // with the plugin.
+        let ccache = keytab
+            .as_ref()
+            .map(|_| format!("MEMORY:{:p}", self as *const Self));
+
+        // SAFETY: `std::env::set_var`/`remove_var` are unsafe in edition
+        // 2024 because they are process-global. `Krb5EnvGuard::apply`
+        // snapshots and mutates the Kerberos variables while
+        // KRB5_ENV_LOCK is held, and its Drop restores them before this
+        // function releases the lock.
+        let _env_guard =
+            Krb5EnvGuard::apply(keytab.as_deref(), krb5_config.as_deref(), ccache.as_deref());
 
         // Pin the mechanism to Kerberos 5 rather than relying on the
         // library's implicit default. Matches librdkafka + the Java
@@ -638,5 +685,68 @@ mod tests {
         // Each build returns a fresh Arc — this is the whole point
         // (per-connection state).
         assert!(!Arc::ptr_eq(&handle_a, &handle_b));
+    }
+
+    #[tokio::test]
+    async fn acquire_cred_restores_krb5_environment_even_on_error() {
+        struct EnvSnapshot {
+            vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+        }
+
+        impl EnvSnapshot {
+            fn new(names: &[&'static str]) -> Self {
+                Self {
+                    vars: names
+                        .iter()
+                        .map(|name| (*name, std::env::var_os(name)))
+                        .collect(),
+                }
+            }
+        }
+
+        impl Drop for EnvSnapshot {
+            fn drop(&mut self) {
+                for (name, value) in &self.vars {
+                    unsafe {
+                        match value {
+                            Some(value) => std::env::set_var(name, value),
+                            None => std::env::remove_var(name),
+                        }
+                    }
+                }
+            }
+        }
+
+        let _snapshot = EnvSnapshot::new(&["KRB5_CLIENT_KTNAME", "KRB5CCNAME", "KRB5_CONFIG"]);
+        unsafe {
+            std::env::set_var("KRB5_CLIENT_KTNAME", "FILE:/tmp/original-client.keytab");
+            std::env::set_var("KRB5CCNAME", "FILE:/tmp/original-ccache");
+            std::env::set_var("KRB5_CONFIG", "/tmp/original-krb5.conf");
+        }
+
+        let keytab = tempfile::NamedTempFile::new().expect("temp keytab");
+        let krb5_config = tempfile::NamedTempFile::new().expect("temp krb5.conf");
+        let plugin = GssapiPlugin::new(
+            "kafka",
+            "kafka.test.local",
+            Some(keytab.path().to_path_buf()),
+            Some(krb5_config.path().to_path_buf()),
+        )
+        .expect("plugin construction");
+
+        let _ = plugin.acquire_cred().await;
+
+        assert_eq!(
+            std::env::var_os("KRB5_CLIENT_KTNAME").as_deref(),
+            Some(std::ffi::OsStr::new("FILE:/tmp/original-client.keytab"))
+        );
+        assert_eq!(
+            std::env::var_os("KRB5CCNAME").as_deref(),
+            Some(std::ffi::OsStr::new("FILE:/tmp/original-ccache"))
+        );
+        assert_eq!(
+            std::env::var_os("KRB5_CONFIG").as_deref(),
+            Some(std::ffi::OsStr::new("/tmp/original-krb5.conf"))
+        );
     }
 }

--- a/crates/kafka-backup-core/src/kafka/sasl/plugin.rs
+++ b/crates/kafka-backup-core/src/kafka/sasl/plugin.rs
@@ -201,10 +201,11 @@ struct Rfc7628Error {
 /// Builds a fresh [`SaslMechanismPluginHandle`] for a specific broker
 /// endpoint. The `KafkaClient::authenticate` path calls
 /// [`SaslMechanismPluginFactory::build`] exactly once per client — the
-/// bootstrap client with the user-configured endpoint, then one per
-/// pooled per-broker client with the advertised broker `host:port` that
-/// [`crate::kafka::partition_router::PartitionLeaderRouter`] rewrites
-/// into the cloned config.
+/// bootstrap client with the user-configured endpoint that successfully
+/// connected, then one per pooled per-broker client with the advertised
+/// broker `host:port` that
+/// [`crate::kafka::partition_router::PartitionLeaderRouter`] rewrites into
+/// the cloned config.
 ///
 /// This replaces the prior "single shared `Arc<dyn SaslMechanismPlugin>`
 /// cloned into every client" design, which had two defects:

--- a/crates/kafka-backup-core/tests/integration_suite/sasl_plugin_mock_tests.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/sasl_plugin_mock_tests.rs
@@ -232,7 +232,7 @@ async fn plugin_reauth_fires_at_80_percent_via_scheduler() {
 
 /// The factory contract: `KafkaClient::authenticate` must call
 /// `SaslMechanismPluginFactory::build` exactly once, passing the
-/// endpoint from `bootstrap_servers[0]`.
+/// configured endpoint that the client successfully dialed.
 ///
 /// This is the test that gates the multi-broker GSSAPI correctness:
 /// when `PartitionLeaderRouter` rewrites `bootstrap_servers` to the
@@ -313,13 +313,99 @@ async fn factory_receives_per_broker_endpoint() {
     );
     let (host, port) = &observed[0];
     // MockKafkaBroker binds 127.0.0.1:<ephemeral>. Assert the factory
-    // receives the exact host + port the client was configured with,
-    // proving the endpoint flows from `bootstrap_servers[0]` through
-    // `parse_broker_endpoint` to the factory.
+    // receives the exact host + port the client successfully dialed,
+    // proving the connected endpoint flows through `parse_broker_endpoint`
+    // to the factory.
     assert_eq!(
         format!("{host}:{port}"),
         bootstrap,
         "factory endpoint must match configured bootstrap exactly"
+    );
+
+    mock.shutdown().await;
+}
+
+/// Regression: if the first bootstrap entry is down and KafkaClient connects
+/// to a later entry, the plugin factory must receive the endpoint that was
+/// actually dialed. GSSAPI derives the broker SPN from this host, and MSK IAM
+/// signs this host/port into the OAuth payload.
+#[tokio::test]
+async fn factory_receives_successful_bootstrap_endpoint_not_first_configured() {
+    use async_trait::async_trait;
+    use kafka_backup_core::kafka::{
+        SaslMechanismPlugin, SaslMechanismPluginFactory, SaslMechanismPluginHandle, SaslPluginError,
+    };
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    struct StubPlugin;
+    #[async_trait]
+    impl SaslMechanismPlugin for StubPlugin {
+        fn mechanism_name(&self) -> &str {
+            "OAUTHBEARER"
+        }
+        async fn initial_payload(&self) -> Result<Vec<u8>, SaslPluginError> {
+            Ok(b"n,a=test-user,\x01auth=Bearer stub\x01\x01".to_vec())
+        }
+    }
+
+    #[derive(Debug)]
+    struct CapturingFactory {
+        calls: Arc<Mutex<Vec<(String, u16)>>>,
+    }
+
+    impl SaslMechanismPluginFactory for CapturingFactory {
+        fn mechanism_name(&self) -> &str {
+            "OAUTHBEARER"
+        }
+        fn build(
+            &self,
+            host: &str,
+            port: u16,
+        ) -> Result<SaslMechanismPluginHandle, SaslPluginError> {
+            self.calls.lock().unwrap().push((host.to_string(), port));
+            Ok(Arc::new(StubPlugin))
+        }
+    }
+
+    let mock = MockKafkaBroker::start(vec![
+        Exchange::HandshakeSuccess,
+        Exchange::AuthenticateSuccess {
+            auth_bytes: vec![],
+            session_lifetime_ms: 0,
+        },
+    ])
+    .await;
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(CapturingFactory {
+        calls: calls.clone(),
+    });
+    let dead_first_bootstrap = "127.0.0.1:1".to_string();
+
+    let config = KafkaConfig {
+        bootstrap_servers: vec![dead_first_bootstrap.clone(), mock.bootstrap()],
+        security: SecurityConfig {
+            security_protocol: SecurityProtocol::SaslPlaintext,
+            sasl_mechanism_plugin_factory: Some(factory),
+            ..Default::default()
+        },
+        topics: TopicSelection::default(),
+        connection: Default::default(),
+    };
+    let client = KafkaClient::new(config);
+    client
+        .connect()
+        .await
+        .expect("connect should skip dead bootstrap and authenticate to mock");
+
+    let observed = calls.lock().unwrap().clone();
+    assert_eq!(observed.len(), 1);
+    let (host, port) = &observed[0];
+    assert_eq!(
+        format!("{host}:{port}"),
+        mock.bootstrap(),
+        "factory must receive the successfully connected bootstrap endpoint, not {dead_first_bootstrap}"
     );
 
     mock.shutdown().await;


### PR DESCRIPTION
## Summary
- pass the successfully connected broker endpoint into SASL plugin factories instead of always using `bootstrap_servers[0]`
- restore process-global Kerberos `KRB5_*` env vars after GSSAPI credential acquisition, including error paths
- add regression coverage for bootstrap fallback endpoint binding and GSSAPI env restoration

## Verification
- `cargo fmt --all --check`
- `cargo test -p kafka-backup-core --test integration_suite_tests factory_receives -- --nocapture`
- `cargo test -p kafka-backup-cli sasl`
- Docker/Linux MIT krb5: `cargo test -p kafka-backup-core --features gssapi acquire_cred_restores_krb5_environment_even_on_error --lib -- --nocapture`
