### PR TITLE
fix(cli): resolve storage URLs for inspection commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1371,6 +1371,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1379,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/Cargo.toml
+++ b/crates/kafka-backup-cli/Cargo.toml
@@ -46,6 +46,9 @@ uuid.workspace = true
 # Crypto for SHA-256 verification
 sha2.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [features]
 default = []
 # Enables SASL/GSSAPI (Kerberos) authentication. Propagates to

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use kafka_backup_core::storage::{FilesystemBackend, StorageBackend};
 use kafka_backup_core::BackupManifest;
 use tracing::info;
+
+use super::storage_path::backend_from_path;
 
 /// Describe command output format
 pub enum OutputFormat {
@@ -21,7 +22,7 @@ impl OutputFormat {
 }
 
 pub async fn run(path: &str, backup_id: &str, format: &str) -> Result<()> {
-    let storage = FilesystemBackend::new(path.into());
+    let storage = backend_from_path(path)?;
     let output_format = OutputFormat::from_str(format);
 
     info!("Loading backup manifest: {}", backup_id);

--- a/crates/kafka-backup-cli/src/commands/list.rs
+++ b/crates/kafka-backup-cli/src/commands/list.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
-use kafka_backup_core::storage::{FilesystemBackend, StorageBackend};
 use kafka_backup_core::BackupManifest;
 use tracing::info;
 
+use super::storage_path::backend_from_path;
+
 pub async fn run(path: &str, backup_id: Option<&str>) -> Result<()> {
-    let storage = FilesystemBackend::new(path.into());
+    let storage = backend_from_path(path)?;
 
     match backup_id {
         Some(id) => {

--- a/crates/kafka-backup-cli/src/commands/mod.rs
+++ b/crates/kafka-backup-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod security_args;
 pub mod snapshot_groups;
 pub mod status;
 pub mod status_watch;
+pub mod storage_path;
 pub mod three_phase;
 pub mod validate;
 pub mod validate_restore;

--- a/crates/kafka-backup-cli/src/commands/storage_path.rs
+++ b/crates/kafka-backup-cli/src/commands/storage_path.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use kafka_backup_core::storage::{
+    create_backend, FilesystemBackend, StorageBackend, StorageBackendConfig,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub fn backend_from_path(path: &str) -> Result<Arc<dyn StorageBackend>> {
+    if path.contains("://") {
+        let config = StorageBackendConfig::from_url(path)?;
+        return Ok(create_backend(&config)?);
+    }
+
+    Ok(Arc::new(FilesystemBackend::new(PathBuf::from(path))))
+}

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use kafka_backup_core::segment::SegmentReader;
-use kafka_backup_core::storage::{FilesystemBackend, StorageBackend};
 use kafka_backup_core::BackupManifest;
-use std::path::PathBuf;
 use tracing::{error, info, warn};
+
+use super::storage_path::backend_from_path;
 
 #[derive(Debug, Default)]
 struct ValidationReport {
+    manifest_loaded: bool,
     segments_checked: usize,
     segments_valid: usize,
     segments_missing: usize,
@@ -17,7 +18,7 @@ struct ValidationReport {
 
 impl ValidationReport {
     fn is_valid(&self) -> bool {
-        self.segments_missing == 0 && self.segments_corrupted == 0
+        self.manifest_loaded && self.segments_missing == 0 && self.segments_corrupted == 0
     }
 
     fn print(&self) {
@@ -47,7 +48,7 @@ impl ValidationReport {
 pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
     info!("Validating backup: {} (deep={})", backup_id, deep);
 
-    let storage = FilesystemBackend::new(PathBuf::from(path));
+    let storage = backend_from_path(path)?;
     let mut report = ValidationReport::default();
 
     // Load manifest
@@ -60,7 +61,7 @@ pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
                 .issues
                 .push(format!("Manifest not found: {}", manifest_key));
             report.print();
-            return Ok(());
+            std::process::exit(1);
         }
     };
 
@@ -70,9 +71,10 @@ pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
             error!("Failed to parse manifest: {}", e);
             report.issues.push(format!("Manifest parse error: {}", e));
             report.print();
-            return Ok(());
+            std::process::exit(1);
         }
     };
+    report.manifest_loaded = true;
 
     println!("Validating backup: {}", manifest.backup_id);
     println!(

--- a/crates/kafka-backup-cli/tests/issue_100_storage_paths.rs
+++ b/crates/kafka-backup-cli/tests/issue_100_storage_paths.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn create_manifest(root: &Path, backup_id: &str) {
+    let backup_dir = root.join(backup_id);
+    fs::create_dir_all(&backup_dir).unwrap();
+
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": 1_700_000_000_000_i64,
+        "source_cluster_id": "test-cluster",
+        "source_brokers": ["localhost:9092"],
+        "compression": "zstd",
+        "topics": []
+    });
+
+    fs::write(
+        backup_dir.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+fn run_kafka_backup(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn list_all_accepts_file_url_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    create_manifest(temp_dir.path(), "issue-100");
+    let path = file_url(temp_dir.path());
+
+    let output = run_kafka_backup(&["list", "--path", &path]);
+    let text = output_text(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("Available backups:"), "{text}");
+    assert!(text.contains("  - issue-100"), "{text}");
+}
+
+#[test]
+fn list_specific_backup_accepts_file_url_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    create_manifest(temp_dir.path(), "issue-100");
+    let path = file_url(temp_dir.path());
+
+    let output = run_kafka_backup(&["list", "--path", &path, "--backup-id", "issue-100"]);
+    let text = output_text(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("Backup ID: issue-100"), "{text}");
+}
+
+#[test]
+fn describe_accepts_file_url_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    create_manifest(temp_dir.path(), "issue-100");
+    let path = file_url(temp_dir.path());
+
+    let output = run_kafka_backup(&[
+        "describe",
+        "--path",
+        &path,
+        "--backup-id",
+        "issue-100",
+        "--format",
+        "json",
+    ]);
+    let text = output_text(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("\"backup_id\": \"issue-100\""), "{text}");
+}
+
+#[test]
+fn validate_accepts_file_url_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    create_manifest(temp_dir.path(), "issue-100");
+    let path = file_url(temp_dir.path());
+
+    let output = run_kafka_backup(&["validate", "--path", &path, "--backup-id", "issue-100"]);
+    let text = output_text(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("Validating backup: issue-100"), "{text}");
+    assert!(text.contains("Created:"), "{text}");
+    assert!(!text.contains("Manifest not found"), "{text}");
+    assert!(text.contains("Result: VALID"), "{text}");
+}
+
+#[test]
+fn validate_missing_manifest_returns_invalid_and_nonzero() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = file_url(temp_dir.path());
+
+    let output = run_kafka_backup(&["validate", "--path", &path, "--backup-id", "missing"]);
+    let text = output_text(&output);
+
+    assert!(!output.status.success(), "{text}");
+    assert!(
+        text.contains("Manifest not found: missing/manifest.json"),
+        "{text}"
+    );
+    assert!(text.contains("Result: INVALID"), "{text}");
+}

--- a/crates/kafka-backup-core/src/storage/config.rs
+++ b/crates/kafka-backup-core/src/storage/config.rs
@@ -123,6 +123,12 @@ impl StorageBackendConfig {
         match parsed.scheme() {
             "s3" | "s3a" => {
                 let bucket = parsed.host_str().unwrap_or_default().to_string();
+                let prefix = parsed.path().trim_matches('/');
+                let prefix = if prefix.is_empty() {
+                    None
+                } else {
+                    Some(prefix.to_string())
+                };
                 let region = parsed
                     .query_pairs()
                     .find(|(k, _)| k == "region")
@@ -143,7 +149,7 @@ impl StorageBackendConfig {
                     endpoint,
                     access_key: std::env::var("AWS_ACCESS_KEY_ID").ok(),
                     secret_key: std::env::var("AWS_SECRET_ACCESS_KEY").ok(),
-                    prefix: None,
+                    prefix,
                     path_style,
                     allow_http: false,
                 })
@@ -218,6 +224,26 @@ mod tests {
             StorageBackendConfig::S3 { bucket, region, .. } => {
                 assert_eq!(bucket, "my-bucket");
                 assert_eq!(region, Some("us-west-2".to_string()));
+            }
+            _ => panic!("Expected S3 config"),
+        }
+    }
+
+    #[test]
+    fn test_s3_url_parsing_preserves_path_prefix() {
+        let config =
+            StorageBackendConfig::from_url("s3://my-bucket/backups/prod/?region=us-west-2")
+                .unwrap();
+        match config {
+            StorageBackendConfig::S3 {
+                bucket,
+                region,
+                prefix,
+                ..
+            } => {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(region, Some("us-west-2".to_string()));
+                assert_eq!(prefix.as_deref(), Some("backups/prod"));
             }
             _ => panic!("Expected S3 config"),
         }


### PR DESCRIPTION
## Summary
- Fixes #100 by routing `list`, `describe`, and `validate` storage paths through the storage backend factory instead of always constructing a filesystem backend.
- Preserves the path component of `s3://bucket/prefix/` as the S3 backend prefix.
- Fixes #101 by making `validate` report `Result: INVALID` and exit non-zero when the manifest cannot be loaded or parsed.
- Bumps the workspace release version to `0.15.2`.

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p kafka-backup-cli --test issue_100_storage_paths`
- `cargo test --workspace`

Fixes #100
Fixes #101