### PR TITLE
perf(backup): pipeline segment compression/upload with fetching (~27% faster backups)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.7"
+version = "0.15.8"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -950,6 +950,12 @@ impl BackupPartitionContext {
         let mut current_offset = start_offset;
         let mut segments_written = 0u64;
 
+        // At most one segment is compressed/uploaded in the background while
+        // we keep fetching; this overlaps compression with fetch wait time
+        // without unbounded memory growth.
+        let segment_flusher = segment_writer.flusher();
+        let mut pending_flush: Option<tokio::task::JoinHandle<Result<SegmentMetadata>>> = None;
+
         // Fetch and store records in segments
         while current_offset < end_offset {
             let fetch_result = self.fetch_records(current_offset, end_offset).await;
@@ -1018,12 +1024,22 @@ impl BackupPartitionContext {
 
                 // Check if we should rotate
                 if segment_writer.should_rotate() {
-                    let seg_start = segment_writer.start_offset().unwrap();
-                    let key = self.segment_key(seg_start);
-                    if let Some(segment_metadata) = segment_writer.flush(&key).await? {
+                    // Wait for the previous in-flight segment first, so
+                    // manifest entries stay ordered and at most one sealed
+                    // segment is held in memory per partition.
+                    if let Some(handle) = pending_flush.take() {
+                        let segment_metadata = join_segment_flush(handle).await?;
                         self.add_segment_to_manifest(segment_metadata).await;
                         self.manifest_persistence.save_progress().await?;
                         segments_written += 1;
+                    }
+
+                    let seg_start = segment_writer.start_offset().unwrap();
+                    let key = self.segment_key(seg_start);
+                    if let Some(sealed) = segment_writer.seal(&key) {
+                        let flusher = segment_flusher.clone();
+                        pending_flush =
+                            Some(tokio::spawn(async move { flusher.write(sealed).await }));
                     }
                 }
             }
@@ -1068,6 +1084,14 @@ impl BackupPartitionContext {
             }
 
             current_offset = next_offset;
+        }
+
+        // Wait for any in-flight segment flush
+        if let Some(handle) = pending_flush.take() {
+            let segment_metadata = join_segment_flush(handle).await?;
+            self.add_segment_to_manifest(segment_metadata).await;
+            self.manifest_persistence.save_progress().await?;
+            segments_written += 1;
         }
 
         // Flush any remaining records
@@ -1155,6 +1179,15 @@ impl BackupPartitionContext {
 
         Ok((fetch_response.records, fetch_response.next_offset))
     }
+}
+
+/// Await a background segment flush task, surfacing panics as errors.
+async fn join_segment_flush(
+    handle: tokio::task::JoinHandle<Result<SegmentMetadata>>,
+) -> Result<SegmentMetadata> {
+    handle
+        .await
+        .map_err(|e| Error::Compression(format!("segment flush task failed: {e}")))?
 }
 
 async fn save_manifest_snapshot(

--- a/crates/kafka-backup-core/src/segment/writer.rs
+++ b/crates/kafka-backup-core/src/segment/writer.rs
@@ -36,6 +36,121 @@ impl Default for SegmentWriterConfig {
     }
 }
 
+/// A full segment taken out of a [`SegmentWriter`], ready to be compressed
+/// and uploaded independently of the writer (e.g. from a spawned task).
+pub struct SealedSegment {
+    key: String,
+    buffer: BytesMut,
+    record_count: u64,
+    start_offset: i64,
+    end_offset: i64,
+    start_timestamp: i64,
+    end_timestamp: i64,
+}
+
+/// Compresses and uploads [`SealedSegment`]s. Cheap to clone; holds only
+/// shared handles, so it can be moved into spawned tasks while the
+/// originating [`SegmentWriter`] keeps accumulating records.
+#[derive(Clone)]
+pub struct SegmentFlusher {
+    config: SegmentWriterConfig,
+    storage: Arc<dyn StorageBackend>,
+    metrics: Arc<PerformanceMetrics>,
+    prometheus_metrics: Option<Arc<PrometheusMetrics>>,
+    backup_id: String,
+}
+
+impl SegmentFlusher {
+    /// Compress a sealed segment and write it to storage.
+    pub async fn write(&self, sealed: SealedSegment) -> Result<SegmentMetadata> {
+        let start = std::time::Instant::now();
+
+        // Build header
+        let header = SegmentHeader {
+            version: super::format::VERSION,
+            compression: self.config.compression,
+            record_count: sealed.record_count,
+            start_offset: sealed.start_offset,
+            end_offset: sealed.end_offset,
+        };
+
+        // Compress record data off the async runtime (zstd on a 128MB
+        // segment takes hundreds of milliseconds of pure CPU)
+        let uncompressed_size = sealed.buffer.len();
+        let compression = self.config.compression;
+        let compression_level = self.config.compression_level;
+        let buffer = sealed.buffer;
+        let compressed_data = tokio::task::spawn_blocking(move || {
+            compression::compress_with_level(&buffer, compression, compression_level)
+        })
+        .await
+        .map_err(|e| crate::Error::Compression(format!("compression task failed: {e}")))??;
+
+        // Build final segment
+        let mut segment =
+            BytesMut::with_capacity(HEADER_SIZE + compressed_data.len() + FOOTER_SIZE);
+        segment.extend_from_slice(&header.to_bytes());
+        segment.extend_from_slice(&compressed_data);
+
+        // Calculate CRC and add footer
+        let crc = super::format::crc32(&segment);
+        segment.put_u32_le(crc);
+        segment.extend_from_slice(&MAGIC_END);
+
+        let compressed_size = segment.len();
+
+        // Write to storage
+        self.storage.put(&sealed.key, Bytes::from(segment)).await?;
+
+        // Update legacy metrics
+        self.metrics
+            .record_bytes(compressed_size as u64, uncompressed_size as u64);
+        self.metrics.record_records(sealed.record_count);
+        self.metrics.record_segment();
+        self.metrics.record_segment_write_latency(start.elapsed());
+
+        // Update Prometheus metrics
+        if let Some(ref prom) = self.prometheus_metrics {
+            let algorithm = format!("{:?}", self.config.compression).to_lowercase();
+            prom.record_compression(
+                &algorithm,
+                &self.backup_id,
+                compressed_size as u64,
+                uncompressed_size as u64,
+            );
+            prom.record_storage_write_latency(
+                "filesystem",
+                StorageOperation::Segment,
+                start.elapsed().as_secs_f64(),
+            );
+            prom.inc_storage_write_bytes("filesystem", &self.backup_id, compressed_size as u64);
+        }
+
+        // Build metadata
+        let metadata = SegmentMetadata {
+            key: sealed.key.clone(),
+            start_offset: sealed.start_offset,
+            end_offset: sealed.end_offset,
+            start_timestamp: sealed.start_timestamp,
+            end_timestamp: sealed.end_timestamp,
+            record_count: sealed.record_count as i64,
+            uncompressed_size: uncompressed_size as u64,
+            compressed_size: compressed_size as u64,
+        };
+
+        info!(
+            "Wrote segment {} with {} records ({} -> {} bytes, {:.1}x compression)",
+            sealed.key,
+            sealed.record_count,
+            uncompressed_size,
+            compressed_size,
+            uncompressed_size as f64 / compressed_size as f64
+        );
+
+        Ok(metadata)
+    }
+}
+
 /// Segment writer that accumulates records and writes segments to storage
 pub struct SegmentWriter {
     config: SegmentWriterConfig,
@@ -155,103 +270,48 @@ impl SegmentWriter {
         self.start_offset
     }
 
-    /// Flush the current segment to storage
-    pub async fn flush(&mut self, key: &str) -> Result<Option<SegmentMetadata>> {
+    /// Get a flusher that can compress/upload sealed segments independently
+    /// of this writer (e.g. from a spawned task).
+    pub fn flusher(&self) -> SegmentFlusher {
+        SegmentFlusher {
+            config: self.config.clone(),
+            storage: self.storage.clone(),
+            metrics: self.metrics.clone(),
+            prometheus_metrics: self.prometheus_metrics.clone(),
+            backup_id: self.backup_id.clone(),
+        }
+    }
+
+    /// Take the current segment out of the writer and reset it, so the
+    /// segment can be compressed/uploaded while new records accumulate.
+    /// Returns `None` if no records are buffered.
+    pub fn seal(&mut self, key: &str) -> Option<SealedSegment> {
         if self.record_count == 0 {
-            return Ok(None);
+            return None;
         }
 
-        let start = std::time::Instant::now();
-
-        // Build header
-        let header = SegmentHeader {
-            version: super::format::VERSION,
-            compression: self.config.compression,
+        let sealed = SealedSegment {
+            key: key.to_string(),
+            buffer: std::mem::replace(&mut self.buffer, BytesMut::with_capacity(1024 * 1024)),
             record_count: self.record_count,
             start_offset: self.start_offset.unwrap_or(-1),
             end_offset: self.end_offset.unwrap_or(-1),
-        };
-
-        // Compress record data
-        let uncompressed_size = self.buffer.len();
-        let compressed_data = compression::compress_with_level(
-            &self.buffer,
-            self.config.compression,
-            self.config.compression_level,
-        )?;
-
-        // Build final segment
-        let mut segment =
-            BytesMut::with_capacity(HEADER_SIZE + compressed_data.len() + FOOTER_SIZE);
-        segment.extend_from_slice(&header.to_bytes());
-        segment.extend_from_slice(&compressed_data);
-
-        // Calculate CRC and add footer
-        let crc = super::format::crc32(&segment);
-        segment.put_u32_le(crc);
-        segment.extend_from_slice(&MAGIC_END);
-
-        let compressed_size = segment.len();
-
-        // Write to storage
-        self.storage.put(key, Bytes::from(segment)).await?;
-
-        // Update legacy metrics
-        self.metrics
-            .record_bytes(compressed_size as u64, uncompressed_size as u64);
-        self.metrics.record_records(self.record_count);
-        self.metrics.record_segment();
-        self.metrics.record_segment_write_latency(start.elapsed());
-
-        // Update Prometheus metrics
-        if let Some(ref prom) = self.prometheus_metrics {
-            let algorithm = format!("{:?}", self.config.compression).to_lowercase();
-            prom.record_compression(
-                &algorithm,
-                &self.backup_id,
-                compressed_size as u64,
-                uncompressed_size as u64,
-            );
-            prom.record_storage_write_latency(
-                "filesystem",
-                StorageOperation::Segment,
-                start.elapsed().as_secs_f64(),
-            );
-            prom.inc_storage_write_bytes("filesystem", &self.backup_id, compressed_size as u64);
-        }
-
-        // Build metadata
-        let metadata = SegmentMetadata {
-            key: key.to_string(),
-            start_offset: self.start_offset.unwrap_or(0),
-            end_offset: self.end_offset.unwrap_or(0),
             start_timestamp: self.start_timestamp.unwrap_or(0),
             end_timestamp: self.end_timestamp.unwrap_or(0),
-            record_count: self.record_count as i64,
-            uncompressed_size: uncompressed_size as u64,
-            compressed_size: compressed_size as u64,
         };
+        self.reset();
+        Some(sealed)
+    }
 
-        info!(
-            "Wrote segment {} with {} records ({} -> {} bytes, {:.1}x compression)",
-            key,
-            self.record_count,
-            uncompressed_size,
-            compressed_size,
-            uncompressed_size as f64 / compressed_size as f64
-        );
-
-        // Reset state
-        self.buffer.clear();
-        self.record_count = 0;
-        self.start_offset = None;
-        self.end_offset = None;
-        self.start_timestamp = None;
-        self.end_timestamp = None;
-        self.segment_start_time = None;
-        self.uncompressed_bytes = 0;
-
-        Ok(Some(metadata))
+    /// Flush the current segment to storage
+    pub async fn flush(&mut self, key: &str) -> Result<Option<SegmentMetadata>> {
+        match self.seal(key) {
+            Some(sealed) => {
+                let metadata = self.flusher().write(sealed).await?;
+                Ok(Some(metadata))
+            }
+            None => Ok(None),
+        }
     }
 
     /// Reset writer state without writing


### PR DESCRIPTION
## Summary

Backup throughput improved **~27%** (8.1s → 5.9s median wall for a 976MB topic, ~120 → ~165 MB/s) by overlapping segment compression + upload with Kafka fetching.

## Problem (measured, not guessed)

Profiling a 1GB / 1M-record backup (4 partitions, local docker Kafka, `sample` + `/usr/bin/time`):

- zstd compression dominates backup CPU: ~3.7s of 4.6s user time per GB
- It adds ~2.4s of *wall* time because each partition's fetch loop stops dead while its 128MB segment is compressed inline (`compression: none` run: 5.8s vs 8.1s baseline)
- Per-record allocation overhead is <1s CPU/GB — not worth optimizing (verified)

## Change

- `SegmentWriter::seal()` — takes the full buffer + segment metadata out of the writer and resets it
- `SegmentFlusher::write()` — compresses (in `spawn_blocking`, off the async runtime) and uploads; holds only cheap `Arc` handles so it can run in a spawned task
- The backup loop now runs flush as a background task while it keeps fetching, with **at most one in-flight flush per partition**
- `flush()` is reimplemented as `seal()` + `write()` — single code path, existing API unchanged

## Correctness preserved

- Manifest entry is added only **after** the upload completes; segment ordering per partition unchanged
- Checkpoint/at-least-once semantics unchanged (flush errors surface on the next rotation or at loop end, before the manifest references the segment)
- All 368 tests pass; `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean
- `validate --deep`: 12/12 segments valid, 1,000,000 records
- Full CLI restore round-trip recovered exactly 1,000,000 records

## Trade-off

Peak RSS rises ~200MB (1.56GB → 1.75GB on the bench) — one sealed 128MB buffer can be held while the next fills.

## Benchmarks (median of 3 runs, 1M × 1KB records, 4 partitions)

| | before | after |
|---|---|---|
| wall time | 8.1s | 5.9s |
| throughput | ~120 MB/s | ~165 MB/s |

Also tried and **reverted** with evidence: raising the 16MB fetch cap to 32MB (no measurable gain — fetch is connection-serialization bound) and switching restore produce compression to LZ4 (kafka-protocol's LZ4 encoder is >2× slower than zstd).

Version bumped 0.15.7 → 0.15.8 (additive API only: new `SealedSegment` / `SegmentFlusher` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)