### PR TITLE
fix(fetch): advance past compacted batch tails to prevent stalled backups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       # *binaries* don't include gssapi (cargo-dist uses default features), so
       # only the pre-release test step here needs the krb5 headers.
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -27,7 +27,7 @@ jobs:
       # which includes the `gssapi` feature. `libgssapi-sys` requires krb5
       # development headers to generate its bindings.
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Run cargo-semver-checks
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       # `libgssapi-sys`'s build.rs needs the krb5 development headers to
       # generate bindings; only the runtime `.so` ships on default runners.
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -79,7 +79,7 @@ jobs:
           toolchain: stable
 
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -122,7 +122,7 @@ jobs:
           toolchain: stable
 
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -173,7 +173,7 @@ jobs:
           toolchain: stable
 
       - name: Install krb5 development headers
-        run: sudo apt-get install -y libkrb5-dev
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,13 +1370,14 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32c",
  "crc32fast",
  "futures",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.12"
+version = "0.15.13"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/Cargo.toml
+++ b/crates/kafka-backup-core/Cargo.toml
@@ -105,6 +105,7 @@ default = []
 gssapi = ["dep:libgssapi"]
 
 [dev-dependencies]
+crc32c = "0.6"
 testcontainers.workspace = true
 testcontainers-modules.workspace = true
 tempfile.workspace = true

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -993,7 +993,11 @@ impl BackupPartitionContext {
             self.kafka_cb.record_success();
             self.health.mark_healthy("kafka");
 
-            if records.is_empty() {
+            // A fetch can return zero records yet still advance the offset:
+            // on compacted topics the log cleaner may have removed every
+            // record in the fetched batches. Only "no records and no
+            // progress" means we have reached the end of available data.
+            if records.is_empty() && next_offset <= current_offset {
                 break;
             }
 
@@ -1058,9 +1062,12 @@ impl BackupPartitionContext {
                 }
             }
 
-            // Update offset tracking
+            // Update offset tracking. Checkpoint the end of the fetched
+            // batches rather than the last record: on compacted topics the
+            // trailing records of a batch may no longer exist, and resuming
+            // there would re-read the whole batch.
             if let Some(ref offset_store) = self.offset_store {
-                let last_offset = records.last().map(|r| r.offset).unwrap_or(current_offset);
+                let last_offset = next_offset - 1;
                 offset_store
                     .set_offset(&self.backup_id, &self.topic, self.partition, last_offset)
                     .await?;

--- a/crates/kafka-backup-core/src/kafka/fetch.rs
+++ b/crates/kafka-backup-core/src/kafka/fetch.rs
@@ -1,6 +1,6 @@
 //! Kafka Fetch API implementation.
 
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use kafka_protocol::messages::{
     ApiKey, BrokerId, FetchRequest, FetchResponse as KafkaFetchResponse, ListOffsetsRequest,
     TopicName,
@@ -96,11 +96,9 @@ pub async fn fetch(
             // Decode record batches
             if let Some(ref records_data) = partition_response.records {
                 if !records_data.is_empty() {
-                    let decoded = decode_records(records_data)?;
-                    for record in decoded {
-                        next_offset = record.offset + 1;
-                        records.push(record);
-                    }
+                    let (decoded, batch_next_offset) = decode_fetch_data(records_data, offset)?;
+                    records = decoded;
+                    next_offset = batch_next_offset;
                 }
             }
         }
@@ -124,36 +122,78 @@ pub async fn fetch(
     })
 }
 
-/// Decode records from raw bytes.
-///
-/// The Kafka Fetch response may contain a truncated record batch at the end
-/// when the response hits max_bytes. We decode batches in a loop and tolerate
-/// a decode error on the final (partial) batch.
-fn decode_records(data: &Bytes) -> Result<Vec<BackupRecord>> {
-    let mut buf = data.clone();
-    let mut records = Vec::new();
+/// Byte positions within a v2 record batch: base_offset 0..8,
+/// batch_length 8..12 (length of everything after itself), then
+/// partition_leader_epoch, magic, crc, attributes, last_offset_delta 23..27.
+const BATCH_LENGTH_END: usize = 12;
+const LAST_OFFSET_DELTA_RANGE: std::ops::Range<usize> = 23..27;
 
-    while buf.has_remaining() {
-        match RecordBatchDecoder::decode(&mut buf) {
-            Ok(record_set) => {
-                for record in &record_set.records {
-                    records.push(convert_record(record));
-                }
-            }
-            Err(_) if !records.is_empty() => {
-                // Truncated trailing batch — safe to ignore since we already
-                // decoded at least one complete batch.
-                break;
-            }
-            Err(e) => {
-                return Err(
-                    KafkaError::Protocol(format!("Failed to decode records: {:?}", e)).into(),
-                );
+/// Decode fetched record data and compute the next offset to fetch.
+///
+/// Records below `fetch_offset` are filtered out: the broker returns whole
+/// batches, so a fetch offset inside a batch also returns the records before
+/// it, which the caller has already processed.
+///
+/// The next offset is derived from each batch's header offset range
+/// (base_offset + last_offset_delta + 1), NOT from the decoded records. On a
+/// compacted topic the log cleaner can remove records from a batch — including
+/// its entire tail — while the batch keeps its original offset range. Deriving
+/// the next offset from the last decoded record would make the fetch loop
+/// re-request the same batch forever (stalled backup, issue #54 in the
+/// operator repo).
+///
+/// The Kafka Fetch response may contain a truncated batch at the end when the
+/// response hits max_bytes; it is detected via the batch_length header and
+/// ignored.
+fn decode_fetch_data(data: &Bytes, fetch_offset: i64) -> Result<(Vec<BackupRecord>, i64)> {
+    let mut records = Vec::new();
+    let mut next_offset = fetch_offset;
+
+    let total = data.len();
+    let mut pos = 0usize;
+
+    while total - pos >= LAST_OFFSET_DELTA_RANGE.end {
+        let base_offset = i64::from_be_bytes(data[pos..pos + 8].try_into().unwrap());
+        let batch_length =
+            i32::from_be_bytes(data[pos + 8..pos + BATCH_LENGTH_END].try_into().unwrap());
+        if batch_length < 0 {
+            return Err(KafkaError::Protocol(format!(
+                "Negative record batch length: {batch_length}"
+            ))
+            .into());
+        }
+        let batch_total = BATCH_LENGTH_END + batch_length as usize;
+        if batch_total > total - pos {
+            // Truncated trailing batch — safe to ignore; it will be fetched
+            // again in full on the next request.
+            break;
+        }
+
+        let mut batch_buf = data.slice(pos..pos + batch_total);
+        let record_set = RecordBatchDecoder::decode(&mut batch_buf).map_err(|e| {
+            crate::Error::from(KafkaError::Protocol(format!(
+                "Failed to decode records: {:?}",
+                e
+            )))
+        })?;
+
+        for record in &record_set.records {
+            if record.offset >= fetch_offset {
+                records.push(convert_record(record));
             }
         }
+
+        let last_offset_delta = i32::from_be_bytes(
+            data[pos + LAST_OFFSET_DELTA_RANGE.start..pos + LAST_OFFSET_DELTA_RANGE.end]
+                .try_into()
+                .unwrap(),
+        );
+        next_offset = next_offset.max(base_offset + last_offset_delta as i64 + 1);
+
+        pos += batch_total;
     }
 
-    Ok(records)
+    Ok((records, next_offset))
 }
 
 /// Convert a kafka-protocol Record to our BackupRecord
@@ -328,4 +368,186 @@ async fn list_offset(
         partition,
     }
     .into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+    use indexmap::IndexMap;
+    use kafka_protocol::records::{
+        Compression, Record, RecordBatchEncoder, RecordEncodeOptions, TimestampType,
+        NO_PARTITION_LEADER_EPOCH, NO_PRODUCER_EPOCH, NO_PRODUCER_ID,
+    };
+
+    /// Byte layout of a v2 record batch header (relative to batch start):
+    /// base_offset 0..8, batch_length 8..12, partition_leader_epoch 12..16,
+    /// magic 16, crc 17..21, attributes 21..23, last_offset_delta 23..27.
+    const CRC_RANGE_START: usize = 21;
+    const CRC_OFFSET: usize = 17;
+    const LAST_OFFSET_DELTA_OFFSET: usize = 23;
+
+    fn make_record(offset: i64) -> Record {
+        Record {
+            transactional: false,
+            control: false,
+            partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
+            producer_id: NO_PRODUCER_ID,
+            producer_epoch: NO_PRODUCER_EPOCH,
+            timestamp_type: TimestampType::Creation,
+            offset,
+            // Keep offset - sequence constant so the encoder packs all
+            // records into a single batch instead of one batch per record.
+            sequence: offset as i32,
+            timestamp: 1_700_000_000_000 + offset,
+            key: Some(Bytes::from(format!("key-{offset}"))),
+            value: Some(Bytes::from(format!("value-{offset}"))),
+            headers: IndexMap::new(),
+        }
+    }
+
+    /// Encode a single v2 batch containing records at the given offsets.
+    fn encode_batch(offsets: &[i64]) -> Vec<u8> {
+        let records: Vec<Record> = offsets.iter().copied().map(make_record).collect();
+        let mut buf = BytesMut::new();
+        RecordBatchEncoder::encode(
+            &mut buf,
+            records.iter(),
+            &RecordEncodeOptions {
+                version: 2,
+                compression: Compression::None,
+            },
+        )
+        .expect("encode failed");
+        buf.to_vec()
+    }
+
+    /// Simulate log compaction removing the tail records of a batch: the
+    /// broker preserves the batch's original last_offset_delta even though
+    /// the records covering those offsets are gone. Patches the header and
+    /// recomputes the CRC (crc32c over attributes..end).
+    fn patch_last_offset_delta(batch: &mut [u8], new_delta: i32) {
+        batch[LAST_OFFSET_DELTA_OFFSET..LAST_OFFSET_DELTA_OFFSET + 4]
+            .copy_from_slice(&new_delta.to_be_bytes());
+        let crc = crc32c::crc32c(&batch[CRC_RANGE_START..]);
+        batch[CRC_OFFSET..CRC_OFFSET + 4].copy_from_slice(&crc.to_be_bytes());
+    }
+
+    fn parse(data: Vec<u8>, fetch_offset: i64) -> (Vec<BackupRecord>, i64) {
+        decode_fetch_data(&Bytes::from(data), fetch_offset).expect("decode failed")
+    }
+
+    #[test]
+    fn normal_batch_returns_all_records_and_advances() {
+        let data = encode_batch(&[100, 101, 102, 103, 104]);
+        let (records, next_offset) = parse(data, 100);
+        assert_eq!(records.len(), 5);
+        assert_eq!(records[0].offset, 100);
+        assert_eq!(records[4].offset, 104);
+        assert_eq!(next_offset, 105);
+    }
+
+    #[test]
+    fn multiple_batches_decode_in_order() {
+        let mut data = encode_batch(&[100, 101, 102]);
+        data.extend_from_slice(&encode_batch(&[103, 104]));
+        let (records, next_offset) = parse(data, 100);
+        assert_eq!(records.len(), 5);
+        assert_eq!(next_offset, 105);
+    }
+
+    /// Issue osodevops/strimzi-backup-operator#54: on a compacted topic the
+    /// tail records of a batch can be removed while the batch keeps its
+    /// original offset range. Fetching at an offset inside that removed tail
+    /// returns the same batch again; next_offset must advance past the whole
+    /// batch (base_offset + last_offset_delta + 1), not stall at the last
+    /// surviving record.
+    #[test]
+    fn compacted_batch_tail_advances_past_batch_end() {
+        let mut batch = encode_batch(&[100, 101, 102, 103, 104]);
+        // Pretend offsets 105..=109 existed but were compacted away.
+        patch_last_offset_delta(&mut batch, 9);
+
+        let (records, next_offset) = parse(batch, 105);
+        assert!(
+            records.is_empty(),
+            "records below the fetch offset must be filtered out, got {:?}",
+            records.iter().map(|r| r.offset).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            next_offset, 110,
+            "next_offset must advance past the batch's full offset range"
+        );
+    }
+
+    /// The exact stall shape from the issue #54 log: fetch at offset N
+    /// repeatedly returns records=1 with next_offset == N.
+    #[test]
+    fn compacted_batch_makes_progress_from_mid_batch_offset() {
+        let mut batch = encode_batch(&[2_961_390, 2_961_395]);
+        // Batch originally spanned 2961390..=2961399; tail compacted away.
+        patch_last_offset_delta(&mut batch, 9);
+
+        let (records, next_offset) = parse(batch, 2_961_396);
+        assert!(records.is_empty());
+        assert!(
+            next_offset > 2_961_396,
+            "next_offset {next_offset} must make progress past the fetch offset"
+        );
+        assert_eq!(next_offset, 2_961_400);
+    }
+
+    /// The broker returns whole batches: a fetch offset in the middle of a
+    /// batch returns records before it, which must not be re-emitted
+    /// (they were already backed up).
+    #[test]
+    fn records_below_fetch_offset_are_filtered() {
+        let data = encode_batch(&[100, 101, 102, 103, 104]);
+        let (records, next_offset) = parse(data, 103);
+        assert_eq!(
+            records.iter().map(|r| r.offset).collect::<Vec<_>>(),
+            vec![103, 104]
+        );
+        assert_eq!(next_offset, 105);
+    }
+
+    /// A batch whose records were ALL compacted away (record_count = 0)
+    /// must still advance next_offset so the engine does not treat it as
+    /// end-of-partition.
+    #[test]
+    fn fully_compacted_batch_still_advances() {
+        let mut full = encode_batch(&[200, 201, 202]);
+        // Rewrite the batch to contain zero records but keep its offset
+        // range, as the log cleaner does: record_count (bytes 57..61) = 0,
+        // truncate the record payload after the 61-byte header.
+        full.truncate(61);
+        full[57..61].copy_from_slice(&0i32.to_be_bytes());
+        // Fix batch_length (bytes 8..12): total - 12.
+        let batch_length = (full.len() - 12) as i32;
+        full[8..12].copy_from_slice(&batch_length.to_be_bytes());
+        patch_last_offset_delta(&mut full, 2);
+
+        let (records, next_offset) = parse(full, 200);
+        assert!(records.is_empty());
+        assert_eq!(next_offset, 203);
+    }
+
+    /// A truncated trailing batch (response hit max_bytes mid-batch) is
+    /// ignored; next_offset only covers the complete batches.
+    #[test]
+    fn truncated_trailing_batch_is_ignored() {
+        let mut data = encode_batch(&[100, 101, 102]);
+        let second = encode_batch(&[103, 104]);
+        data.extend_from_slice(&second[..second.len() - 7]);
+        let (records, next_offset) = parse(data, 100);
+        assert_eq!(records.len(), 3);
+        assert_eq!(next_offset, 103);
+    }
+
+    #[test]
+    fn empty_data_returns_no_progress() {
+        let (records, next_offset) = parse(Vec::new(), 42);
+        assert!(records.is_empty());
+        assert_eq!(next_offset, 42);
+    }
 }


### PR DESCRIPTION
Fixes the stalled-backup infinite loop on compacted topics reported in osodevops/strimzi-backup-operator#54.

## Root cause

`fetch.rs` derived `next_offset` from the **last decoded record** (`record.offset + 1`). On a topic with `cleanup.policy=compact`, the log cleaner removes records from inside a batch while the batch keeps its original offset range (`last_offset_delta` is preserved, per the v2 record batch format). Three failure modes follow:

1. **Infinite loop / stalled backup** (the reported bug): when the tail records of a batch are compacted away, fetching at `last_surviving_record + 1` returns the *same batch* again — every decoded record is below the fetch offset, so `next_offset` never advances. This is exactly the reporter's log signature: `records=1 high_watermark=5369685 next_offset=2961396 offset_start=2961396` repeating forever.
2. **Runaway duplicate writes**: each loop iteration re-appends those already-processed records to the segment writer, producing an endless stream of duplicate segments to storage.
3. **Silent data loss**: a batch whose records were *all* compacted away (`count=0`, kept for producer state) decodes to zero records, which the engine treated as end-of-partition — terminating the backup early and reporting success.

## Fix

- `kafka/fetch.rs`: walk the raw v2 batch headers and derive `next_offset` from `base_offset + last_offset_delta + 1` of each complete batch instead of the last decoded record; filter out records below the fetch offset so re-fetched batch prefixes are not written twice. Truncated trailing batches (response hit `max_bytes`) are now detected explicitly via the `batch_length` header.
- `backup/engine.rs`: a fetch returning zero records but an advanced offset (fully-compacted range) continues instead of terminating the partition backup; checkpoints store the end of the fetched batches so resume can't land inside a compacted tail.

## Tests (TDD)

8 new unit tests in `kafka/fetch.rs` written against real encoded v2 batches, with a helper that simulates the log cleaner (patches `last_offset_delta` + recomputes CRC). Written first, 4 failed on the old logic, all pass on the fix:

- `compacted_batch_tail_advances_past_batch_end` — the stall scenario
- `compacted_batch_makes_progress_from_mid_batch_offset` — the exact `records=1, next_offset==offset_start` shape from the issue log
- `records_below_fetch_offset_are_filtered` — the duplicate-write scenario
- `fully_compacted_batch_still_advances` — the silent-early-exit scenario
- plus normal/multi-batch/truncated-batch/empty-response behavior preservation

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full test suite (241 tests) pass.

## E2E reproduction and verification (local Kafka 3.7.1)

Created a 1-partition `cleanup.policy=compact` topic, produced 20k keyed records, overwrote keys k10000–k19999, rolled segments, and let the log cleaner run. `kafka-dump-log` confirms the pathological post-compaction shapes:

```
baseOffset: 9576  lastOffset: 11969 count: 424   <- tail (10000-11969) compacted away
baseOffset: 19152 lastOffset: 19999 count: 0     <- fully compacted batch
```

**Before (v0.15.12)** — stalls at offset 10000 and writes duplicates until killed (30 s):

```
fetch_result: issue54-compacted:0 records=424 high_watermark=32000 next_offset=10000 offset_start=9576
fetch_result: issue54-compacted:0 records=424 high_watermark=32000 next_offset=10000 offset_start=10000
fetch_result: issue54-compacted:0 records=424 high_watermark=32000 next_offset=10000 offset_start=10000
... 13,622 identical iterations, 3,353 duplicate segments written in 30 s ...
```

**After (this PR)** — sails past the compacted range and completes:

```
fetch_result: issue54-compacted:0 records=424  high_watermark=32000 next_offset=20000 offset_start=9576
fetch_result: issue54-compacted:0 records=2394 high_watermark=32000 next_offset=22394 offset_start=20000
...
fetch_result: issue54-compacted:0 records=2000 high_watermark=32000 next_offset=32000 offset_start=30000
Completed snapshot backup of issue54-compacted:0 - 13 segments (reached target offset 32000)
```

**Integrity verification** of the fixed backup:
- Manifest: 13 segments, 22,000 records, contiguous non-overlapping offset coverage 0→31999 across the compacted gap.
- Restore round-trip into a fresh topic: exactly 22,000 records produced.
- Consumed all restored records: 22,000 unique keys, **0 duplicates**, value distribution exactly as expected (10,000 round-1 survivors + 10,000 round-2 overwrites + 2,000 fillers), all 20,000 overwritten/original keys present exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
