### PR TITLE
Fix metrics scrape window for short-lived batch jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.9] - 2026-07-07
+
+### Added
+- Add `metrics.keep_alive_seconds` for one-shot backup and restore jobs, keeping
+  the Prometheus metrics server alive after operation completion so short-lived
+  Kubernetes CronJobs can be scraped before the pod exits.
+
+### Fixed
+- Preserve immediate shutdown on SIGINT/SIGTERM during the post-completion
+  metrics keep-alive window, so Kubernetes termination signals are not delayed.
+
 ## [0.15.7] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.8"
+version = "0.15.9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.8"
+version = "0.15.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.8"
+version = "0.15.9"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/README.md
+++ b/README.md
@@ -330,7 +330,12 @@ kafka-backup exposes Prometheus metrics at `/metrics` for monitoring backup oper
 metrics:
   enabled: true
   port: 8080
+  keep_alive_seconds: 90  # Optional: final scrape window for short-lived CronJobs
 ```
+
+For one-shot Kubernetes CronJobs, set `keep_alive_seconds` to at least 2x your
+Prometheus scrape interval so the final metrics snapshot can be scraped before
+the pod exits. Keep the value within the pod termination grace period.
 
 **Key metrics:**
 - `kafka_backup_lag_records` — Consumer lag per partition

--- a/crates/kafka-backup-cli/src/commands/backup.rs
+++ b/crates/kafka-backup-cli/src/commands/backup.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
-use kafka_backup_core::{
-    backup::BackupEngine, Config, MetricsServer, MetricsServerConfig, PrometheusMetrics,
-};
+use kafka_backup_core::{backup::BackupEngine, Config, PrometheusMetrics};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::info;
@@ -22,60 +20,30 @@ pub async fn run(config_path: &str) -> Result<()> {
         metrics_config.max_partition_labels,
     ));
 
-    // Start metrics server if enabled
-    let (shutdown_tx, _) = broadcast::channel::<()>(1);
-    let metrics_server_handle = if metrics_config.enabled {
-        let server_config = MetricsServerConfig::new(
-            format!("{}:{}", metrics_config.bind_address, metrics_config.port)
-                .parse()
-                .unwrap_or_else(|_| "0.0.0.0:8080".parse().unwrap()),
-            metrics_config.path.clone(),
-        );
-
-        let server = MetricsServer::new(server_config, prometheus_metrics.clone());
-        let shutdown_rx = shutdown_tx.subscribe();
-
-        Some(tokio::spawn(async move {
-            if let Err(e) = server.run(shutdown_rx).await {
-                tracing::error!("Metrics server error: {}", e);
-            }
-        }))
-    } else {
-        None
-    };
+    let metrics_server = super::metrics_runtime::RunningMetricsServer::start(
+        &metrics_config,
+        prometheus_metrics.clone(),
+    );
 
     // Run the backup engine with Prometheus metrics
     let engine = BackupEngine::new_with_metrics(config, Some(prometheus_metrics)).await?;
 
     // Spawn signal handler for graceful shutdown (SIGTERM + SIGINT/Ctrl-C)
     let shutdown_tx_signal = engine.shutdown_handle();
-    let signal_task = tokio::spawn(async move {
-        #[cfg(unix)]
-        {
-            use tokio::signal::unix::{signal, SignalKind};
-            let mut sigterm =
-                signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {}
-                _ = sigterm.recv() => {}
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = tokio::signal::ctrl_c().await;
-        }
-        info!("Received shutdown signal, initiating graceful shutdown...");
-        let _ = shutdown_tx_signal.send(());
-    });
+    let (lifecycle_shutdown_tx, mut lifecycle_shutdown_rx) = broadcast::channel::<()>(1);
+    let signal_task = super::metrics_runtime::spawn_shutdown_signal_forwarder(
+        shutdown_tx_signal,
+        lifecycle_shutdown_tx,
+    );
 
     let result = engine.run().await;
-    signal_task.abort(); // Clean up signal watcher if engine finished normally
 
-    // Shutdown metrics server
-    let _ = shutdown_tx.send(());
-    if let Some(handle) = metrics_server_handle {
-        let _ = handle.await;
+    if let Some(metrics_server) = metrics_server {
+        metrics_server
+            .shutdown_after_operation(&mut lifecycle_shutdown_rx)
+            .await;
     }
+    signal_task.abort(); // Clean up signal watcher if operation finished normally
 
     result?;
     info!("Backup completed successfully");

--- a/crates/kafka-backup-cli/src/commands/metrics_runtime.rs
+++ b/crates/kafka-backup-cli/src/commands/metrics_runtime.rs
@@ -1,0 +1,145 @@
+use kafka_backup_core::{MetricsConfig, MetricsServer, MetricsServerConfig, PrometheusMetrics};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, Duration};
+use tracing::{info, warn};
+
+pub struct RunningMetricsServer {
+    shutdown_tx: broadcast::Sender<()>,
+    handle: JoinHandle<()>,
+    keep_alive_seconds: u64,
+}
+
+impl RunningMetricsServer {
+    pub fn start(
+        metrics_config: &MetricsConfig,
+        prometheus_metrics: Arc<PrometheusMetrics>,
+    ) -> Option<Self> {
+        if !metrics_config.enabled {
+            return None;
+        }
+
+        let (shutdown_tx, _) = broadcast::channel::<()>(1);
+        let server_config = MetricsServerConfig::new(
+            format!("{}:{}", metrics_config.bind_address, metrics_config.port)
+                .parse()
+                .unwrap_or_else(|_| "0.0.0.0:8080".parse().unwrap()),
+            metrics_config.path.clone(),
+        );
+
+        let server = MetricsServer::new(server_config, prometheus_metrics);
+        let shutdown_rx = shutdown_tx.subscribe();
+        let handle = tokio::spawn(async move {
+            if let Err(e) = server.run(shutdown_rx).await {
+                tracing::error!("Metrics server error: {}", e);
+            }
+        });
+
+        Some(Self {
+            shutdown_tx,
+            handle,
+            keep_alive_seconds: metrics_config.keep_alive_seconds,
+        })
+    }
+
+    pub async fn shutdown_after_operation(self, signal_rx: &mut broadcast::Receiver<()>) {
+        if self.handle.is_finished() {
+            warn!("Skipping metrics keep-alive because the metrics server is no longer running");
+        } else if wait_for_keep_alive(self.keep_alive_seconds, signal_rx).await {
+            info!("Shutdown signal received during metrics keep-alive");
+        }
+
+        let _ = self.shutdown_tx.send(());
+        let _ = self.handle.await;
+    }
+}
+
+pub fn spawn_shutdown_signal_forwarder(
+    operation_shutdown_tx: broadcast::Sender<()>,
+    lifecycle_shutdown_tx: broadcast::Sender<()>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        wait_for_shutdown_signal().await;
+        info!("Received shutdown signal, initiating graceful shutdown...");
+        let _ = operation_shutdown_tx.send(());
+        let _ = lifecycle_shutdown_tx.send(());
+    })
+}
+
+async fn wait_for_keep_alive(
+    keep_alive_seconds: u64,
+    signal_rx: &mut broadcast::Receiver<()>,
+) -> bool {
+    if keep_alive_seconds == 0 {
+        return false;
+    }
+
+    info!(
+        "Keeping metrics server alive for {} seconds after operation completion",
+        keep_alive_seconds
+    );
+
+    tokio::select! {
+        _ = sleep(Duration::from_secs(keep_alive_seconds)) => false,
+        result = signal_rx.recv() => {
+            if let Err(e) = result {
+                warn!("Metrics keep-alive signal channel closed: {}", e);
+            }
+            true
+        }
+    }
+}
+
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::timeout;
+
+    #[tokio::test]
+    async fn keep_alive_zero_returns_immediately() {
+        let (_tx, mut rx) = broadcast::channel::<()>(1);
+
+        timeout(Duration::from_millis(20), wait_for_keep_alive(0, &mut rx))
+            .await
+            .expect("zero keep-alive should not wait");
+    }
+
+    #[tokio::test]
+    async fn keep_alive_is_interrupted_by_signal() {
+        let (tx, mut rx) = broadcast::channel::<()>(1);
+        let _ = tx.send(());
+
+        let interrupted = timeout(Duration::from_millis(20), wait_for_keep_alive(60, &mut rx))
+            .await
+            .expect("signal should interrupt keep-alive promptly");
+
+        assert!(interrupted);
+    }
+
+    #[tokio::test]
+    async fn keep_alive_waits_without_signal() {
+        let (_tx, mut rx) = broadcast::channel::<()>(1);
+
+        let result = timeout(Duration::from_millis(20), wait_for_keep_alive(60, &mut rx)).await;
+
+        assert!(result.is_err(), "keep-alive should wait without a signal");
+    }
+}

--- a/crates/kafka-backup-cli/src/commands/mod.rs
+++ b/crates/kafka-backup-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod config;
 pub mod describe;
 pub mod list;
+pub mod metrics_runtime;
 pub mod offset_mapping;
 pub mod offset_reset;
 pub mod offset_reset_bulk;

--- a/crates/kafka-backup-cli/src/commands/restore.rs
+++ b/crates/kafka-backup-cli/src/commands/restore.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
-use kafka_backup_core::{
-    restore::RestoreEngine, Config, MetricsServer, MetricsServerConfig, PrometheusMetrics,
-};
+use kafka_backup_core::{restore::RestoreEngine, Config, PrometheusMetrics};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::info;
@@ -22,60 +20,28 @@ pub async fn run(config_path: &str) -> Result<()> {
         metrics_config.max_partition_labels,
     ));
 
-    // Start metrics server if enabled
-    let (shutdown_tx, _) = broadcast::channel::<()>(1);
-    let metrics_server_handle = if metrics_config.enabled {
-        let server_config = MetricsServerConfig::new(
-            format!("{}:{}", metrics_config.bind_address, metrics_config.port)
-                .parse()
-                .unwrap_or_else(|_| "0.0.0.0:8080".parse().unwrap()),
-            metrics_config.path.clone(),
-        );
-
-        let server = MetricsServer::new(server_config, prometheus_metrics.clone());
-        let shutdown_rx = shutdown_tx.subscribe();
-
-        Some(tokio::spawn(async move {
-            if let Err(e) = server.run(shutdown_rx).await {
-                tracing::error!("Metrics server error: {}", e);
-            }
-        }))
-    } else {
-        None
-    };
+    let metrics_server =
+        super::metrics_runtime::RunningMetricsServer::start(&metrics_config, prometheus_metrics);
 
     // Run the restore engine
     let engine = RestoreEngine::new(config)?;
 
     // Spawn signal handler for graceful shutdown (SIGTERM + SIGINT/Ctrl-C)
     let shutdown_tx_signal = engine.shutdown_handle();
-    let signal_task = tokio::spawn(async move {
-        #[cfg(unix)]
-        {
-            use tokio::signal::unix::{signal, SignalKind};
-            let mut sigterm =
-                signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
-            tokio::select! {
-                _ = tokio::signal::ctrl_c() => {}
-                _ = sigterm.recv() => {}
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = tokio::signal::ctrl_c().await;
-        }
-        info!("Received shutdown signal, initiating graceful shutdown...");
-        let _ = shutdown_tx_signal.send(());
-    });
+    let (lifecycle_shutdown_tx, mut lifecycle_shutdown_rx) = broadcast::channel::<()>(1);
+    let signal_task = super::metrics_runtime::spawn_shutdown_signal_forwarder(
+        shutdown_tx_signal,
+        lifecycle_shutdown_tx,
+    );
 
     let result = engine.run().await;
-    signal_task.abort(); // Clean up signal watcher if engine finished normally
 
-    // Shutdown metrics server
-    let _ = shutdown_tx.send(());
-    if let Some(handle) = metrics_server_handle {
-        let _ = handle.await;
+    if let Some(metrics_server) = metrics_server {
+        metrics_server
+            .shutdown_after_operation(&mut lifecycle_shutdown_rx)
+            .await;
     }
+    signal_task.abort(); // Clean up signal watcher if operation finished normally
 
     result?;
     info!("Restore completed successfully");

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -64,6 +64,11 @@ pub struct MetricsConfig {
     #[serde(default = "default_metrics_update_interval_ms")]
     pub update_interval_ms: u64,
 
+    /// Keep serving metrics for this many seconds after a one-shot operation
+    /// completes (default: 0).
+    #[serde(default = "default_metrics_keep_alive_seconds")]
+    pub keep_alive_seconds: u64,
+
     /// Maximum partition labels to prevent cardinality explosion (default: 100)
     #[serde(default = "default_max_partition_labels")]
     pub max_partition_labels: usize,
@@ -77,6 +82,7 @@ impl Default for MetricsConfig {
             bind_address: default_metrics_bind_address(),
             path: default_metrics_path(),
             update_interval_ms: default_metrics_update_interval_ms(),
+            keep_alive_seconds: default_metrics_keep_alive_seconds(),
             max_partition_labels: default_max_partition_labels(),
         }
     }
@@ -100,6 +106,10 @@ fn default_metrics_path() -> String {
 
 fn default_metrics_update_interval_ms() -> u64 {
     500
+}
+
+fn default_metrics_keep_alive_seconds() -> u64 {
+    0
 }
 
 fn default_max_partition_labels() -> usize {
@@ -1003,6 +1013,25 @@ bootstrap_servers:
         assert_eq!(config.connection.keepalive_time_secs, 60);
         assert_eq!(config.connection.keepalive_interval_secs, 20);
         assert!(config.connection.tcp_nodelay);
+    }
+
+    #[test]
+    fn test_metrics_config_defaults() {
+        let config = MetricsConfig::default();
+        assert_eq!(config.keep_alive_seconds, 0);
+    }
+
+    #[test]
+    fn test_metrics_config_keep_alive_yaml() {
+        let yaml = r#"
+enabled: true
+port: 8080
+bind_address: "0.0.0.0"
+path: "/metrics"
+keep_alive_seconds: 90
+"#;
+        let config: MetricsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.keep_alive_seconds, 90);
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -481,14 +481,22 @@ Configuration for the Prometheus metrics and health check HTTP server.
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `metrics.enabled` | bool | No | `false` | Enable the metrics HTTP server |
+| `metrics.enabled` | bool | No | `true` | Enable the metrics HTTP server |
 | `metrics.port` | int | No | `8080` | Port for the metrics server |
-| `metrics.bind_address` | string | No | `127.0.0.1` | Bind address (use `0.0.0.0` for Kubernetes) |
+| `metrics.bind_address` | string | No | `0.0.0.0` | Bind address (use `0.0.0.0` for Kubernetes Service routing) |
 | `metrics.path` | string | No | `/metrics` | Path for the Prometheus metrics endpoint |
+| `metrics.keep_alive_seconds` | int | No | `0` | Keep serving metrics for N seconds after one-shot backup or restore completion |
 
 When enabled, the server exposes:
 - `GET /metrics` — Prometheus/OpenMetrics scrape endpoint
 - `GET /health` — Liveness check (returns 200 OK)
+
+For short-lived CronJob backups or restores, set `keep_alive_seconds` to at
+least 2x your Prometheus scrape interval so Prometheus has more than one chance
+to scrape the final metrics snapshot. For example, use `60` to `90` seconds
+with a 30 second scrape interval. In Kubernetes, ensure
+`terminationGracePeriodSeconds` and any Job `activeDeadlineSeconds` account for
+this extra serving window.
 
 ### Example
 
@@ -498,9 +506,12 @@ metrics:
   port: 8080
   bind_address: "0.0.0.0"   # Required for Kubernetes Service routing
   path: "/metrics"
+  keep_alive_seconds: 90     # Optional: useful for short-lived CronJobs
 ```
 
-> **Kubernetes note:** Set `bind_address: "0.0.0.0"` when running in Kubernetes. The default `127.0.0.1` only accepts localhost connections and will not be reachable via a Service.
+> **Kubernetes note:** `bind_address: "0.0.0.0"` is required for Kubernetes
+> Service routing. `keep_alive_seconds` extends the pod lifetime after work
+> completes; keep it within the pod termination grace period.
 
 ### Key Metrics
 

--- a/docs/storage_guide.md
+++ b/docs/storage_guide.md
@@ -610,9 +610,13 @@ data:
       port: 8080
       bind_address: "0.0.0.0"  # Required for K8s - allows Service routing
       path: "/metrics"
+      keep_alive_seconds: 90   # Optional for short-lived CronJobs
 ```
 
-> **Important:** When running in Kubernetes, set `bind_address: "0.0.0.0"` to allow the Service to route traffic to the metrics endpoint. The default `127.0.0.1` only accepts localhost connections.
+> **Important:** When running in Kubernetes, bind to `0.0.0.0` to allow the
+> Service to route traffic to the metrics endpoint. For short-lived CronJobs,
+> set `keep_alive_seconds` to at least 2x your Prometheus scrape interval and
+> keep it within the pod termination grace period.
 
 #### Secret (AWS Credentials)
 
@@ -743,11 +747,12 @@ spec:
   schedule: "0 */6 * * *"  # Every 6 hours
   jobTemplate:
     spec:
-      template:
-        spec:
-          containers:
-            - name: kafka-backup
-              image: kafka-backup:latest
+          template:
+            spec:
+              terminationGracePeriodSeconds: 120
+              containers:
+                - name: kafka-backup
+                  image: kafka-backup:latest
               args:
                 - backup
                 - --config


### PR DESCRIPTION
## Summary
- add metrics.keep_alive_seconds with a default of 0 for backwards compatibility
- keep the metrics server alive after one-shot backup and restore completion when configured
- allow SIGINT/SIGTERM to interrupt the keep-alive window for Kubernetes termination behavior
- document CronJob sizing guidance and bump the workspace version to 0.15.9

Fixes #120.

## Verification
- cargo fmt --all -- --check
- cargo check --workspace --no-default-features
- cargo test -p kafka-backup-core test_metrics_config --no-default-features
- cargo test -p kafka-backup-cli metrics_runtime --no-default-features
- cargo test --workspace --no-default-features
- PKG_CONFIG_PATH=/opt/homebrew/opt/krb5/lib/pkgconfig CFLAGS='-I/opt/homebrew/opt/krb5/include' LDFLAGS='-L/opt/homebrew/opt/krb5/lib' cargo clippy --all-targets --all-features -- -D warnings
- PKG_CONFIG_PATH=/opt/homebrew/opt/krb5/lib/pkgconfig CFLAGS='-I/opt/homebrew/opt/krb5/include' LDFLAGS='-L/opt/homebrew/opt/krb5/lib' cargo test --lib --all-features
- PKG_CONFIG_PATH=/opt/homebrew/opt/krb5/lib/pkgconfig CFLAGS='-I/opt/homebrew/opt/krb5/include' LDFLAGS='-L/opt/homebrew/opt/krb5/lib' cargo test --test unit_tests --all-features
- python3 scripts/ci/check-release-version.py --base-ref origin/main --mode guard --event-name pull_request
- docker build -t kafka-backup:issue120-keepalive .
- docker run --rm kafka-backup:issue120-keepalive --version
- docker run --rm kafka-backup:issue120-keepalive --help >/dev/null
- docker run --rm --entrypoint ldd kafka-backup:issue120-keepalive /usr/local/bin/kafka-backup
- local Kafka repro: empty one-shot backup completed in 0.01s, /metrics returned HTTP 200 throughout a 3s keep-alive, then exited cleanly
- local SIGTERM repro: 30s keep-alive interrupted by SIGTERM and exited in ~165ms with exit code 0