### PR TITLE
fix(restore): reset consumer offsets and purge by leader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.4"
+version = "0.15.5"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/kafka/admin.rs
+++ b/crates/kafka-backup-core/src/kafka/admin.rs
@@ -277,6 +277,12 @@ pub async fn delete_records(
     let response: DeleteRecordsResponse =
         client.send_request(ApiKey::DeleteRecords, request).await?;
 
+    handle_delete_records_response(&response)
+}
+
+fn handle_delete_records_response(response: &DeleteRecordsResponse) -> Result<()> {
+    let mut failures = Vec::new();
+
     for topic_result in &response.topics {
         for part in &topic_result.partitions {
             if part.error_code != 0 {
@@ -284,6 +290,10 @@ pub async fn delete_records(
                     "DeleteRecords failed for {}[{}]: error_code={}",
                     topic_result.name.0, part.partition_index, part.error_code
                 );
+                failures.push(format!(
+                    "{}[{}]: error_code={} low_watermark={}",
+                    topic_result.name.0, part.partition_index, part.error_code, part.low_watermark
+                ));
             } else {
                 debug!(
                     "Purged {}[{}] new log-start-offset={}",
@@ -291,6 +301,12 @@ pub async fn delete_records(
                 );
             }
         }
+    }
+
+    if !failures.is_empty() {
+        return Err(
+            KafkaError::Protocol(format!("DeleteRecords failed: {}", failures.join("; "))).into(),
+        );
     }
 
     Ok(())
@@ -430,6 +446,9 @@ pub async fn incremental_alter_configs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kafka_protocol::messages::delete_records_response::{
+        DeleteRecordsPartitionResult, DeleteRecordsTopicResult,
+    };
 
     #[test]
     fn test_create_topic_result_success() {
@@ -465,5 +484,31 @@ mod tests {
         assert!(!result.is_success());
         assert!(!result.is_success_or_exists());
         assert!(!result.already_exists());
+    }
+
+    #[test]
+    fn delete_records_partition_errors_should_fail_request() {
+        let response =
+            DeleteRecordsResponse::default().with_topics(vec![DeleteRecordsTopicResult::default()
+                .with_name(TopicName(StrBytes::from_static_str("issue51-topic")))
+                .with_partitions(vec![
+                    DeleteRecordsPartitionResult::default()
+                        .with_partition_index(0)
+                        .with_low_watermark(10)
+                        .with_error_code(0),
+                    DeleteRecordsPartitionResult::default()
+                        .with_partition_index(1)
+                        .with_low_watermark(-1)
+                        .with_error_code(6),
+                ])]);
+
+        let err = handle_delete_records_response(&response)
+            .expect_err("DeleteRecords partition errors must fail the purge request");
+
+        assert!(
+            err.to_string().contains("issue51-topic[1]")
+                && err.to_string().contains("error_code=6"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -797,8 +797,104 @@ impl PartitionLeaderRouter {
         partitions: &[(i32, i64)],
         timeout_ms: i32,
     ) -> Result<()> {
-        super::admin::delete_records(&self.bootstrap_client, topic, partitions, timeout_ms).await
+        const MAX_CONNECTION_RETRIES: u32 = 5;
+        const MAX_LEADER_RETRIES: u32 = 20;
+
+        if partitions.is_empty() {
+            return Ok(());
+        }
+
+        let mut connection_attempts = 0;
+        let mut leader_attempts = 0;
+
+        loop {
+            match self
+                .delete_records_internal(topic, partitions, timeout_ms)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(e) if is_not_leader_error(&e) && leader_attempts < MAX_LEADER_RETRIES => {
+                    leader_attempts += 1;
+                    let backoff = Duration::from_millis((250 * leader_attempts as u64).min(2_000));
+                    warn!(
+                        "NOT_LEADER_FOR_PARTITION during DeleteRecords for topic {} (attempt {}/{}), refreshing metadata after {:?}: {}",
+                        topic, leader_attempts, MAX_LEADER_RETRIES, backoff, e
+                    );
+                    self.refresh_metadata().await?;
+                    self.clear_connection_cache().await;
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e)
+                    if is_connection_error(&e) && connection_attempts < MAX_CONNECTION_RETRIES =>
+                {
+                    connection_attempts += 1;
+                    let backoff = Duration::from_millis(500 * connection_attempts as u64);
+                    warn!(
+                        "Connection error during DeleteRecords for topic {} (attempt {}/{}), retrying after {:?}: {}",
+                        topic, connection_attempts, MAX_CONNECTION_RETRIES, backoff, e
+                    );
+                    self.clear_connection_cache().await;
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
+
+    async fn delete_records_internal(
+        &self,
+        topic: &str,
+        partitions: &[(i32, i64)],
+        timeout_ms: i32,
+    ) -> Result<()> {
+        let mut partition_leaders = HashMap::new();
+        for (partition, _) in partitions {
+            let leader_id = self.get_leader(topic, *partition).await?;
+            partition_leaders.insert((topic.to_string(), *partition), leader_id);
+        }
+
+        let broker_partitions =
+            group_partition_offsets_by_leader(topic, partitions, &partition_leaders)?;
+
+        debug!(
+            "delete_records: {} partitions for topic {} across {} brokers",
+            partitions.len(),
+            topic,
+            broker_partitions.len()
+        );
+
+        for (broker_id, broker_parts) in &broker_partitions {
+            let client = self.get_broker_connection(*broker_id).await?;
+            super::admin::delete_records(&client, topic, broker_parts, timeout_ms).await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn group_partition_offsets_by_leader(
+    topic: &str,
+    partitions: &[(i32, i64)],
+    partition_leaders: &HashMap<(String, i32), i32>,
+) -> Result<HashMap<i32, Vec<(i32, i64)>>> {
+    let mut broker_partitions: HashMap<i32, Vec<(i32, i64)>> = HashMap::new();
+
+    for (partition, offset) in partitions {
+        let leader_id = partition_leaders
+            .get(&(topic.to_string(), *partition))
+            .copied()
+            .ok_or_else(|| KafkaError::PartitionNotAvailable {
+                topic: topic.to_string(),
+                partition: *partition,
+            })?;
+
+        broker_partitions
+            .entry(leader_id)
+            .or_default()
+            .push((*partition, *offset));
+    }
+
+    Ok(broker_partitions)
 }
 
 /// Check if an error is a connection-level error that warrants a retry.
@@ -823,7 +919,7 @@ fn is_not_leader_error(error: &crate::Error) -> bool {
         _ => {
             // Also check error message as fallback
             let msg = error.to_string();
-            msg.contains("NOT_LEADER") || msg.contains("code 6")
+            msg.contains("NOT_LEADER") || msg.contains("code 6") || msg.contains("error_code=6")
         }
     }
 }
@@ -863,11 +959,32 @@ mod tests {
         });
         assert!(is_not_leader_error(&error));
 
+        let protocol_error = crate::Error::Kafka(KafkaError::Protocol(
+            "DeleteRecords failed: orders[1]: error_code=6 low_watermark=-1".to_string(),
+        ));
+        assert!(is_not_leader_error(&protocol_error));
+
         let other_error = crate::Error::Kafka(KafkaError::BrokerError {
             code: 1,
             message: "Some other error".to_string(),
         });
         assert!(!is_not_leader_error(&other_error));
+    }
+
+    #[test]
+    fn delete_records_partitions_are_grouped_by_leader() {
+        let mut leaders = HashMap::new();
+        leaders.insert(("orders".to_string(), 0), 1);
+        leaders.insert(("orders".to_string(), 1), 2);
+        leaders.insert(("orders".to_string(), 2), 1);
+
+        let grouped =
+            group_partition_offsets_by_leader("orders", &[(0, 10), (1, 20), (2, 30)], &leaders)
+                .expect("partitions should group by leader");
+
+        assert_eq!(grouped.len(), 2);
+        assert_eq!(grouped.get(&1), Some(&vec![(0, 10), (2, 30)]));
+        assert_eq!(grouped.get(&2), Some(&vec![(1, 20)]));
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -1,6 +1,6 @@
 //! Restore engine orchestration.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex, Semaphore};
@@ -119,6 +119,119 @@ pub struct RestoreEngine {
     offset_mapping: Arc<Mutex<OffsetMapping>>,
     progress_tx: broadcast::Sender<RestoreProgress>,
     target_config: Option<crate::config::KafkaConfig>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct AutoConsumerGroupSnapshot {
+    #[serde(default)]
+    snapshot_time: Option<i64>,
+    #[serde(default)]
+    groups: Vec<AutoConsumerGroupSnapshotGroup>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct AutoConsumerGroupSnapshotGroup {
+    group_id: String,
+    #[serde(default)]
+    offsets: HashMap<String, HashMap<String, i64>>,
+}
+
+impl AutoConsumerGroupSnapshot {
+    fn group_ids(&self) -> Vec<String> {
+        self.groups
+            .iter()
+            .map(|group| group.group_id.clone())
+            .collect()
+    }
+}
+
+fn parse_auto_consumer_group_snapshot(data: &[u8]) -> Result<AutoConsumerGroupSnapshot> {
+    Ok(serde_json::from_slice(data)?)
+}
+
+fn import_auto_consumer_group_snapshot_offsets(
+    offset_mapping: &mut OffsetMapping,
+    snapshot: &AutoConsumerGroupSnapshot,
+    restore_options: &RestoreOptions,
+) -> Vec<String> {
+    let group_ids = snapshot.group_ids();
+    let timestamp = snapshot
+        .snapshot_time
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+    let mut imported_offsets = 0usize;
+    let mut skipped_offsets = 0usize;
+
+    for group in &snapshot.groups {
+        for (source_topic, topic_offsets) in &group.offsets {
+            let target_topic = restore_options
+                .topic_mapping
+                .get(source_topic)
+                .map(String::as_str)
+                .unwrap_or(source_topic.as_str());
+
+            for (source_partition, source_offset) in topic_offsets {
+                if *source_offset < 0 {
+                    skipped_offsets += 1;
+                    warn!(
+                        "auto_consumer_groups: skipping negative offset for group {} topic {} partition {}",
+                        group.group_id, source_topic, source_partition
+                    );
+                    continue;
+                }
+
+                let source_partition = match source_partition.parse::<i32>() {
+                    Ok(partition) => partition,
+                    Err(e) => {
+                        skipped_offsets += 1;
+                        warn!(
+                            "auto_consumer_groups: skipping invalid partition '{}' for group {} topic {}: {}",
+                            source_partition, group.group_id, source_topic, e
+                        );
+                        continue;
+                    }
+                };
+
+                let target_partition = restore_options
+                    .partition_mapping
+                    .get(&source_partition)
+                    .copied()
+                    .unwrap_or(source_partition);
+
+                offset_mapping.add_consumer_group_offset(
+                    &group.group_id,
+                    target_topic,
+                    target_partition,
+                    *source_offset,
+                    timestamp,
+                    None,
+                );
+                imported_offsets += 1;
+            }
+        }
+    }
+
+    offset_mapping.recalculate_consumer_group_offsets();
+
+    if imported_offsets == 0 && !group_ids.is_empty() {
+        warn!(
+            "auto_consumer_groups: snapshot listed {} groups but contained no usable offsets",
+            group_ids.len()
+        );
+    } else {
+        info!(
+            "auto_consumer_groups: imported {} consumer group offsets from snapshot",
+            imported_offsets
+        );
+    }
+
+    if skipped_offsets > 0 {
+        warn!(
+            "auto_consumer_groups: skipped {} malformed snapshot offsets",
+            skipped_offsets
+        );
+    }
+
+    group_ids
 }
 
 impl RestoreEngine {
@@ -538,25 +651,38 @@ impl RestoreEngine {
                 .await?;
         }
 
-        // Auto-load consumer groups from snapshot if requested (Issue #67 bug 5)
-        if restore_options.auto_consumer_groups && restore_options.consumer_groups.is_empty() {
-            match self.load_auto_consumer_groups().await {
-                Ok(groups) => {
+        // Auto-load consumer groups from snapshot if requested (Issue #51 / #67 bug 5)
+        let auto_consumer_group_snapshot = if restore_options.auto_consumer_groups
+            && restore_options.consumer_groups.is_empty()
+        {
+            match self.load_auto_consumer_group_snapshot().await {
+                Ok(snapshot) => {
+                    let groups = snapshot.group_ids();
+                    let offset_count = snapshot
+                        .groups
+                        .iter()
+                        .map(|group| group.offsets.values().map(HashMap::len).sum::<usize>())
+                        .sum::<usize>();
+
                     info!(
-                        "auto_consumer_groups: loaded {} groups from snapshot",
-                        groups.len()
+                        "auto_consumer_groups: loaded {} groups and {} offsets from snapshot",
+                        groups.len(),
+                        offset_count
                     );
                     restore_options.consumer_groups = groups;
                     restore_options.reset_consumer_offsets = true;
+                    Some(snapshot)
                 }
                 Err(e) => {
                     warn!(
-                        "auto_consumer_groups: failed to load snapshot ({}); continuing without group reset",
-                        e
+                        "auto_consumer_groups: failed to load snapshot ({e}); continuing without group reset"
                     );
+                    None
                 }
             }
-        }
+        } else {
+            None
+        };
 
         // Purge target topics before restore if requested (Issue #67 bug 10)
         if restore_options.purge_topics {
@@ -609,6 +735,11 @@ impl RestoreEngine {
             }
         }
 
+        if let Some(snapshot) = &auto_consumer_group_snapshot {
+            let mut mapping = self.offset_mapping.lock().await;
+            import_auto_consumer_group_snapshot_offsets(&mut mapping, snapshot, &restore_options);
+        }
+
         let offset_mapping = self.offset_mapping.lock().await.clone();
 
         let report = RestoreReport {
@@ -631,11 +762,11 @@ impl RestoreEngine {
         finalize_restore_report(report)
     }
 
-    /// Load consumer group IDs from the snapshot written by `snapshot_consumer_groups()`.
+    /// Load the consumer group snapshot written by `snapshot_consumer_groups()`.
     ///
     /// Reads `{backup_id}/consumer-groups-snapshot.json`. Returns an error when the
     /// file is absent so the caller can treat it as a non-fatal warning.
-    async fn load_auto_consumer_groups(&self) -> Result<Vec<String>> {
+    async fn load_auto_consumer_group_snapshot(&self) -> Result<AutoConsumerGroupSnapshot> {
         let key = format!("{}/consumer-groups-snapshot.json", self.config.backup_id);
         let data = self.storage.get(&key).await.map_err(|e| {
             Error::BackupNotFound(format!(
@@ -644,17 +775,7 @@ impl RestoreEngine {
             ))
         })?;
 
-        #[derive(serde::Deserialize)]
-        struct Snapshot {
-            groups: Vec<GroupEntry>,
-        }
-        #[derive(serde::Deserialize)]
-        struct GroupEntry {
-            group_id: String,
-        }
-
-        let snapshot: Snapshot = serde_json::from_slice(&data)?;
-        Ok(snapshot.groups.into_iter().map(|g| g.group_id).collect())
+        parse_auto_consumer_group_snapshot(&data)
     }
 
     /// Purge target topics before restore by advancing log-start-offset to the current end.
@@ -1520,6 +1641,8 @@ fn finalize_restore_report(report: RestoreReport) -> Result<RestoreReport> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::restore::offset_reset::{OffsetResetExecutor, OffsetResetStrategy};
+    use std::collections::HashMap;
 
     #[test]
     fn test_glob_match() {
@@ -1598,5 +1721,85 @@ mod tests {
             err.to_string().contains("Restore completed with 1 error"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn auto_consumer_group_snapshot_offsets_feed_reset_plan() {
+        let snapshot = parse_auto_consumer_group_snapshot(
+            br#"{
+                "snapshot_time": 1778044734905,
+                "groups": [
+                    {
+                        "group_id": "issue51-group",
+                        "offsets": {
+                            "issue51-topic": {
+                                "0": 10,
+                                "2": 10,
+                                "1": 10
+                            }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .expect("snapshot should parse");
+
+        let mut restore_options = RestoreOptions::default();
+        restore_options.topic_mapping.insert(
+            "issue51-topic".to_string(),
+            "issue51-restored-topic".to_string(),
+        );
+        restore_options.partition_mapping.insert(2, 5);
+
+        let mut mapping = OffsetMapping::new();
+        for source_offset in 0..10 {
+            mapping.add_detailed(
+                "issue51-restored-topic",
+                0,
+                source_offset,
+                100 + source_offset,
+                1778044700000 + source_offset,
+            );
+            mapping.add_detailed(
+                "issue51-restored-topic",
+                1,
+                source_offset,
+                200 + source_offset,
+                1778044700000 + source_offset,
+            );
+            mapping.add_detailed(
+                "issue51-restored-topic",
+                5,
+                source_offset,
+                500 + source_offset,
+                1778044700000 + source_offset,
+            );
+        }
+
+        let group_ids =
+            import_auto_consumer_group_snapshot_offsets(&mut mapping, &snapshot, &restore_options);
+
+        assert_eq!(group_ids, vec!["issue51-group".to_string()]);
+
+        let executor = OffsetResetExecutor::new_offline(vec!["target:9092".to_string()]);
+        let plan = executor
+            .generate_plan(&mapping, &group_ids, OffsetResetStrategy::Auto)
+            .await
+            .expect("reset plan should be generated from snapshot offsets");
+
+        assert_eq!(plan.groups.len(), 1);
+        let group_plan = &plan.groups[0];
+        assert!(group_plan.complete);
+        assert_eq!(group_plan.partition_count, 3);
+
+        let planned_offsets: HashMap<i32, i64> = group_plan
+            .partitions
+            .iter()
+            .map(|partition| (partition.partition, partition.target_offset))
+            .collect();
+
+        assert_eq!(planned_offsets.get(&0), Some(&110));
+        assert_eq!(planned_offsets.get(&1), Some(&210));
+        assert_eq!(planned_offsets.get(&5), Some(&510));
     }
 }

--- a/crates/kafka-backup-core/src/restore/offset_reset.rs
+++ b/crates/kafka-backup-core/src/restore/offset_reset.rs
@@ -8,9 +8,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::kafka::{commit_offsets, fetch_offsets, KafkaClient};
+use crate::kafka::{commit_offsets, fetch_offsets, KafkaClient, PartitionLeaderRouter};
 #[cfg(test)]
 use crate::manifest::ConsumerGroupOffset;
 use crate::manifest::{ConsumerGroupOffsets, OffsetMapping};
@@ -133,17 +134,73 @@ pub enum OffsetResetStrategy {
 /// Offset reset executor
 pub struct OffsetResetExecutor {
     /// Target Kafka client
-    client: Option<KafkaClient>,
+    client: Option<Arc<KafkaClient>>,
+
+    /// Commit backend used when applying a reset plan
+    committer: Option<Arc<dyn OffsetCommitter>>,
 
     /// Bootstrap servers for shell script generation
     bootstrap_servers: Vec<String>,
 }
 
+#[async_trait::async_trait]
+trait OffsetCommitter: Send + Sync {
+    async fn commit_offsets(
+        &self,
+        group_id: &str,
+        offsets: &[(String, i32, i64, Option<String>)],
+    ) -> Result<Vec<(String, i32, i16)>>;
+}
+
+struct ClientOffsetCommitter {
+    client: Arc<KafkaClient>,
+}
+
+#[async_trait::async_trait]
+impl OffsetCommitter for ClientOffsetCommitter {
+    async fn commit_offsets(
+        &self,
+        group_id: &str,
+        offsets: &[(String, i32, i64, Option<String>)],
+    ) -> Result<Vec<(String, i32, i16)>> {
+        commit_offsets(&self.client, group_id, offsets).await
+    }
+}
+
+struct RouterOffsetCommitter {
+    router: Arc<PartitionLeaderRouter>,
+}
+
+#[async_trait::async_trait]
+impl OffsetCommitter for RouterOffsetCommitter {
+    async fn commit_offsets(
+        &self,
+        group_id: &str,
+        offsets: &[(String, i32, i64, Option<String>)],
+    ) -> Result<Vec<(String, i32, i16)>> {
+        self.router.commit_group_offsets(group_id, offsets).await
+    }
+}
+
 impl OffsetResetExecutor {
     /// Create a new executor with a Kafka client
     pub fn new(client: KafkaClient, bootstrap_servers: Vec<String>) -> Self {
+        let client = Arc::new(client);
         Self {
-            client: Some(client),
+            client: Some(Arc::clone(&client)),
+            committer: Some(Arc::new(ClientOffsetCommitter { client })),
+            bootstrap_servers,
+        }
+    }
+
+    /// Create a new executor that commits offsets through group coordinators.
+    pub fn new_with_router(
+        router: Arc<PartitionLeaderRouter>,
+        bootstrap_servers: Vec<String>,
+    ) -> Self {
+        Self {
+            client: None,
+            committer: Some(Arc::new(RouterOffsetCommitter { router })),
             bootstrap_servers,
         }
     }
@@ -152,6 +209,7 @@ impl OffsetResetExecutor {
     pub fn new_offline(bootstrap_servers: Vec<String>) -> Self {
         Self {
             client: None,
+            committer: None,
             bootstrap_servers,
         }
     }
@@ -279,16 +337,18 @@ impl OffsetResetExecutor {
     /// Execute an offset reset plan
     pub async fn execute_plan(&self, plan: &OffsetResetPlan) -> Result<OffsetResetReport> {
         let start_time = std::time::Instant::now();
-        let client = self.client.as_ref().ok_or_else(|| {
-            crate::Error::Config("Kafka client required to execute offset reset".to_string())
-        })?;
+        if self.committer.is_none() {
+            return Err(crate::Error::Config(
+                "Kafka client required to execute offset reset".to_string(),
+            ));
+        }
 
         let mut groups_reset = Vec::new();
         let mut total_errors = Vec::new();
         let mut total_partitions_reset = 0u64;
 
         for group_plan in &plan.groups {
-            let result = self.execute_group_reset(client, group_plan).await;
+            let result = self.execute_group_reset(group_plan).await;
 
             match result {
                 Ok(group_result) => {
@@ -340,11 +400,7 @@ impl OffsetResetExecutor {
     }
 
     /// Execute offset reset for a single group
-    async fn execute_group_reset(
-        &self,
-        client: &KafkaClient,
-        plan: &GroupResetPlan,
-    ) -> Result<GroupResetResult> {
+    async fn execute_group_reset(&self, plan: &GroupResetPlan) -> Result<GroupResetResult> {
         let offsets: Vec<_> = plan
             .partitions
             .iter()
@@ -358,7 +414,10 @@ impl OffsetResetExecutor {
             })
             .collect();
 
-        let results = commit_offsets(client, &plan.group_id, &offsets).await?;
+        let committer = self.committer.as_ref().ok_or_else(|| {
+            crate::Error::Config("Kafka client required to execute offset reset".to_string())
+        })?;
+        let results = committer.commit_offsets(&plan.group_id, &offsets).await?;
 
         let mut partitions_reset = 0u64;
         let mut partitions_failed = 0u64;
@@ -759,5 +818,89 @@ mod tests {
     fn test_offset_reset_strategy_default() {
         let strategy: OffsetResetStrategy = Default::default();
         assert_eq!(strategy, OffsetResetStrategy::Manual);
+    }
+
+    type RecordedCommitCall = (String, Vec<(String, i32, i64, Option<String>)>);
+
+    #[derive(Default)]
+    struct RecordingCommitter {
+        calls: std::sync::Mutex<Vec<RecordedCommitCall>>,
+    }
+
+    #[async_trait::async_trait]
+    impl OffsetCommitter for RecordingCommitter {
+        async fn commit_offsets(
+            &self,
+            group_id: &str,
+            offsets: &[(String, i32, i64, Option<String>)],
+        ) -> Result<Vec<(String, i32, i16)>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((group_id.to_string(), offsets.to_vec()));
+
+            Ok(offsets
+                .iter()
+                .map(|(topic, partition, _, _)| (topic.clone(), *partition, 0))
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_plan_uses_configured_offset_committer() {
+        let committer = std::sync::Arc::new(RecordingCommitter::default());
+        let executor = OffsetResetExecutor {
+            client: None,
+            committer: Some(committer.clone()),
+            bootstrap_servers: vec!["kafka:9092".to_string()],
+        };
+
+        let plan = OffsetResetPlan {
+            groups: vec![GroupResetPlan {
+                group_id: "issue51-group".to_string(),
+                partitions: vec![
+                    PartitionResetPlan {
+                        topic: "orders".to_string(),
+                        partition: 0,
+                        source_offset: 10,
+                        target_offset: 30,
+                        timestamp: 1000,
+                        metadata: None,
+                    },
+                    PartitionResetPlan {
+                        topic: "orders".to_string(),
+                        partition: 1,
+                        source_offset: 12,
+                        target_offset: 42,
+                        timestamp: 1000,
+                        metadata: Some("snapshot".to_string()),
+                    },
+                ],
+                partition_count: 2,
+                complete: true,
+            }],
+            generated_at: 0,
+            strategy: "Auto".to_string(),
+            dry_run: false,
+            backup_id: None,
+            source_cluster_id: None,
+            target_bootstrap_servers: vec![],
+        };
+
+        let report = executor.execute_plan(&plan).await.unwrap();
+
+        assert!(report.success);
+        assert_eq!(report.partitions_reset, 2);
+
+        let calls = committer.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "issue51-group");
+        assert_eq!(
+            calls[0].1,
+            vec![
+                ("orders".to_string(), 0, 30, None),
+                ("orders".to_string(), 1, 42, Some("snapshot".to_string())),
+            ]
+        );
     }
 }

--- a/crates/kafka-backup-core/src/restore/three_phase.rs
+++ b/crates/kafka-backup-core/src/restore/three_phase.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use crate::config::Config;
-use crate::kafka::KafkaClient;
+use crate::kafka::{KafkaClient, PartitionLeaderRouter};
 use crate::manifest::{OffsetMapping, RestoreReport};
 use crate::Result;
 
@@ -257,10 +257,11 @@ impl ThreePhaseRestore {
             )
         })?;
 
-        let client = KafkaClient::new(target.clone());
-        client.connect().await?;
-
-        let executor = OffsetResetExecutor::new(client, target.bootstrap_servers.clone());
+        let router = PartitionLeaderRouter::new(target.clone()).await?;
+        let executor = OffsetResetExecutor::new_with_router(
+            std::sync::Arc::new(router),
+            target.bootstrap_servers.clone(),
+        );
         executor.execute_plan(plan).await
     }
 


### PR DESCRIPTION
## Summary

Refs osodevops/kafka-backup-operator#51.

This prepares `kafka-backup-core` `v0.15.5` and fixes the remaining Issue #51 restore behavior:

- imports auto consumer group snapshot offsets into the restore offset mapping before Phase 3 reset planning
- commits restored offsets through the discovered group coordinator instead of a single bootstrap broker
- treats DeleteRecords partition errors as restore failures instead of logging success
- routes DeleteRecords purge requests to partition leaders with metadata refresh/retry on `NOT_LEADER_FOR_PARTITION`
- bumps the workspace and lockfile from `0.15.4` to `0.15.5`

## Validation

Local:

- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/ci/check-release-version.py --base-ref origin/main --mode guard --event-name pull_request`
- `cargo test -p kafka-backup-core -p kafka-backup-cli`

Minikube end-to-end verification with the operator built against this local core:

- restore completed successfully
- purge no longer logged `DeleteRecords failed ... error_code=6`
- topic earliest offsets advanced to the pre-restore latest offsets on all partitions
- visible restored records matched the backup: `25 + 15 + 20 = 60`
- consumer group `issue51-fixed-group` was reset to log end on all three partitions with lag `0`

## Release Notes

This is intended to release as core `v0.15.5`. After this PR merges and the core release workflow completes, the operator should be updated to depend on `kafka-backup-core` tag `v0.15.5`.
