### PR TITLE
fix: retry CreateTopics on NOT_CONTROLLER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.7] - 2026-05-19
+
+### Fixed
+- Retry topic creation against the active controller when Kafka returns
+  `NOT_CONTROLLER`, fixing restore topic creation through bootstrap endpoints
+  that are not the controller.
+
 ## [0.15.0] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.6"
+version = "0.15.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.6"
+version = "0.15.7"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/kafka/admin.rs
+++ b/crates/kafka-backup-core/src/kafka/admin.rs
@@ -11,15 +11,20 @@ use kafka_protocol::messages::{
         AlterConfigsResource, AlterableConfig, IncrementalAlterConfigsRequest,
     },
     ApiKey, CreateTopicsResponse, DeleteRecordsRequest, DeleteRecordsResponse,
-    DescribeConfigsResponse, IncrementalAlterConfigsResponse, TopicName,
+    DescribeConfigsResponse, IncrementalAlterConfigsResponse, MetadataRequest, MetadataResponse,
+    TopicName,
 };
 use kafka_protocol::protocol::StrBytes;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
+use super::metadata::BrokerMetadata;
 use super::KafkaClient;
 use crate::error::KafkaError;
 use crate::Result;
+
+const TOPIC_ALREADY_EXISTS: i16 = 36;
+const NOT_CONTROLLER: i16 = 41;
 
 /// Configuration for a topic to be created
 #[derive(Debug, Clone)]
@@ -127,7 +132,7 @@ pub struct ConfigChange {
 impl CreateTopicResult {
     /// Check if the topic was created successfully or already existed
     pub fn is_success_or_exists(&self) -> bool {
-        self.error_code == 0 || self.error_code == 36 // TOPIC_ALREADY_EXISTS
+        self.error_code == 0 || self.error_code == TOPIC_ALREADY_EXISTS
     }
 
     /// Check if the operation was successful (topic created)
@@ -137,7 +142,7 @@ impl CreateTopicResult {
 
     /// Check if topic already existed
     pub fn already_exists(&self) -> bool {
-        self.error_code == 36
+        self.error_code == TOPIC_ALREADY_EXISTS
     }
 }
 
@@ -151,6 +156,24 @@ impl CreateTopicResult {
 /// # Returns
 /// Vec of results, one per topic
 pub async fn create_topics(
+    client: &KafkaClient,
+    topics: Vec<TopicToCreate>,
+    timeout_ms: i32,
+) -> Result<Vec<CreateTopicResult>> {
+    let results = create_topics_once(client, topics.clone(), timeout_ms).await?;
+
+    let results = if results.iter().any(is_not_controller) {
+        retry_not_controller_topics(client, &topics, results, timeout_ms).await?
+    } else {
+        results
+    };
+
+    validate_create_topic_results(&results)?;
+
+    Ok(results)
+}
+
+async fn create_topics_once(
     client: &KafkaClient,
     topics: Vec<TopicToCreate>,
     timeout_ms: i32,
@@ -192,7 +215,6 @@ pub async fn create_topics(
         if error_code == 0 {
             info!("Created topic: {}", name);
         } else if error_code == 36 {
-            // TOPIC_ALREADY_EXISTS
             debug!("Topic already exists: {}", name);
         } else {
             warn!(
@@ -207,8 +229,10 @@ pub async fn create_topics(
             error_message,
         });
     }
+    Ok(results)
+}
 
-    // Check for any unexpected failures (not success or already exists)
+fn validate_create_topic_results(results: &[CreateTopicResult]) -> Result<()> {
     let failures: Vec<_> = results
         .iter()
         .filter(|r| !r.is_success_or_exists())
@@ -232,7 +256,115 @@ pub async fn create_topics(
         .into());
     }
 
-    Ok(results)
+    Ok(())
+}
+
+async fn retry_not_controller_topics(
+    client: &KafkaClient,
+    topics: &[TopicToCreate],
+    results: Vec<CreateTopicResult>,
+    timeout_ms: i32,
+) -> Result<Vec<CreateTopicResult>> {
+    let retry_topics: Vec<TopicToCreate> = topics
+        .iter()
+        .filter(|topic| {
+            results
+                .iter()
+                .any(|result| result.name == topic.name && is_not_controller(result))
+        })
+        .cloned()
+        .collect();
+
+    if retry_topics.is_empty() {
+        return Ok(results);
+    }
+
+    warn!(
+        "CreateTopics returned NOT_CONTROLLER for {:?}; refreshing controller metadata and retrying",
+        retry_topics
+            .iter()
+            .map(|topic| topic.name.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    let controller = fetch_controller_broker(client).await?;
+    let retry_results =
+        create_topics_on_controller(client, &controller, retry_topics, timeout_ms).await?;
+
+    Ok(merge_create_topic_results(results, retry_results))
+}
+
+fn is_not_controller(result: &CreateTopicResult) -> bool {
+    result.error_code == NOT_CONTROLLER
+}
+
+async fn fetch_controller_broker(client: &KafkaClient) -> Result<BrokerMetadata> {
+    let request = MetadataRequest::default()
+        .with_topics(None)
+        .with_allow_auto_topic_creation(false);
+
+    let response: MetadataResponse = client.send_request(ApiKey::Metadata, request).await?;
+
+    let brokers: Vec<BrokerMetadata> = response
+        .brokers
+        .iter()
+        .map(|broker| BrokerMetadata {
+            node_id: broker.node_id.0,
+            host: broker.host.to_string(),
+            port: broker.port,
+            rack: broker.rack.as_ref().map(|rack| rack.to_string()),
+        })
+        .collect();
+
+    client.update_brokers(brokers.clone()).await;
+
+    let controller_id = response.controller_id.0;
+    brokers
+        .into_iter()
+        .find(|broker| broker.node_id == controller_id)
+        .ok_or_else(|| {
+            KafkaError::Protocol(format!(
+                "Metadata response did not include controller broker id {}",
+                controller_id
+            ))
+            .into()
+        })
+}
+
+async fn create_topics_on_controller(
+    client: &KafkaClient,
+    controller: &BrokerMetadata,
+    topics: Vec<TopicToCreate>,
+    timeout_ms: i32,
+) -> Result<Vec<CreateTopicResult>> {
+    let mut controller_config = client.config_clone();
+    controller_config.bootstrap_servers = vec![format!("{}:{}", controller.host, controller.port)];
+
+    let controller_client = KafkaClient::new(controller_config);
+    controller_client.connect().await?;
+
+    create_topics_once(&controller_client, topics, timeout_ms).await
+}
+
+fn merge_create_topic_results(
+    original: Vec<CreateTopicResult>,
+    retry_results: Vec<CreateTopicResult>,
+) -> Vec<CreateTopicResult> {
+    let mut retry_by_name: HashMap<String, CreateTopicResult> = retry_results
+        .into_iter()
+        .map(|result| (result.name.clone(), result))
+        .collect();
+
+    original
+        .into_iter()
+        .map(|result| {
+            if is_not_controller(&result) {
+                retry_by_name.remove(&result.name).unwrap_or(result)
+            } else {
+                result
+            }
+        })
+        .collect()
 }
 
 /// Delete records from Kafka partitions by advancing the log-start-offset.
@@ -446,9 +578,114 @@ pub async fn incremental_alter_configs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::{BufMut, Bytes, BytesMut};
+    use kafka_protocol::messages::create_topics_response::CreatableTopicResult;
     use kafka_protocol::messages::delete_records_response::{
         DeleteRecordsPartitionResult, DeleteRecordsTopicResult,
     };
+    use kafka_protocol::messages::metadata_response::MetadataResponseBroker;
+    use kafka_protocol::messages::{MetadataResponse, RequestHeader, ResponseHeader};
+    use kafka_protocol::protocol::{Decodable, Encodable};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    use crate::config::{ConnectionConfig, KafkaConfig, SecurityConfig, TopicSelection};
+
+    const NOT_CONTROLLER: i16 = 41;
+
+    #[tokio::test]
+    async fn create_topics_recovers_from_not_controller() {
+        let controller_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind controller listener");
+        let controller_addr = controller_listener
+            .local_addr()
+            .expect("controller listener address");
+
+        let bootstrap_listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind bootstrap listener");
+        let bootstrap_addr = bootstrap_listener
+            .local_addr()
+            .expect("bootstrap listener address");
+
+        let bootstrap_task = tokio::spawn(async move {
+            let (mut stream, _) = bootstrap_listener
+                .accept()
+                .await
+                .expect("accept bootstrap connection");
+
+            let (api_key, api_version, correlation_id, _) =
+                read_request(&mut stream).await.expect("read first request");
+            assert_eq!(api_key, ApiKey::CreateTopics);
+            write_response(
+                &mut stream,
+                api_key,
+                api_version,
+                correlation_id,
+                &create_topics_response("issue-57-topic", NOT_CONTROLLER),
+            )
+            .await;
+
+            if let Some((api_key, api_version, correlation_id, _)) = read_request(&mut stream).await
+            {
+                assert_eq!(api_key, ApiKey::Metadata);
+                write_response(
+                    &mut stream,
+                    api_key,
+                    api_version,
+                    correlation_id,
+                    &metadata_response(controller_addr),
+                )
+                .await;
+            }
+        });
+
+        let controller_task = tokio::spawn(async move {
+            let (mut stream, _) = controller_listener
+                .accept()
+                .await
+                .expect("accept controller connection");
+            let (api_key, api_version, correlation_id, _) = read_request(&mut stream)
+                .await
+                .expect("read controller create-topics request");
+            assert_eq!(api_key, ApiKey::CreateTopics);
+            write_response(
+                &mut stream,
+                api_key,
+                api_version,
+                correlation_id,
+                &create_topics_response("issue-57-topic", 0),
+            )
+            .await;
+        });
+
+        let client = KafkaClient::new(KafkaConfig {
+            bootstrap_servers: vec![bootstrap_addr.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection::default(),
+            connection: ConnectionConfig::default(),
+        });
+        client.connect().await.expect("connect to mock bootstrap");
+
+        let results = create_topics(
+            &client,
+            vec![TopicToCreate {
+                name: "issue-57-topic".to_string(),
+                num_partitions: 1,
+                replication_factor: -1,
+            }],
+            30_000,
+        )
+        .await
+        .expect("CreateTopics should retry NOT_CONTROLLER on the controller broker");
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_success());
+
+        bootstrap_task.abort();
+        controller_task.abort();
+    }
 
     #[test]
     fn test_create_topic_result_success() {
@@ -510,5 +747,74 @@ mod tests {
                 && err.to_string().contains("error_code=6"),
             "unexpected error: {err}"
         );
+    }
+
+    async fn read_request(stream: &mut TcpStream) -> Option<(ApiKey, i16, i32, Bytes)> {
+        let mut len_buf = [0u8; 4];
+        if stream.read_exact(&mut len_buf).await.is_err() {
+            return None;
+        }
+        let len = i32::from_be_bytes(len_buf) as usize;
+        let mut frame = vec![0u8; len];
+        if stream.read_exact(&mut frame).await.is_err() {
+            return None;
+        }
+
+        if frame.len() < 4 {
+            return None;
+        }
+        let api_key_raw = i16::from_be_bytes([frame[0], frame[1]]);
+        let api_version = i16::from_be_bytes([frame[2], frame[3]]);
+        let api_key = ApiKey::try_from(api_key_raw).expect("known api_key");
+        let header_version = api_key.request_header_version(api_version);
+
+        let mut frame_bytes = Bytes::from(frame);
+        let header =
+            RequestHeader::decode(&mut frame_bytes, header_version).expect("decode request header");
+
+        Some((api_key, api_version, header.correlation_id, frame_bytes))
+    }
+
+    async fn write_response<Resp: Encodable>(
+        stream: &mut TcpStream,
+        api_key: ApiKey,
+        api_version: i16,
+        correlation_id: i32,
+        response: &Resp,
+    ) {
+        let header_version = api_key.response_header_version(api_version);
+        let header = ResponseHeader::default().with_correlation_id(correlation_id);
+
+        let mut buf = BytesMut::new();
+        buf.put_i32(0);
+        header
+            .encode(&mut buf, header_version)
+            .expect("encode response header");
+        response
+            .encode(&mut buf, api_version)
+            .expect("encode response body");
+        let len = (buf.len() - 4) as i32;
+        buf[0..4].copy_from_slice(&len.to_be_bytes());
+
+        stream
+            .write_all(&buf)
+            .await
+            .expect("write response to mock client");
+    }
+
+    fn create_topics_response(topic: &str, error_code: i16) -> CreateTopicsResponse {
+        CreateTopicsResponse::default().with_topics(vec![CreatableTopicResult::default()
+            .with_name(TopicName(StrBytes::from_string(topic.to_string())))
+            .with_error_code(error_code)])
+    }
+
+    fn metadata_response(controller_addr: std::net::SocketAddr) -> MetadataResponse {
+        MetadataResponse::default()
+            .with_brokers(vec![MetadataResponseBroker::default()
+                .with_node_id(1.into())
+                .with_host(StrBytes::from_string(controller_addr.ip().to_string()))
+                .with_port(controller_addr.port() as i32)])
+            .with_controller_id(1.into())
+            .with_topics(vec![])
     }
 }

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -102,6 +102,10 @@ impl KafkaClient {
         }
     }
 
+    pub(super) fn config_clone(&self) -> KafkaConfig {
+        self.config.clone()
+    }
+
     /// Connect to the Kafka cluster
     pub async fn connect(&self) -> Result<()> {
         // Try each bootstrap server until one connects


### PR DESCRIPTION
## Summary
- add a protocol-level regression test for issue #57's `CreateTopics` `NOT_CONTROLLER` failure
- split topic creation into request, validation, and retry steps
- when `CreateTopics` returns Kafka error `41` (`NOT_CONTROLLER`), refresh metadata, locate `MetadataResponse.controller_id`, connect to that controller broker, and retry the failed topics once

## Why
`NOT_CONTROLLER` is a retriable Kafka protocol error. In ZooKeeper clusters behind ingress/load-balanced bootstrap endpoints, `CreateTopics` can land on a non-controller broker and return `code=41`. Previously core treated that topic-level result as terminal, which causes operator restores with `createTopics=true` to fail.

## Reproduction
Before the fix, the new test failed with:

```text
Kafka(Protocol("Failed to create topics: issue-57-topic: code=41, msg=Some(\"\")"))
```

The test now passes by simulating a bootstrap broker returning `NOT_CONTROLLER` and a controller broker accepting the retry.

## Local verification
- `cargo fmt --all -- --check`
- `cargo test -p kafka-backup-core create_topics_recovers_from_not_controller --lib -- --nocapture`
- `cargo test -p kafka-backup-core --lib`
- `cargo test -p kafka-backup-core --tests`
- `cargo test -p kafka-backup-core`
- `cargo clippy -p kafka-backup-core --all-targets -- -D warnings`
- `cargo check --workspace`

Note: `cargo clippy -p kafka-backup-core --all-targets --all-features -- -D warnings` is blocked on this local macOS environment by optional `libgssapi` symbols missing from the system GSSAPI headers before it reaches project code.
