### PR TITLE
fix(metrics): correct storage backend label and doubled _total suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.12] - 2026-07-21
+
+### Fixed
+- Label segment storage write metrics (`kafka_backup_storage_write_bytes_total`,
+  `kafka_backup_storage_write_latency_seconds`) with the storage backend that
+  was actually written to (`s3`, `azure`, `gcs`, `filesystem`, `memory`)
+  instead of a hardcoded `filesystem`. Addresses
+  [strimzi-backup-operator#50](https://github.com/osodevops/strimzi-backup-operator/issues/50).
+- Register counters without an explicit `_total` suffix so exposed series match
+  the documented names (e.g. `kafka_backup_records_total`) instead of carrying
+  a doubled suffix (`kafka_backup_records_total_total`); `prometheus-client`
+  appends `_total` to counters at encode time. Dashboards or alerts built on
+  the doubled names must move to the documented single-`_total` names.
+
 ## [0.15.11] - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.11"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.11"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.11"
+version = "0.15.12"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/src/commands/status_watch.rs
+++ b/crates/kafka-backup-cli/src/commands/status_watch.rs
@@ -232,7 +232,10 @@ fn parse_prometheus_metrics(text: &str) -> ParsedMetrics {
                 | "kafka_backup_segments_written_total" => {
                     metrics.segments_written = value as u64;
                 }
-                "kafka_backup_storage_write_bytes_total_total" if metrics.bytes_total == 0 => {
+                "kafka_backup_storage_write_bytes_total"
+                | "kafka_backup_storage_write_bytes_total_total"
+                    if metrics.bytes_total == 0 =>
+                {
                     metrics.bytes_total = value as u64;
                 }
                 "kafka_backup_throughput_records_per_second" => {

--- a/crates/kafka-backup-core/src/metrics/instrumented_storage.rs
+++ b/crates/kafka-backup-core/src/metrics/instrumented_storage.rs
@@ -70,11 +70,6 @@ impl InstrumentedStorageBackend {
         }
     }
 
-    /// Get the backend name.
-    pub fn backend_name(&self) -> &str {
-        &self.backend_name
-    }
-
     /// Get the inner storage backend.
     pub fn inner(&self) -> &Arc<dyn StorageBackend> {
         &self.inner
@@ -95,6 +90,10 @@ impl InstrumentedStorageBackend {
 
 #[async_trait]
 impl StorageBackend for InstrumentedStorageBackend {
+    fn backend_name(&self) -> &str {
+        &self.backend_name
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let operation = self.classify_operation(key);
         let bytes_len = data.len() as u64;

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -295,12 +295,12 @@ impl PrometheusMetrics {
             throughput_bytes_per_sec.clone(),
         );
         registry.register(
-            "kafka_backup_records_total",
+            "kafka_backup_records",
             "Cumulative records backed up",
             records_total.clone(),
         );
         registry.register(
-            "kafka_backup_bytes_total",
+            "kafka_backup_bytes",
             "Cumulative bytes backed up",
             bytes_total.clone(),
         );
@@ -329,17 +329,17 @@ impl PrometheusMetrics {
             storage_read_latency_seconds.clone(),
         );
         registry.register(
-            "kafka_backup_storage_write_bytes_total",
+            "kafka_backup_storage_write_bytes",
             "Cumulative bytes written to storage",
             storage_write_bytes_total.clone(),
         );
         registry.register(
-            "kafka_backup_storage_read_bytes_total",
+            "kafka_backup_storage_read_bytes",
             "Cumulative bytes read from storage",
             storage_read_bytes_total.clone(),
         );
         registry.register(
-            "kafka_backup_storage_errors_total",
+            "kafka_backup_storage_errors",
             "Storage operation errors by type",
             storage_errors_total.clone(),
         );
@@ -351,24 +351,24 @@ impl PrometheusMetrics {
             compression_ratio.clone(),
         );
         registry.register(
-            "kafka_backup_compressed_bytes_total",
+            "kafka_backup_compressed_bytes",
             "Cumulative bytes after compression",
             compressed_bytes_total.clone(),
         );
         registry.register(
-            "kafka_backup_uncompressed_bytes_total",
+            "kafka_backup_uncompressed_bytes",
             "Cumulative bytes before compression",
             uncompressed_bytes_total.clone(),
         );
 
         // Error & Health Metrics
         registry.register(
-            "kafka_backup_errors_total",
+            "kafka_backup_errors",
             "Cumulative errors by category",
             errors_total.clone(),
         );
         registry.register(
-            "kafka_backup_retries_total",
+            "kafka_backup_retries",
             "Cumulative retries by operation",
             retries_total.clone(),
         );
@@ -378,7 +378,7 @@ impl PrometheusMetrics {
             last_successful_commit.clone(),
         );
         registry.register(
-            "kafka_backup_consumer_rebalance_total",
+            "kafka_backup_consumer_rebalance",
             "Number of consumer group rebalances",
             consumer_rebalance_total.clone(),
         );
@@ -400,7 +400,7 @@ impl PrometheusMetrics {
             restore_throughput_records_per_sec.clone(),
         );
         registry.register(
-            "kafka_restore_records_total",
+            "kafka_restore_records",
             "Cumulative records restored",
             restore_records_total.clone(),
         );
@@ -912,7 +912,7 @@ mod tests {
         metrics.record_error("backup-001", ErrorType::BrokerConnection);
 
         let encoded = metrics.encode();
-        assert!(encoded.contains("kafka_backup_errors_total"));
+        assert!(encoded.contains("kafka_backup_errors"));
         assert!(encoded.contains("broker_connection"));
     }
 
@@ -923,7 +923,7 @@ mod tests {
 
         let encoded = metrics.encode();
         assert!(encoded.contains("kafka_backup_compression_ratio"));
-        assert!(encoded.contains("kafka_backup_compressed_bytes_total"));
+        assert!(encoded.contains("kafka_backup_compressed_bytes"));
     }
 
     #[test]
@@ -1031,6 +1031,42 @@ mod tests {
         // Check for Prometheus text format markers
         assert!(encoded.contains("# HELP"));
         assert!(encoded.contains("# TYPE"));
-        assert!(encoded.contains("kafka_backup_records_total"));
+        assert!(encoded.contains("kafka_backup_records_total{"));
+    }
+
+    #[test]
+    fn counters_expose_single_total_suffix() {
+        // prometheus-client appends `_total` to counters at encode time, so
+        // registering counters with an explicit `_total` produced names like
+        // `kafka_backup_records_total_total` (operator issue #50).
+        let metrics = PrometheusMetrics::new();
+        metrics.inc_records("backup-001", 100);
+        metrics.inc_bytes("backup-001", 1024);
+        metrics.inc_storage_write_bytes("s3", "backup-001", 2048);
+        metrics.inc_storage_read_bytes("s3", "backup-001", 512);
+        metrics.inc_storage_error("s3", ErrorType::StorageIo);
+        metrics.record_compression("zstd", "backup-001", 100, 400);
+        metrics.record_error("backup-001", ErrorType::BrokerConnection);
+        metrics.record_retry("backup-001", "fetch");
+        metrics.record_rebalance("backup-001");
+        metrics.inc_restore_records("restore-001", 10);
+
+        let encoded = metrics.encode();
+        assert!(!encoded.contains("_total_total"));
+        for name in [
+            "kafka_backup_records_total{",
+            "kafka_backup_bytes_total{",
+            "kafka_backup_storage_write_bytes_total{",
+            "kafka_backup_storage_read_bytes_total{",
+            "kafka_backup_storage_errors_total{",
+            "kafka_backup_compressed_bytes_total{",
+            "kafka_backup_uncompressed_bytes_total{",
+            "kafka_backup_errors_total{",
+            "kafka_backup_retries_total{",
+            "kafka_backup_consumer_rebalance_total{",
+            "kafka_restore_records_total{",
+        ] {
+            assert!(encoded.contains(name), "missing counter series: {name}");
+        }
     }
 }

--- a/crates/kafka-backup-core/src/segment/writer.rs
+++ b/crates/kafka-backup-core/src/segment/writer.rs
@@ -118,12 +118,13 @@ impl SegmentFlusher {
                 compressed_size as u64,
                 uncompressed_size as u64,
             );
+            let backend = self.storage.backend_name();
             prom.record_storage_write_latency(
-                "filesystem",
+                backend,
                 StorageOperation::Segment,
                 start.elapsed().as_secs_f64(),
             );
-            prom.inc_storage_write_bytes("filesystem", &self.backup_id, compressed_size as u64);
+            prom.inc_storage_write_bytes(backend, &self.backup_id, compressed_size as u64);
         }
 
         // Build metadata
@@ -365,6 +366,42 @@ mod tests {
 
         // Verify file exists
         assert!(storage.exists("test-segment.bin").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_segment_flush_labels_actual_backend() {
+        use crate::metrics::PrometheusMetrics;
+        use crate::storage::MemoryBackend;
+
+        let storage = Arc::new(MemoryBackend::new());
+        let metrics = Arc::new(PerformanceMetrics::new());
+        let prometheus = Arc::new(PrometheusMetrics::new());
+        let config = SegmentWriterConfig::default();
+
+        let mut writer = SegmentWriter::with_prometheus(
+            config,
+            storage,
+            metrics,
+            Some(prometheus.clone()),
+            "backend-label-test".to_string(),
+        );
+
+        writer
+            .add_record(BinaryRecord {
+                timestamp: 1000,
+                offset: 0,
+                key: None,
+                value: Some(Bytes::from("value")),
+                headers: vec![],
+            })
+            .unwrap();
+        writer.flush("test-segment.bin").await.unwrap().unwrap();
+
+        // The storage metrics must be labelled with the backend that was
+        // actually written to, not a hardcoded "filesystem" (operator issue #50).
+        let encoded = prometheus.encode();
+        assert!(encoded.contains("kafka_backup_storage_write_bytes_total{backend=\"memory\",backup_id=\"backend-label-test\"}"));
+        assert!(!encoded.contains("backend=\"filesystem\""));
     }
 
     #[tokio::test]

--- a/crates/kafka-backup-core/src/storage/azure.rs
+++ b/crates/kafka-backup-core/src/storage/azure.rs
@@ -165,6 +165,10 @@ impl AzureBackend {
 
 #[async_trait]
 impl StorageBackend for AzureBackend {
+    fn backend_name(&self) -> &str {
+        "azure"
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let path = self.full_path(key);
         debug!("Azure PUT: {}", path);

--- a/crates/kafka-backup-core/src/storage/backend.rs
+++ b/crates/kafka-backup-core/src/storage/backend.rs
@@ -19,6 +19,12 @@ pub struct ObjectMetadata {
 /// Trait for storage backends
 #[async_trait]
 pub trait StorageBackend: Send + Sync {
+    /// Short backend identifier used as the `backend` label on storage
+    /// metrics (e.g. "s3", "azure", "gcs", "filesystem", "memory").
+    fn backend_name(&self) -> &str {
+        "unknown"
+    }
+
     /// Write data to a key
     async fn put(&self, key: &str, data: Bytes) -> Result<()>;
 

--- a/crates/kafka-backup-core/src/storage/filesystem.rs
+++ b/crates/kafka-backup-core/src/storage/filesystem.rs
@@ -39,6 +39,10 @@ impl FilesystemBackend {
 
 #[async_trait]
 impl StorageBackend for FilesystemBackend {
+    fn backend_name(&self) -> &str {
+        "filesystem"
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let path = self.key_to_path(key);
 

--- a/crates/kafka-backup-core/src/storage/gcs.rs
+++ b/crates/kafka-backup-core/src/storage/gcs.rs
@@ -84,6 +84,10 @@ impl GcsBackend {
 
 #[async_trait]
 impl StorageBackend for GcsBackend {
+    fn backend_name(&self) -> &str {
+        "gcs"
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let path = self.full_path(key);
         debug!("GCS PUT: {}", path);

--- a/crates/kafka-backup-core/src/storage/memory.rs
+++ b/crates/kafka-backup-core/src/storage/memory.rs
@@ -36,6 +36,10 @@ impl Default for MemoryBackend {
 
 #[async_trait]
 impl StorageBackend for MemoryBackend {
+    fn backend_name(&self) -> &str {
+        "memory"
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let path = Path::from(key);
         self.store

--- a/crates/kafka-backup-core/src/storage/s3.rs
+++ b/crates/kafka-backup-core/src/storage/s3.rs
@@ -107,6 +107,10 @@ impl S3Backend {
 
 #[async_trait]
 impl StorageBackend for S3Backend {
+    fn backend_name(&self) -> &str {
+        "s3"
+    }
+
     async fn put(&self, key: &str, data: Bytes) -> Result<()> {
         let path = self.full_path(key);
         debug!("S3 PUT: {}", path);


### PR DESCRIPTION
## Summary

Fixes the two metric defects reported in [strimzi-backup-operator#50](https://github.com/osodevops/strimzi-backup-operator/issues/50):

- **`backend="filesystem"` on S3 backups** — `SegmentFlusher::write` hardcoded `"filesystem"` when recording `kafka_backup_storage_write_bytes_total` and `kafka_backup_storage_write_latency_seconds`, regardless of the configured backend. `StorageBackend` now exposes a `backend_name()` method (`s3`, `azure`, `gcs`, `filesystem`, `memory`) and the flusher labels metrics with the backend it actually wrote to. To be clear for the reporter: segments were always streamed directly to object storage — only the label was wrong, no PVC is needed.
- **Doubled `_total_total` suffix** — counters were registered with an explicit `_total` suffix, but `prometheus-client` appends `_total` to counters at encode time, so series were exposed as e.g. `kafka_backup_records_total_total` / `kafka_backup_storage_write_bytes_total_total`. Counters are now registered un-suffixed, so exposed series finally match the names documented in `docs/configuration.md` (`kafka_backup_records_total`, `kafka_backup_storage_write_bytes_total`, …). `status-watch` continues to accept the old doubled names so it can watch pre-0.15.12 endpoints.

> **Breaking (dashboards only):** any dashboard/alert built on the doubled `*_total_total` names must move to the documented single-`_total` names.

The third symptom in that issue — static `kafka_backup_lag_records` / `kafka_backup_lag_records_sum` / `kafka_backup_snapshot_records_remaining` — is the cardinality-budget freeze already fixed in v0.15.11 (#131): the reporter's long-running job predates the v0.15.11 image rollout. Verified below that v0.15.11+ gauges track progress correctly.

## Verification

Reproduced locally against `apache/kafka:3.7.1` + MinIO with 3.2M records (~1.9GB) in a 6-partition topic, snapshot mode (`stop_at_current_offsets: true`), scraping `/metrics` every 400ms during the run:

| | v0.15.10 image behaviour | this branch |
|---|---|---|
| `kafka_backup_lag_records` | frozen at initial values for entire run | counts down to 0 per partition |
| `kafka_backup_snapshot_records_remaining` | absent | 3,191,285 → 0 |
| `kafka_backup_lag_records_sum` | absent | 3,191,285 → 0 |
| storage write bytes | `kafka_backup_storage_write_bytes_total_total{backend="filesystem"}` | `kafka_backup_storage_write_bytes_total{backend="s3"}` |

- `cargo test --workspace` — 259 tests pass, including new regression tests:
  - `counters_expose_single_total_suffix` (no `_total_total` anywhere in encoded output)
  - `test_segment_flush_labels_actual_backend` (flusher labels the real backend, never a hardcoded `filesystem`)
- `cargo clippy --workspace --all-targets -- -D warnings` clean

## Follow-ups

- kafka-backup-docs `reference/metrics.md` documents the `_total_total` names and should be updated to the single-`_total` form once this ships.
- strimzi-backup-operator `DEFAULT_BACKUP_IMAGE` should be bumped to `v0.15.12` after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)