### PR TITLE
fix(kafka): harden restore and coordinator routing for MSK migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.3"
+version = "0.15.4"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -679,8 +679,9 @@ pub struct RestoreOptions {
     /// Broker-side produce timeout in milliseconds (default: 30 000).
     ///
     /// The broker waits up to this duration for the required acks before
-    /// returning REQUEST_TIMED_OUT. The client-side socket timeout
-    /// (RESPONSE_TIMEOUT_SECS = 10 s) is a hard ceiling regardless.
+    /// returning REQUEST_TIMED_OUT. The client-side socket timeout must stay
+    /// above this value so slow replicated writes can return broker errors
+    /// instead of being misclassified as transport failures.
     #[serde(default = "default_produce_timeout_ms")]
     pub produce_timeout_ms: i32,
 

--- a/crates/kafka-backup-core/src/kafka/admin.rs
+++ b/crates/kafka-backup-core/src/kafka/admin.rs
@@ -1,11 +1,20 @@
-//! Kafka Admin API implementation (CreateTopics, DeleteRecords, etc.)
+//! Kafka Admin API implementation (CreateTopics, DeleteRecords, DescribeConfigs,
+//! IncrementalAlterConfigs, etc.)
 
 use kafka_protocol::messages::{
     create_topics_request::{CreatableTopic, CreateTopicsRequest},
     delete_records_request::{DeleteRecordsPartition, DeleteRecordsTopic},
-    ApiKey, CreateTopicsResponse, DeleteRecordsRequest, DeleteRecordsResponse, TopicName,
+    describe_configs_request::{
+        DescribeConfigsRequest, DescribeConfigsResource as DescribeConfigsRequestResource,
+    },
+    incremental_alter_configs_request::{
+        AlterConfigsResource, AlterableConfig, IncrementalAlterConfigsRequest,
+    },
+    ApiKey, CreateTopicsResponse, DeleteRecordsRequest, DeleteRecordsResponse,
+    DescribeConfigsResponse, IncrementalAlterConfigsResponse, TopicName,
 };
 use kafka_protocol::protocol::StrBytes;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
 use super::KafkaClient;
@@ -32,6 +41,87 @@ pub struct CreateTopicResult {
     pub error_code: i16,
     /// Error message (if any)
     pub error_message: Option<String>,
+}
+
+/// Kafka config-resource type values used by DescribeConfigs and
+/// IncrementalAlterConfigs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConfigResourceType {
+    Topic,
+    Broker,
+}
+
+impl ConfigResourceType {
+    fn wire(self) -> i8 {
+        match self {
+            Self::Topic => 2,
+            Self::Broker => 4,
+        }
+    }
+
+    fn from_wire(value: i8) -> Option<Self> {
+        match value {
+            2 => Some(Self::Topic),
+            4 => Some(Self::Broker),
+            _ => None,
+        }
+    }
+}
+
+/// One configuration entry returned by DescribeConfigs.
+#[derive(Debug, Clone)]
+pub struct ConfigEntry {
+    pub name: String,
+    pub value: Option<String>,
+    pub read_only: bool,
+    pub config_source: i8,
+    pub is_default: bool,
+    pub is_sensitive: bool,
+}
+
+impl ConfigEntry {
+    /// True for explicit topic-level configuration values. Kafka's
+    /// ConfigSource value `1` is TOPIC_CONFIG.
+    pub fn is_topic_override(&self) -> bool {
+        self.config_source == 1
+    }
+}
+
+/// One incremental config operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigOp {
+    Set { name: String, value: String },
+    Delete { name: String },
+}
+
+impl ConfigOp {
+    fn name(&self) -> &str {
+        match self {
+            Self::Set { name, .. } | Self::Delete { name } => name,
+        }
+    }
+
+    fn operation(&self) -> i8 {
+        match self {
+            Self::Set { .. } => 0,
+            Self::Delete { .. } => 1,
+        }
+    }
+
+    fn value(&self) -> Option<StrBytes> {
+        match self {
+            Self::Set { value, .. } => Some(StrBytes::from_string(value.clone())),
+            Self::Delete { .. } => None,
+        }
+    }
+}
+
+/// Incremental config changes for one resource.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigChange {
+    pub resource_type: ConfigResourceType,
+    pub resource_name: String,
+    pub ops: Vec<ConfigOp>,
 }
 
 impl CreateTopicResult {
@@ -201,6 +291,137 @@ pub async fn delete_records(
                 );
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Describe configuration entries for the requested resources.
+pub async fn describe_configs(
+    client: &KafkaClient,
+    resources: &[(ConfigResourceType, String)],
+) -> Result<HashMap<(ConfigResourceType, String), Vec<ConfigEntry>>> {
+    if resources.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let request_resources: Vec<DescribeConfigsRequestResource> = resources
+        .iter()
+        .map(|(resource_type, resource_name)| {
+            DescribeConfigsRequestResource::default()
+                .with_resource_type(resource_type.wire())
+                .with_resource_name(StrBytes::from_string(resource_name.clone()))
+                .with_configuration_keys(None)
+        })
+        .collect();
+
+    let request = DescribeConfigsRequest::default()
+        .with_resources(request_resources)
+        .with_include_synonyms(false)
+        .with_include_documentation(false);
+
+    let response: DescribeConfigsResponse = client
+        .send_request(ApiKey::DescribeConfigs, request)
+        .await?;
+
+    let mut out = HashMap::new();
+    for result in response.results {
+        if result.error_code != 0 {
+            let msg = result
+                .error_message
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "<no-message>".to_string());
+            return Err(KafkaError::Protocol(format!(
+                "DescribeConfigs failed for {}/{}: error_code={} message={}",
+                result.resource_type, result.resource_name, result.error_code, msg
+            ))
+            .into());
+        }
+
+        let Some(resource_type) = ConfigResourceType::from_wire(result.resource_type) else {
+            continue;
+        };
+        let resource_name = result.resource_name.to_string();
+        let entries = result
+            .configs
+            .into_iter()
+            .map(|entry| ConfigEntry {
+                name: entry.name.to_string(),
+                value: entry.value.map(|v| v.to_string()),
+                read_only: entry.read_only,
+                config_source: entry.config_source,
+                is_default: entry.config_source == 5,
+                is_sensitive: entry.is_sensitive,
+            })
+            .collect();
+        out.insert((resource_type, resource_name), entries);
+    }
+
+    Ok(out)
+}
+
+/// Apply incremental config changes. Returns an error if any resource fails.
+pub async fn incremental_alter_configs(
+    client: &KafkaClient,
+    changes: &[ConfigChange],
+) -> Result<()> {
+    let resources: Vec<AlterConfigsResource> = changes
+        .iter()
+        .filter(|change| !change.ops.is_empty())
+        .map(|change| {
+            let configs: Vec<AlterableConfig> = change
+                .ops
+                .iter()
+                .map(|op| {
+                    AlterableConfig::default()
+                        .with_name(StrBytes::from_string(op.name().to_string()))
+                        .with_config_operation(op.operation())
+                        .with_value(op.value())
+                })
+                .collect();
+            AlterConfigsResource::default()
+                .with_resource_type(change.resource_type.wire())
+                .with_resource_name(StrBytes::from_string(change.resource_name.clone()))
+                .with_configs(configs)
+        })
+        .collect();
+
+    if resources.is_empty() {
+        return Ok(());
+    }
+
+    let request = IncrementalAlterConfigsRequest::default()
+        .with_resources(resources)
+        .with_validate_only(false);
+
+    let response: IncrementalAlterConfigsResponse = client
+        .send_request(ApiKey::IncrementalAlterConfigs, request)
+        .await?;
+
+    let failures: Vec<String> = response
+        .responses
+        .into_iter()
+        .filter(|r| r.error_code != 0)
+        .map(|r| {
+            let msg = r
+                .error_message
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "<no-message>".to_string());
+            format!(
+                "{}/{}: error_code={} message={}",
+                r.resource_type, r.resource_name, r.error_code, msg
+            )
+        })
+        .collect();
+
+    if !failures.is_empty() {
+        return Err(KafkaError::Protocol(format!(
+            "IncrementalAlterConfigs failed: {}",
+            failures.join("; ")
+        ))
+        .into());
     }
 
     Ok(())

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -22,9 +22,10 @@ use tracing::{debug, trace, warn};
 pub const WRITE_TIMEOUT_SECS: u64 = 10;
 
 /// Client-side deadline for receiving a broker response.
-/// A healthy broker with acks=1 responds in <100ms; 10s is very generous.
-/// Must be kept larger than produce_timeout_ms to avoid false positives.
-pub const RESPONSE_TIMEOUT_SECS: u64 = 10;
+/// Restore produces default to acks=all with a 30s broker-side timeout, so this
+/// must stay above that ceiling or slow replicated writes are misclassified as
+/// connection failures while the broker may still be processing the request.
+pub const RESPONSE_TIMEOUT_SECS: u64 = 60;
 
 use crate::config::{KafkaConfig, SaslMechanism, SecurityProtocol};
 use crate::error::KafkaError;
@@ -597,6 +598,10 @@ impl KafkaClient {
             ApiKey::OffsetCommit => 5,
             ApiKey::ListGroups => 2,
             ApiKey::DeleteRecords => 1,
+            ApiKey::DescribeConfigs => 1,
+            ApiKey::IncrementalAlterConfigs => 1,
+            ApiKey::DescribeAcls => 1,
+            ApiKey::CreateAcls => 1,
             _ => 0,
         }
     }

--- a/crates/kafka-backup-core/src/kafka/consumer_groups.rs
+++ b/crates/kafka-backup-core/src/kafka/consumer_groups.rs
@@ -8,9 +8,10 @@
 //! - ListOffsetsForTimes: Find offsets by timestamp
 
 use kafka_protocol::messages::{
-    ApiKey, DescribeGroupsRequest, DescribeGroupsResponse, GroupId, ListGroupsRequest,
-    ListGroupsResponse, ListOffsetsRequest, ListOffsetsResponse, OffsetCommitRequest,
-    OffsetCommitResponse, OffsetFetchRequest, OffsetFetchResponse, TopicName,
+    ApiKey, DescribeGroupsRequest, DescribeGroupsResponse, FindCoordinatorRequest,
+    FindCoordinatorResponse, GroupId, ListGroupsRequest, ListGroupsResponse, ListOffsetsRequest,
+    ListOffsetsResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetFetchRequest,
+    OffsetFetchResponse, TopicName,
 };
 use kafka_protocol::protocol::StrBytes;
 use std::collections::HashMap;
@@ -89,6 +90,17 @@ pub struct TimestampOffset {
     pub timestamp: i64,
     /// Error code (0 = success)
     pub error_code: i16,
+}
+
+/// Broker that coordinates a consumer group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupCoordinator {
+    /// Coordinator broker node ID
+    pub node_id: i32,
+    /// Coordinator broker host
+    pub host: String,
+    /// Coordinator broker port
+    pub port: i32,
 }
 
 /// List all consumer groups on the cluster
@@ -230,6 +242,107 @@ pub async fn fetch_offsets(
     Ok(offsets)
 }
 
+/// Find the broker coordinating a consumer group.
+pub async fn find_group_coordinator(
+    client: &KafkaClient,
+    group_id: &str,
+) -> Result<GroupCoordinator> {
+    let request = FindCoordinatorRequest::default()
+        .with_key(StrBytes::from_string(group_id.to_string()))
+        .with_key_type(0);
+
+    let response: FindCoordinatorResponse = client
+        .send_request(ApiKey::FindCoordinator, request)
+        .await?;
+
+    group_coordinator_from_response(group_id, response)
+}
+
+fn group_coordinator_from_response(
+    group_id: &str,
+    response: FindCoordinatorResponse,
+) -> Result<GroupCoordinator> {
+    if response.coordinators.is_empty() {
+        if response.error_code != 0 {
+            return Err(KafkaError::BrokerError {
+                code: response.error_code,
+                message: response
+                    .error_message
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| {
+                        format!(
+                            "FindCoordinator failed for group {group_id} with error code {}",
+                            response.error_code
+                        )
+                    }),
+            }
+            .into());
+        }
+        return Ok(GroupCoordinator {
+            node_id: response.node_id.0,
+            host: response.host.to_string(),
+            port: response.port,
+        });
+    }
+
+    let mut fallback = None;
+    for coordinator in response.coordinators {
+        let is_match = coordinator.key.as_str() == group_id;
+        if fallback.is_none() {
+            fallback = Some(coordinator.clone());
+        }
+        if !is_match {
+            continue;
+        }
+        if coordinator.error_code != 0 {
+            return Err(KafkaError::BrokerError {
+                code: coordinator.error_code,
+                message: coordinator
+                    .error_message
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| {
+                        format!(
+                            "FindCoordinator failed for group {group_id} with error code {}",
+                            coordinator.error_code
+                        )
+                    }),
+            }
+            .into());
+        }
+        return Ok(GroupCoordinator {
+            node_id: coordinator.node_id.0,
+            host: coordinator.host.to_string(),
+            port: coordinator.port,
+        });
+    }
+
+    let coordinator = fallback.ok_or_else(|| {
+        KafkaError::Protocol(format!(
+            "FindCoordinator returned no coordinator for group {group_id}"
+        ))
+    })?;
+    if coordinator.error_code != 0 {
+        return Err(KafkaError::BrokerError {
+            code: coordinator.error_code,
+            message: coordinator
+                .error_message
+                .map(|m| m.to_string())
+                .unwrap_or_else(|| {
+                    format!(
+                        "FindCoordinator failed for group {group_id} with error code {}",
+                        coordinator.error_code
+                    )
+                }),
+        }
+        .into());
+    }
+    Ok(GroupCoordinator {
+        node_id: coordinator.node_id.0,
+        host: coordinator.host.to_string(),
+        port: coordinator.port,
+    })
+}
+
 /// Commit offsets for a consumer group
 pub async fn commit_offsets(
     client: &KafkaClient,
@@ -368,10 +481,35 @@ fn parse_member_assignment(bytes: &[u8]) -> HashMap<String, Vec<i32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kafka_protocol::messages::find_coordinator_response::Coordinator;
+    use kafka_protocol::messages::{BrokerId, FindCoordinatorResponse};
+    use kafka_protocol::protocol::StrBytes;
 
     #[test]
     fn test_parse_empty_member_assignment() {
         let result = parse_member_assignment(&[]);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn group_coordinator_from_response_picks_matching_modern_response() {
+        let response = FindCoordinatorResponse::default().with_coordinators(vec![
+            Coordinator::default()
+                .with_key(StrBytes::from_static_str("other"))
+                .with_node_id(BrokerId(1))
+                .with_host(StrBytes::from_static_str("broker-1"))
+                .with_port(9092),
+            Coordinator::default()
+                .with_key(StrBytes::from_static_str("analytics"))
+                .with_node_id(BrokerId(2))
+                .with_host(StrBytes::from_static_str("broker-2"))
+                .with_port(9093),
+        ]);
+
+        let coordinator = group_coordinator_from_response("analytics", response).unwrap();
+
+        assert_eq!(coordinator.node_id, 2);
+        assert_eq!(coordinator.host, "broker-2");
+        assert_eq!(coordinator.port, 9093);
     }
 }

--- a/crates/kafka-backup-core/src/kafka/mod.rs
+++ b/crates/kafka-backup-core/src/kafka/mod.rs
@@ -11,14 +11,18 @@ pub mod sasl;
 mod scram;
 pub mod tls;
 
-pub use admin::{create_topics, delete_records, CreateTopicResult, TopicToCreate};
+pub use admin::{
+    create_topics, delete_records, describe_configs, incremental_alter_configs, ConfigChange,
+    ConfigEntry, ConfigOp, ConfigResourceType, CreateTopicResult, TopicToCreate,
+};
 pub use client::{KafkaClient, RESPONSE_TIMEOUT_SECS, WRITE_TIMEOUT_SECS};
 pub use consumer_groups::{
-    commit_offsets, describe_groups, fetch_offsets, list_groups, offsets_for_times,
-    CommittedOffset, ConsumerGroup, ConsumerGroupDescription, ConsumerGroupMember, TimestampOffset,
+    commit_offsets, describe_groups, fetch_offsets, find_group_coordinator, list_groups,
+    offsets_for_times, CommittedOffset, ConsumerGroup, ConsumerGroupDescription,
+    ConsumerGroupMember, GroupCoordinator, TimestampOffset,
 };
 pub use fetch::FetchResponse;
-pub use metadata::{BrokerMetadata, PartitionMetadata, TopicMetadata};
+pub use metadata::{fetch_metadata, BrokerMetadata, PartitionMetadata, TopicMetadata};
 pub use partition_router::PartitionLeaderRouter;
 pub use produce::ProduceResponse;
 pub use sasl::{

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -20,6 +20,11 @@ use super::metadata::{BrokerMetadata, PartitionMetadata, TopicMetadata};
 use super::{FetchResponse, KafkaClient, ProduceResponse};
 use crate::manifest::BackupRecord;
 
+const COORDINATOR_LOAD_IN_PROGRESS: i16 = 14;
+const COORDINATOR_NOT_AVAILABLE: i16 = 15;
+const NOT_COORDINATOR: i16 = 16;
+const MAX_COORDINATOR_RETRIES: u32 = 12;
+
 /// Routes Kafka requests to the correct partition leader broker.
 ///
 /// This router maintains:
@@ -477,74 +482,48 @@ impl PartitionLeaderRouter {
         timeout_ms: i32,
     ) -> Result<ProduceResponse> {
         const MAX_CONNECTION_RETRIES: u32 = 5;
+        const MAX_LEADER_RETRIES: u32 = 20;
 
-        // First attempt — no clone yet
-        let err = match self
-            .produce_internal(topic, partition, &records, acks, timeout_ms)
-            .await
-        {
-            Ok(response) => return Ok(response),
-            Err(e) if is_not_leader_error(&e) => {
-                warn!(
-                    "NOT_LEADER_FOR_PARTITION for {}/{}, refreshing metadata and retrying",
-                    topic, partition
-                );
-                self.refresh_partition_leader(topic, partition).await?;
-                self.clear_connection_cache().await;
-                match self
-                    .produce_internal(topic, partition, &records, acks, timeout_ms)
-                    .await
-                {
-                    Ok(response) => return Ok(response),
-                    Err(e) if !is_connection_error(&e) => return Err(e),
-                    Err(e) => {
-                        warn!(
-                            "Connection error after leader refresh for {}/{}: {}",
-                            topic, partition, e
-                        );
-                        self.clear_connection_cache().await;
-                        e
-                    }
-                }
-            }
-            Err(e) if !is_connection_error(&e) => return Err(e),
-            Err(e) => {
-                warn!(
-                    "Connection error for {}/{} (attempt 0), will retry: {}",
-                    topic, partition, e
-                );
-                self.clear_connection_cache().await;
-                e
-            }
-        };
+        let mut connection_attempts = 0;
+        let mut leader_attempts = 0;
 
-        // Connection-error retry loop with linear back-off (500ms, 1s, 1.5s, 2s, 2.5s)
-        let mut last_err = err;
-        for attempt in 1..=MAX_CONNECTION_RETRIES {
-            let backoff = Duration::from_millis(500 * attempt as u64);
-            warn!(
-                "Retrying produce for {}/{} (attempt {}/{}) after {:?}: {}",
-                topic, partition, attempt, MAX_CONNECTION_RETRIES, backoff, last_err
-            );
-            tokio::time::sleep(backoff).await;
-
+        loop {
             match self
                 .produce_internal(topic, partition, &records, acks, timeout_ms)
                 .await
             {
                 Ok(response) => return Ok(response),
-                Err(e) if is_connection_error(&e) => {
+                Err(e) if is_not_leader_error(&e) && leader_attempts < MAX_LEADER_RETRIES => {
+                    leader_attempts += 1;
+                    let backoff = Duration::from_millis((250 * leader_attempts as u64).min(2_000));
+                    warn!(
+                        "NOT_LEADER_FOR_PARTITION for {}/{} (attempt {}/{}), refreshing metadata after {:?}: {}",
+                        topic,
+                        partition,
+                        leader_attempts,
+                        MAX_LEADER_RETRIES,
+                        backoff,
+                        e
+                    );
+                    self.refresh_partition_leader(topic, partition).await?;
                     self.clear_connection_cache().await;
-                    last_err = e;
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e)
+                    if is_connection_error(&e) && connection_attempts < MAX_CONNECTION_RETRIES =>
+                {
+                    connection_attempts += 1;
+                    let backoff = Duration::from_millis(500 * connection_attempts as u64);
+                    warn!(
+                        "Connection error for {}/{} (attempt {}/{}), retrying after {:?}: {}",
+                        topic, partition, connection_attempts, MAX_CONNECTION_RETRIES, backoff, e
+                    );
+                    self.clear_connection_cache().await;
+                    tokio::time::sleep(backoff).await;
                 }
                 Err(e) => return Err(e),
             }
         }
-
-        Err(crate::Error::Kafka(KafkaError::Protocol(format!(
-            "Produce failed for {}/{} after {} connection retries: {}",
-            topic, partition, MAX_CONNECTION_RETRIES, last_err
-        ))))
     }
 
     /// Internal produce implementation — borrows records to avoid unnecessary cloning.
@@ -728,6 +707,84 @@ impl PartitionLeaderRouter {
         Ok(all_offsets)
     }
 
+    /// Commit offsets for a consumer group through that group's coordinator.
+    ///
+    /// `OffsetCommit` must be sent to the broker that coordinates the group. A
+    /// bootstrap broker may not coordinate the group, and committing there can
+    /// return coordinator errors in multi-broker KRaft clusters.
+    pub async fn commit_group_offsets(
+        &self,
+        group_id: &str,
+        offsets: &[(String, i32, i64, Option<String>)],
+    ) -> Result<Vec<(String, i32, i16)>> {
+        for attempt in 1..=MAX_COORDINATOR_RETRIES {
+            let coordinator = match super::consumer_groups::find_group_coordinator(
+                &self.bootstrap_client,
+                group_id,
+            )
+            .await
+            {
+                Ok(coordinator) => coordinator,
+                Err(e)
+                    if is_transient_coordinator_error(&e) && attempt < MAX_COORDINATOR_RETRIES =>
+                {
+                    let backoff = coordinator_backoff(attempt);
+                    warn!(
+                            "FindCoordinator for group {} returned transient error on attempt {}/{}; retrying after {:?}: {}",
+                            group_id, attempt, MAX_COORDINATOR_RETRIES, backoff, e
+                        );
+                    tokio::time::sleep(backoff).await;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+            {
+                let mut brokers = self.broker_metadata.write().await;
+                brokers
+                    .entry(coordinator.node_id)
+                    .or_insert_with(|| BrokerMetadata {
+                        node_id: coordinator.node_id,
+                        host: coordinator.host.clone(),
+                        port: coordinator.port,
+                        rack: None,
+                    });
+            }
+
+            let client = match self.get_broker_connection(coordinator.node_id).await {
+                Ok(client) => client,
+                Err(e) => {
+                    warn!(
+                        "Failed to connect to coordinator broker {} for group {}: {}; refreshing metadata",
+                        coordinator.node_id, group_id, e
+                    );
+                    self.refresh_metadata().await?;
+                    self.get_broker_connection(coordinator.node_id).await?
+                }
+            };
+
+            let results =
+                super::consumer_groups::commit_offsets(&client, group_id, offsets).await?;
+            if has_transient_coordinator_commit_error(&results) && attempt < MAX_COORDINATOR_RETRIES
+            {
+                let backoff = coordinator_backoff(attempt);
+                warn!(
+                    "OffsetCommit for group {} returned transient coordinator error on attempt {}/{}; retrying after {:?}",
+                    group_id, attempt, MAX_COORDINATOR_RETRIES, backoff
+                );
+                self.refresh_metadata().await?;
+                tokio::time::sleep(backoff).await;
+                continue;
+            }
+
+            return Ok(results);
+        }
+
+        Err(KafkaError::Timeout(format!(
+            "coordinator for group {group_id} was not ready after {MAX_COORDINATOR_RETRIES} attempts"
+        ))
+        .into())
+    }
+
     /// Delete records from a topic by advancing the log-start-offset to `before_offset`.
     ///
     /// Records with offset < `before_offset` become inaccessible. This empties a topic
@@ -771,6 +828,29 @@ fn is_not_leader_error(error: &crate::Error) -> bool {
     }
 }
 
+fn is_transient_coordinator_error(error: &crate::Error) -> bool {
+    matches!(
+        error,
+        crate::Error::Kafka(KafkaError::BrokerError {
+            code: COORDINATOR_LOAD_IN_PROGRESS | COORDINATOR_NOT_AVAILABLE | NOT_COORDINATOR,
+            ..
+        })
+    )
+}
+
+fn has_transient_coordinator_commit_error(results: &[(String, i32, i16)]) -> bool {
+    results.iter().any(|(_, _, code)| {
+        matches!(
+            *code,
+            COORDINATOR_LOAD_IN_PROGRESS | COORDINATOR_NOT_AVAILABLE | NOT_COORDINATOR
+        )
+    })
+}
+
+fn coordinator_backoff(attempt: u32) -> Duration {
+    Duration::from_millis((250 * attempt as u64).min(2_000))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,5 +868,38 @@ mod tests {
             message: "Some other error".to_string(),
         });
         assert!(!is_not_leader_error(&other_error));
+    }
+
+    #[test]
+    fn transient_coordinator_errors_are_retryable() {
+        for code in [
+            COORDINATOR_LOAD_IN_PROGRESS,
+            COORDINATOR_NOT_AVAILABLE,
+            NOT_COORDINATOR,
+        ] {
+            let error = crate::Error::Kafka(KafkaError::BrokerError {
+                code,
+                message: "coordinator transient".to_string(),
+            });
+            assert!(is_transient_coordinator_error(&error));
+        }
+
+        let fatal = crate::Error::Kafka(KafkaError::BrokerError {
+            code: 30,
+            message: "group authorization failed".to_string(),
+        });
+        assert!(!is_transient_coordinator_error(&fatal));
+    }
+
+    #[test]
+    fn transient_commit_partition_errors_are_retryable() {
+        let results = vec![
+            ("orders".to_string(), 0, 0),
+            ("orders".to_string(), 1, COORDINATOR_NOT_AVAILABLE),
+        ];
+        assert!(has_transient_coordinator_commit_error(&results));
+
+        let fatal = vec![("orders".to_string(), 0, 30)];
+        assert!(!has_transient_coordinator_commit_error(&fatal));
     }
 }

--- a/crates/kafka-backup-core/src/kafka/produce.rs
+++ b/crates/kafka-backup-core/src/kafka/produce.rs
@@ -145,7 +145,7 @@ pub async fn produce(
 
         let options = RecordEncodeOptions {
             version: 2,
-            compression: Compression::None,
+            compression: Compression::Zstd,
         };
 
         let mut records_buf = BytesMut::new();

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -600,15 +600,19 @@ impl OffsetMapping {
     ) {
         let key = format!("{}/{}", topic, partition);
         if let Some(entry) = self.entries.get_mut(&key) {
-            if source_offset < entry.source_first_offset {
+            if source_offset <= entry.source_first_offset {
                 entry.source_first_offset = source_offset;
-                entry.target_first_offset = target_offset;
-                entry.first_timestamp = timestamp;
+                if target_offset.is_some() || entry.target_first_offset.is_none() {
+                    entry.target_first_offset = target_offset;
+                }
+                entry.first_timestamp = timestamp.min(entry.first_timestamp);
             }
-            if source_offset > entry.source_last_offset {
+            if source_offset >= entry.source_last_offset {
                 entry.source_last_offset = source_offset;
-                entry.target_last_offset = target_offset;
-                entry.last_timestamp = timestamp;
+                if target_offset.is_some() || entry.target_last_offset.is_none() {
+                    entry.target_last_offset = target_offset;
+                }
+                entry.last_timestamp = timestamp.max(entry.last_timestamp);
             }
         } else {
             self.add(topic, partition, source_offset, target_offset, timestamp);
@@ -1072,5 +1076,98 @@ mod tests {
         assert_eq!(pair.source_offset, 100);
         assert_eq!(pair.target_offset, 5100);
         assert_eq!(pair.timestamp, 1700000000000);
+    }
+
+    #[test]
+    fn update_range_none_then_some_preserves_targets() {
+        // Reproduces the RestoreEngine pattern: a pre-produce loop calls
+        // update_range with None targets for all records in a segment, then
+        // the post-produce add_detailed calls update_range with Some targets.
+        // Before the fix, the pre-produce loop advanced source_last_offset so
+        // that post-produce calls never matched the > boundary, leaving
+        // target_first_offset and target_last_offset as None.
+        let mut m = OffsetMapping::new();
+
+        // Pre-produce: register source range without target offsets
+        for src in 0..1000i64 {
+            m.update_range("t", 0, src, None, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(e.source_first_offset, 0);
+        assert_eq!(e.source_last_offset, 999);
+        assert_eq!(e.target_first_offset, None, "no target yet");
+        assert_eq!(e.target_last_offset, None, "no target yet");
+
+        // Post-produce: add_detailed fills in actual target offsets
+        for src in 0..1000i64 {
+            m.add_detailed("t", 0, src, src, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(e.target_first_offset, Some(0), "seed first target");
+        assert_eq!(e.target_last_offset, Some(999), "seed last target");
+    }
+
+    #[test]
+    fn update_range_some_not_overwritten_by_none() {
+        // When a second segment's pre-produce loop calls update_range(None)
+        // for offsets beyond the first segment, it must not overwrite the
+        // Some(target_last) that the first segment's post-produce set.
+        let mut m = OffsetMapping::new();
+
+        // Segment 1 (offsets 0-999): pre-produce then post-produce
+        for src in 0..1000i64 {
+            m.update_range("t", 0, src, None, 1000 + src);
+        }
+        for src in 0..1000i64 {
+            m.add_detailed("t", 0, src, src, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(e.target_first_offset, Some(0));
+        assert_eq!(e.target_last_offset, Some(999));
+
+        // Segment 2 (offsets 1000-1999): pre-produce with None
+        for src in 1000..2000i64 {
+            m.update_range("t", 0, src, None, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(
+            e.target_last_offset,
+            Some(999),
+            "None must not overwrite Some"
+        );
+
+        // Segment 2: post-produce with Some
+        for src in 1000..2000i64 {
+            m.add_detailed("t", 0, src, src, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(e.source_first_offset, 0);
+        assert_eq!(e.source_last_offset, 1999);
+        assert_eq!(e.target_first_offset, Some(0));
+        assert_eq!(e.target_last_offset, Some(1999));
+    }
+
+    #[test]
+    fn update_range_shifted_target_offsets() {
+        // Target offsets can differ from source (e.g. target partition not
+        // empty). Verify the range tracks correctly.
+        let mut m = OffsetMapping::new();
+        let base = 5000i64;
+
+        for src in 0..100i64 {
+            m.update_range("t", 0, src, None, 1000 + src);
+        }
+        for src in 0..100i64 {
+            m.add_detailed("t", 0, src, base + src, 1000 + src);
+        }
+
+        let e = m.entries.get("t/0").unwrap();
+        assert_eq!(e.target_first_offset, Some(5000));
+        assert_eq!(e.target_last_offset, Some(5099));
     }
 }

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -611,9 +611,7 @@ impl RestoreEngine {
 
         let offset_mapping = self.offset_mapping.lock().await.clone();
 
-        info!("Restore completed successfully");
-
-        Ok(RestoreReport {
+        let report = RestoreReport {
             backup_id: self.config.backup_id.clone(),
             dry_run: false,
             start_time: 0,
@@ -628,7 +626,9 @@ impl RestoreEngine {
             errors,
             offset_mapping,
             resolved_consumer_groups: restore_options.consumer_groups.clone(),
-        })
+        };
+
+        finalize_restore_report(report)
     }
 
     /// Load consumer group IDs from the snapshot written by `snapshot_consumer_groups()`.
@@ -1504,6 +1504,19 @@ fn glob_match_impl(pattern: &[char], text: &[char]) -> bool {
     }
 }
 
+fn finalize_restore_report(report: RestoreReport) -> Result<RestoreReport> {
+    if !report.errors.is_empty() {
+        let error_count = report.errors.len();
+        let joined = report.errors.join("; ");
+        return Err(Error::Config(format!(
+            "Restore completed with {error_count} error(s): {joined}"
+        )));
+    }
+
+    info!("Restore completed successfully");
+    Ok(report)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1557,5 +1570,33 @@ mod tests {
         assert!(!pattern_match("orders", "orders-v1"));
         assert!(pattern_match("~^orders$", "orders"));
         assert!(!pattern_match("~^orders$", "orders-v1"));
+    }
+
+    #[test]
+    fn restore_report_with_errors_is_failure() {
+        let report = RestoreReport {
+            backup_id: "restore-error-regression".to_string(),
+            dry_run: false,
+            start_time: 0,
+            end_time: 0,
+            duration_ms: 0,
+            topics_restored: Vec::new(),
+            segments_processed: 0,
+            records_restored: 0,
+            bytes_restored: 0,
+            throughput_records_per_sec: 0.0,
+            throughput_bytes_per_sec: 0.0,
+            errors: vec!["Topic orders: Produce error for orders:5: code 6".to_string()],
+            offset_mapping: OffsetMapping::new(),
+            resolved_consumer_groups: Vec::new(),
+        };
+
+        let err = finalize_restore_report(report).expect_err(
+            "restore reports containing partition/topic errors must fail the restore run",
+        );
+        assert!(
+            err.to_string().contains("Restore completed with 1 error"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/kafka-backup-core/tests/integration_suite/issue_67_fixes.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_67_fixes.rs
@@ -742,15 +742,15 @@ async fn test_bug7_socket_timeout_constants_all_io_paths_protected() {
     );
     assert_eq!(
         kafka_backup_core::kafka::RESPONSE_TIMEOUT_SECS,
-        10,
-        "RESPONSE_TIMEOUT_SECS should be 10"
+        60,
+        "RESPONSE_TIMEOUT_SECS should stay above the default 30s produce timeout"
     );
 
     // The timeout error message must be classified as a connection error so it
     // triggers the existing reconnect-and-retry path in send_request().
     let timeout_err =
         kafka_backup_core::Error::Kafka(kafka_backup_core::error::KafkaError::Protocol(
-            "Request timed out after 10s waiting for broker response".to_string(),
+            "Request timed out after 60s waiting for broker response".to_string(),
         ));
     assert!(
         kafka_backup_core::kafka::is_connection_error_public(&timeout_err),
@@ -759,7 +759,7 @@ async fn test_bug7_socket_timeout_constants_all_io_paths_protected() {
 
     // Verify the body-read timeout message is distinct (the PR #68 gap we fixed)
     let body_err = kafka_backup_core::Error::Kafka(kafka_backup_core::error::KafkaError::Protocol(
-        "Response body read timed out after 10s".to_string(),
+        "Response body read timed out after 60s".to_string(),
     ));
     assert!(
         kafka_backup_core::kafka::is_connection_error_public(&body_err),

--- a/crates/kafka-backup-core/tests/produce_debug.rs
+++ b/crates/kafka-backup-core/tests/produce_debug.rs
@@ -13,10 +13,27 @@ use kafka_protocol::records::{
     NO_PARTITION_LEADER_EPOCH, NO_PRODUCER_EPOCH, NO_PRODUCER_ID, NO_SEQUENCE,
 };
 
-use kafka_backup_core::config::{ConnectionConfig, KafkaConfig, SecurityConfig, TopicSelection};
+use kafka_backup_core::config::{
+    ConnectionConfig, KafkaConfig, SaslMechanism, SecurityConfig, SecurityProtocol, TopicSelection,
+};
 use kafka_backup_core::kafka::KafkaClient;
 
 fn test_config() -> KafkaConfig {
+    if let Ok(bootstrap) = std::env::var("KAFKA_BOOTSTRAP") {
+        return KafkaConfig {
+            bootstrap_servers: bootstrap.split(',').map(str::to_string).collect(),
+            security: SecurityConfig {
+                security_protocol: SecurityProtocol::SaslSsl,
+                sasl_mechanism: Some(SaslMechanism::ScramSha512),
+                sasl_username: std::env::var("KAFKA_SASL_USERNAME").ok(),
+                sasl_password: std::env::var("KAFKA_SASL_PASSWORD").ok(),
+                ..SecurityConfig::default()
+            },
+            topics: TopicSelection::default(),
+            connection: ConnectionConfig::default(),
+        };
+    }
+
     KafkaConfig {
         bootstrap_servers: vec!["localhost:9092".to_string()],
         security: SecurityConfig::default(),
@@ -149,6 +166,57 @@ async fn test_produce_via_client_method() {
 
     let result = client.produce("orders", 0, records, -1, 30_000).await;
     println!("Produce via client.produce(): {:?}", result);
+}
+
+/// Test 3b: Large BackupRecord through the production client path against an
+/// externally configured cluster. Intended for MSK diagnosis:
+///
+/// KAFKA_BOOTSTRAP=host:9096 \
+/// KAFKA_SASL_USERNAME=migrator \
+/// KAFKA_SASL_PASSWORD=... \
+/// KAFKA_TEST_TOPIC=e2e.large \
+/// KAFKA_TEST_ACKS=1 \
+/// cargo test -p kafka-backup-core --test produce_debug \
+///   test_large_produce_via_client_method -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "requires external Kafka configured via KAFKA_* env vars"]
+async fn test_large_produce_via_client_method() {
+    let client = KafkaClient::new(test_config());
+    client.connect().await.expect("Failed to connect");
+
+    let topic = std::env::var("KAFKA_TEST_TOPIC").unwrap_or_else(|_| "orders".to_string());
+    let partition = std::env::var("KAFKA_TEST_PARTITION")
+        .ok()
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(0);
+    let acks = std::env::var("KAFKA_TEST_ACKS")
+        .ok()
+        .and_then(|s| s.parse::<i16>().ok())
+        .unwrap_or(-1);
+    let timeout_ms = std::env::var("KAFKA_TEST_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(30_000);
+    let value_len = std::env::var("KAFKA_TEST_VALUE_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(131_072);
+
+    let records = vec![kafka_backup_core::manifest::BackupRecord {
+        key: Some(b"rust-large-diag".to_vec()),
+        value: Some(vec![b'x'; value_len]),
+        headers: vec![],
+        timestamp: chrono::Utc::now().timestamp_millis(),
+        offset: 0,
+    }];
+
+    let result = client
+        .produce(&topic, partition, records, acks, timeout_ms)
+        .await;
+    println!(
+        "Large produce via client.produce(topic={topic}, partition={partition}, acks={acks}, timeout_ms={timeout_ms}, value_len={value_len}): {result:?}"
+    );
+    result.expect("large produce failed");
 }
 
 /// Test 4: Batch produce - isolate whether separate batches per record causes error 87

--- a/docs/pr-msk-kraft-runtime-hardening.md
+++ b/docs/pr-msk-kraft-runtime-hardening.md
@@ -1,0 +1,138 @@
+# PR: Runtime hardening for MSK KRaft migration support
+
+## Title
+
+`fix(kafka): harden restore and coordinator routing for MSK migrations`
+
+## Summary
+
+This PR hardens the OSS Kafka client and restore path for the enterprise MSK ZooKeeper to KRaft migration workflow. The enterprise AWS E2E migration completed only after these fixes were present locally.
+
+The key production issue was a restore failure on MSK target clusters when the Rust client produced large uncompressed record batches around 128 KiB with `acks=all`. Java Kafka tooling could produce the same record, proving broker/network/auth were healthy. Switching restored produce batches to zstd compression fixed the Rust client path and allowed the full migration to complete.
+
+This PR does **not** add the enterprise MSK IAM/OAUTHBEARER plugin, and it does **not** add new GSSAPI/Kerberos implementation scope. Current `main` already contains the generic SASL plugin extension point and an optional GSSAPI feature from earlier PRs. This PR only adds the remaining OSS runtime behavior required by the production MSK migration.
+
+If the project decides that the optional GSSAPI implementation should not remain in OSS, that should be handled as a separate cleanup PR that preserves the generic `SaslMechanismPlugin`/factory contract used by enterprise.
+
+## What Changed
+
+### Restore Produce Path
+
+- Increased client response timeout from 10s to 60s.
+- Updated timeout documentation so the client timeout stays above the default 30s broker-side produce timeout.
+- Changed production record-batch encoding from no compression to zstd.
+- Added an ignored external diagnostic test for large MSK produce cases using:
+  - `KAFKA_BOOTSTRAP`
+  - `KAFKA_SASL_USERNAME`
+  - `KAFKA_SASL_PASSWORD`
+  - `KAFKA_TEST_TOPIC`
+  - `KAFKA_TEST_ACKS`
+  - `KAFKA_TEST_TIMEOUT_MS`
+  - `KAFKA_TEST_VALUE_BYTES`
+
+### Restore Correctness
+
+- Restore runs now fail if the report contains partition/topic errors instead of returning a successful `RestoreReport` with embedded errors.
+- Offset mapping range updates now preserve target offsets when the restore pre-produce pass records source offsets with `None` target offsets.
+- Added regression tests for:
+  - `None` then `Some` offset-map updates
+  - preserving existing target offsets
+  - shifted source/target offset ranges
+  - restore reports with errors failing the restore
+
+### Consumer Group Coordinator Routing
+
+- Added `FindCoordinator` support.
+- Added `GroupCoordinator` parsing for modern response shapes.
+- Added coordinator-routed offset commits through `PartitionLeaderRouter::commit_group_offsets`.
+- Added retries for transient coordinator errors:
+  - `COORDINATOR_LOAD_IN_PROGRESS`
+  - `COORDINATOR_NOT_AVAILABLE`
+  - `NOT_COORDINATOR`
+- Added tests for coordinator response selection and transient commit retry classification.
+
+### Kafka Admin APIs
+
+- Added `DescribeConfigs`.
+- Added `IncrementalAlterConfigs`.
+- Added resource/config types for topic and broker config handling.
+- Exported the new admin APIs through `kafka::mod`.
+- Added API version mappings for:
+  - `DescribeConfigs`
+  - `IncrementalAlterConfigs`
+  - `DescribeAcls`
+  - `CreateAcls`
+
+## Bugs Fixed
+
+- Fixed MSK restore stalls/timeouts on large restored records by using zstd record batches.
+- Fixed client-side timeout being shorter than the default broker-side produce timeout.
+- Fixed restore success being reported even when restore errors were present.
+- Fixed offset-map target offsets being lost when source ranges were first recorded without target offsets.
+- Fixed group offset commits being sent to non-coordinator brokers.
+- Added missing Kafka admin APIs used by enterprise topology/config migration.
+
+## Release Metadata
+
+- Bumped the workspace package version from `0.15.3` to `0.15.4`.
+- Updated `Cargo.lock` package entries for `kafka-backup-core` and `kafka-backup-cli` to `0.15.4`.
+
+## Relationship To Enterprise MSK KRaft PR
+
+The enterprise migration PR depends on these OSS fixes. Without them:
+
+- target restore can fail on large records;
+- restore can hide partition-level failures in a nominally successful report;
+- offset translation can be incomplete when offset-map target bounds remain `None`;
+- consumer group offset commits can fail or hit the wrong broker in multi-broker clusters;
+- enterprise topology/config diff and apply paths lack OSS admin API support.
+
+The generic SASL plugin extension point is a prerequisite for enterprise MSK IAM/OAUTHBEARER, but that prerequisite is already on `main`. The enterprise-specific MSK IAM implementation remains in the enterprise repo.
+
+## Verification
+
+Local OSS checks:
+
+```sh
+cargo fmt --all --check
+cargo test -p kafka-backup-core -p kafka-backup-cli -- --nocapture
+```
+
+Focused checks:
+
+```sh
+cargo test -p kafka-backup-core issue_67_fixes -- --nocapture
+```
+
+External MSK diagnostic used during AWS E2E:
+
+```sh
+KAFKA_BOOTSTRAP=<target-scram-bootstrap> \
+KAFKA_SASL_USERNAME=migrator \
+KAFKA_SASL_PASSWORD=<redacted> \
+KAFKA_TEST_TOPIC=e2e.large \
+KAFKA_TEST_ACKS=-1 \
+KAFKA_TEST_VALUE_BYTES=131072 \
+cargo test -p kafka-backup-core --test produce_debug \
+  test_large_produce_via_client_method -- --ignored --nocapture
+```
+
+Enterprise AWS E2E proof:
+
+- Migration ID: `aws-e2e-r4-20260507T200820Z`
+- Source: MSK ZooKeeper provisioned cluster
+- Target: MSK KRaft provisioned cluster
+- Seed restored `119281` records.
+- Tail replayed `1410` live records.
+- Cutover translated `37` offsets across `3` consumer groups.
+- Final validation found no count/offset mismatches and all comparable spot checks matched.
+- Post-switch target produce/read succeeded.
+
+## Out Of Scope
+
+- No AWS resource creation or deletion.
+- No enterprise migration code.
+- No enterprise MSK IAM/OAUTHBEARER token provider.
+- No new GSSAPI/Kerberos feature work.
+- No change to topic deletion or cleanup behavior.
+- No default credential changes.


### PR DESCRIPTION
# PR: Runtime hardening for MSK KRaft migration support

## Title

`fix(kafka): harden restore and coordinator routing for MSK migrations`

## Summary

This PR hardens the OSS Kafka client and restore path for the enterprise MSK ZooKeeper to KRaft migration workflow. The enterprise AWS E2E migration completed only after these fixes were present locally.

The key production issue was a restore failure on MSK target clusters when the Rust client produced large uncompressed record batches around 128 KiB with `acks=all`. Java Kafka tooling could produce the same record, proving broker/network/auth were healthy. Switching restored produce batches to zstd compression fixed the Rust client path and allowed the full migration to complete.

This PR does **not** add the enterprise MSK IAM/OAUTHBEARER plugin, and it does **not** add new GSSAPI/Kerberos implementation scope. Current `main` already contains the generic SASL plugin extension point and an optional GSSAPI feature from earlier PRs. This PR only adds the remaining OSS runtime behavior required by the production MSK migration.

If the project decides that the optional GSSAPI implementation should not remain in OSS, that should be handled as a separate cleanup PR that preserves the generic `SaslMechanismPlugin`/factory contract used by enterprise.

## What Changed

### Restore Produce Path

- Increased client response timeout from 10s to 60s.
- Updated timeout documentation so the client timeout stays above the default 30s broker-side produce timeout.
- Changed production record-batch encoding from no compression to zstd.
- Added an ignored external diagnostic test for large MSK produce cases using:
  - `KAFKA_BOOTSTRAP`
  - `KAFKA_SASL_USERNAME`
  - `KAFKA_SASL_PASSWORD`
  - `KAFKA_TEST_TOPIC`
  - `KAFKA_TEST_ACKS`
  - `KAFKA_TEST_TIMEOUT_MS`
  - `KAFKA_TEST_VALUE_BYTES`

### Restore Correctness

- Restore runs now fail if the report contains partition/topic errors instead of returning a successful `RestoreReport` with embedded errors.
- Offset mapping range updates now preserve target offsets when the restore pre-produce pass records source offsets with `None` target offsets.
- Added regression tests for:
  - `None` then `Some` offset-map updates
  - preserving existing target offsets
  - shifted source/target offset ranges
  - restore reports with errors failing the restore

### Consumer Group Coordinator Routing

- Added `FindCoordinator` support.
- Added `GroupCoordinator` parsing for modern response shapes.
- Added coordinator-routed offset commits through `PartitionLeaderRouter::commit_group_offsets`.
- Added retries for transient coordinator errors:
  - `COORDINATOR_LOAD_IN_PROGRESS`
  - `COORDINATOR_NOT_AVAILABLE`
  - `NOT_COORDINATOR`
- Added tests for coordinator response selection and transient commit retry classification.

### Kafka Admin APIs

- Added `DescribeConfigs`.
- Added `IncrementalAlterConfigs`.
- Added resource/config types for topic and broker config handling.
- Exported the new admin APIs through `kafka::mod`.
- Added API version mappings for:
  - `DescribeConfigs`
  - `IncrementalAlterConfigs`
  - `DescribeAcls`
  - `CreateAcls`

## Bugs Fixed

- Fixed MSK restore stalls/timeouts on large restored records by using zstd record batches.
- Fixed client-side timeout being shorter than the default broker-side produce timeout.
- Fixed restore success being reported even when restore errors were present.
- Fixed offset-map target offsets being lost when source ranges were first recorded without target offsets.
- Fixed group offset commits being sent to non-coordinator brokers.
- Added missing Kafka admin APIs used by enterprise topology/config migration.

## Release Metadata

- Bumped the workspace package version from `0.15.3` to `0.15.4`.
- Updated `Cargo.lock` package entries for `kafka-backup-core` and `kafka-backup-cli` to `0.15.4`.

## Relationship To Enterprise MSK KRaft PR

The enterprise migration PR depends on these OSS fixes. Without them:

- target restore can fail on large records;
- restore can hide partition-level failures in a nominally successful report;
- offset translation can be incomplete when offset-map target bounds remain `None`;
- consumer group offset commits can fail or hit the wrong broker in multi-broker clusters;
- enterprise topology/config diff and apply paths lack OSS admin API support.

The generic SASL plugin extension point is a prerequisite for enterprise MSK IAM/OAUTHBEARER, but that prerequisite is already on `main`. The enterprise-specific MSK IAM implementation remains in the enterprise repo.

## Verification

Local OSS checks:

```sh
cargo fmt --all --check
cargo test -p kafka-backup-core -p kafka-backup-cli -- --nocapture
```

Focused checks:

```sh
cargo test -p kafka-backup-core issue_67_fixes -- --nocapture
```

External MSK diagnostic used during AWS E2E:

```sh
KAFKA_BOOTSTRAP=<target-scram-bootstrap> \
KAFKA_SASL_USERNAME=migrator \
KAFKA_SASL_PASSWORD=<redacted> \
KAFKA_TEST_TOPIC=e2e.large \
KAFKA_TEST_ACKS=-1 \
KAFKA_TEST_VALUE_BYTES=131072 \
cargo test -p kafka-backup-core --test produce_debug \
  test_large_produce_via_client_method -- --ignored --nocapture
```

Enterprise AWS E2E proof:

- Migration ID: `aws-e2e-r4-20260507T200820Z`
- Source: MSK ZooKeeper provisioned cluster
- Target: MSK KRaft provisioned cluster
- Seed restored `119281` records.
- Tail replayed `1410` live records.
- Cutover translated `37` offsets across `3` consumer groups.
- Final validation found no count/offset mismatches and all comparable spot checks matched.
- Post-switch target produce/read succeeded.

## Out Of Scope

- No AWS resource creation or deletion.
- No enterprise migration code.
- No enterprise MSK IAM/OAUTHBEARER token provider.
- No new GSSAPI/Kerberos feature work.
- No change to topic deletion or cleanup behavior.
- No default credential changes.
