### PR TITLE
feat(config): add fetch_max_bytes and segment_max_records backup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-08-11
+
+### Added
+- `backup.fetch_max_bytes` — maximum bytes requested per Kafka Fetch request,
+  decoupled from the segment size (previously always
+  `min(segment_max_bytes, 16MB)`).
+- `backup.segment_max_records` — rotate segments once they hold this many
+  records, in addition to the existing size/interval thresholds.
+- Warn on unknown config keys at load time instead of silently ignoring them.
+  Requested in
+  [strimzi-backup-operator#53](https://github.com/osodevops/strimzi-backup-operator/issues/53).
+
+### Changed
+- `kafka-backup-core`: `BackupOptions` and `SegmentWriterConfig` gained new
+  public fields (breaking for struct-literal construction; use
+  `..Default::default()`).
+
+## [0.15.13] - 2026-08-11
+
+### Fixed
+- Advance fetches past record batches whose tail records were removed by log
+  compaction instead of re-requesting the same batch forever (stalled backup,
+  duplicate segments written to storage), and continue past fully-compacted
+  batches instead of ending the partition backup early. Fixes
+  [strimzi-backup-operator#54](https://github.com/osodevops/strimzi-backup-operator/issues/54).
+
 ## [0.15.12] - 2026-07-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.15.13"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.15.13"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1399,6 +1399,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml",
  "sha2",
@@ -2456,6 +2457,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.13"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]
@@ -27,6 +27,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+serde_ignored = "0.1"
 bytes = "1"
 
 # Compression

--- a/crates/kafka-backup-cli/src/commands/backup.rs
+++ b/crates/kafka-backup-cli/src/commands/backup.rs
@@ -9,7 +9,7 @@ pub async fn run(config_path: &str) -> Result<()> {
 
     let config_content = tokio::fs::read_to_string(config_path).await?;
     let config_content = super::config::expand_env_vars(&config_content);
-    let mut config: Config = serde_yaml::from_str(&config_content)?;
+    let mut config: Config = super::config::parse_config(&config_content)?;
     super::sasl_plugin::populate_sasl_plugin_opt(&mut config.source)?;
 
     info!("Starting backup: {}", config.backup_id);

--- a/crates/kafka-backup-cli/src/commands/config.rs
+++ b/crates/kafka-backup-cli/src/commands/config.rs
@@ -34,6 +34,20 @@ pub fn expand_env_vars(input: &str) -> String {
     result
 }
 
+/// Parse a config YAML string, logging a warning for every key that the
+/// config schema does not recognize (they would otherwise be silently
+/// ignored — e.g. a typo like `fetch_max_bytez` doing nothing).
+pub fn parse_config(
+    config_content: &str,
+) -> kafka_backup_core::Result<kafka_backup_core::config::Config> {
+    let (config, ignored) =
+        kafka_backup_core::config::Config::from_yaml_with_warnings(config_content)?;
+    for path in &ignored {
+        tracing::warn!("Ignoring unknown config key `{path}` — check for typos; see https://kafkabackup.com/reference/config-yaml");
+    }
+    Ok(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kafka-backup-cli/src/commands/restore.rs
+++ b/crates/kafka-backup-cli/src/commands/restore.rs
@@ -9,7 +9,7 @@ pub async fn run(config_path: &str) -> Result<()> {
 
     let config_content = tokio::fs::read_to_string(config_path).await?;
     let config_content = super::config::expand_env_vars(&config_content);
-    let mut config: Config = serde_yaml::from_str(&config_content)?;
+    let mut config: Config = super::config::parse_config(&config_content)?;
     super::sasl_plugin::populate_sasl_plugin_opt(&mut config.target)?;
 
     info!("Starting restore from backup: {}", config.backup_id);

--- a/crates/kafka-backup-cli/src/commands/snapshot_groups.rs
+++ b/crates/kafka-backup-cli/src/commands/snapshot_groups.rs
@@ -40,7 +40,7 @@ pub async fn run(config_path: &str) -> Result<()> {
 
     let config_content = tokio::fs::read_to_string(config_path).await?;
     let config_content = super::config::expand_env_vars(&config_content);
-    let mut config: Config = serde_yaml::from_str(&config_content)?;
+    let mut config: Config = super::config::parse_config(&config_content)?;
     super::sasl_plugin::populate_sasl_plugin_opt(&mut config.source)?;
 
     if config.mode != Mode::Backup {

--- a/crates/kafka-backup-cli/src/commands/status_watch.rs
+++ b/crates/kafka-backup-cli/src/commands/status_watch.rs
@@ -288,7 +288,7 @@ fn load_metrics_config(config_path: &str) -> Result<(MetricsConfig, String)> {
     let config_content = super::config::expand_env_vars(&config_content);
 
     let config: Config =
-        serde_yaml::from_str(&config_content).context("Failed to parse config file")?;
+        super::config::parse_config(&config_content).context("Failed to parse config file")?;
 
     let metrics_config = config.metrics.unwrap_or_default();
     let backup_id = config.backup_id.clone();

--- a/crates/kafka-backup-cli/src/commands/three_phase.rs
+++ b/crates/kafka-backup-cli/src/commands/three_phase.rs
@@ -13,7 +13,7 @@ pub async fn run(config_path: &str) -> Result<()> {
 
     let config_content = tokio::fs::read_to_string(config_path).await?;
     let config_content = super::config::expand_env_vars(&config_content);
-    let mut config: Config = serde_yaml::from_str(&config_content)?;
+    let mut config: Config = super::config::parse_config(&config_content)?;
     super::sasl_plugin::populate_sasl_plugin_opt(&mut config.source)?;
     super::sasl_plugin::populate_sasl_plugin_opt(&mut config.target)?;
 

--- a/crates/kafka-backup-cli/src/commands/validate_restore.rs
+++ b/crates/kafka-backup-cli/src/commands/validate_restore.rs
@@ -6,7 +6,7 @@ pub async fn run(config_path: &str, format: &str) -> Result<()> {
     // Load configuration
     let config_content = std::fs::read_to_string(config_path)?;
     let config_content = super::config::expand_env_vars(&config_content);
-    let mut config: Config = serde_yaml::from_str(&config_content)?;
+    let mut config: Config = super::config::parse_config(&config_content)?;
 
     // Force dry-run mode
     if let Some(ref mut restore) = config.restore {

--- a/crates/kafka-backup-core/Cargo.toml
+++ b/crates/kafka-backup-core/Cargo.toml
@@ -26,6 +26,7 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+serde_ignored.workspace = true
 bytes.workspace = true
 
 # Compression

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -952,6 +952,7 @@ impl BackupPartitionContext {
             max_segment_interval_ms: self.options.segment_max_interval_ms,
             compression: self.options.compression,
             compression_level: self.options.compression_level,
+            max_segment_records: self.options.segment_max_records,
         };
         let mut segment_writer = SegmentWriter::with_prometheus(
             writer_config,
@@ -1197,7 +1198,7 @@ impl BackupPartitionContext {
         start_offset: i64,
         _end_offset: i64,
     ) -> Result<(Vec<BackupRecord>, i64)> {
-        let max_bytes = self.options.segment_max_bytes.min(16 * 1024 * 1024) as i32;
+        let max_bytes = effective_fetch_max_bytes(&self.options);
 
         // Fetch records using router (automatically routes to partition leader)
         let fetch_response = self
@@ -1207,6 +1208,17 @@ impl BackupPartitionContext {
 
         Ok((fetch_response.records, fetch_response.next_offset))
     }
+}
+
+/// Maximum bytes to request per Fetch call: an explicit `fetch_max_bytes`
+/// wins; otherwise fall back to the segment size capped at 16MB. Clamped to
+/// the Kafka protocol's i32 range.
+fn effective_fetch_max_bytes(options: &BackupOptions) -> i32 {
+    const DEFAULT_FETCH_CAP: u64 = 16 * 1024 * 1024;
+    options
+        .fetch_max_bytes
+        .unwrap_or_else(|| options.segment_max_bytes.min(DEFAULT_FETCH_CAP))
+        .clamp(1, i32::MAX as u64) as i32
 }
 
 /// Await a background segment flush task, surfacing panics as errors.
@@ -1404,6 +1416,43 @@ fn should_create_offset_store(continuous: bool, offset_storage_configured: bool)
 mod tests {
     use super::*;
     use crate::manifest::{PartitionBackup, TopicBackup};
+
+    #[test]
+    fn fetch_max_bytes_defaults_to_capped_segment_size() {
+        let mut opts = BackupOptions {
+            segment_max_bytes: 512 * 1024,
+            ..BackupOptions::default()
+        };
+        assert_eq!(effective_fetch_max_bytes(&opts), 512 * 1024);
+
+        opts.segment_max_bytes = 256 * 1024 * 1024;
+        assert_eq!(effective_fetch_max_bytes(&opts), 16 * 1024 * 1024);
+    }
+
+    #[test]
+    fn explicit_fetch_max_bytes_wins_over_segment_size() {
+        let opts = BackupOptions {
+            segment_max_bytes: 256 * 1024 * 1024,
+            fetch_max_bytes: Some(64 * 1024 * 1024),
+            ..BackupOptions::default()
+        };
+        assert_eq!(effective_fetch_max_bytes(&opts), 64 * 1024 * 1024);
+    }
+
+    #[test]
+    fn fetch_max_bytes_is_clamped_to_protocol_range() {
+        let opts = BackupOptions {
+            fetch_max_bytes: Some(u64::MAX),
+            ..BackupOptions::default()
+        };
+        assert_eq!(effective_fetch_max_bytes(&opts), i32::MAX);
+
+        let opts = BackupOptions {
+            fetch_max_bytes: Some(0),
+            ..BackupOptions::default()
+        };
+        assert_eq!(effective_fetch_max_bytes(&opts), 1);
+    }
 
     #[test]
     fn test_glob_match() {

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -497,6 +497,20 @@ pub struct BackupOptions {
     /// Default: `false` — opt in explicitly to avoid unexpected overhead.
     #[serde(default)]
     pub consumer_group_snapshot: bool,
+
+    /// Maximum bytes requested per Kafka Fetch request.
+    ///
+    /// When unset, fetches request `min(segment_max_bytes, 16MB)`.
+    /// Values are clamped to the Kafka protocol's i32 range.
+    #[serde(default)]
+    pub fetch_max_bytes: Option<u64>,
+
+    /// Maximum records per segment before rotation.
+    ///
+    /// When unset, segments rotate on `segment_max_bytes` /
+    /// `segment_max_interval_ms` only.
+    #[serde(default)]
+    pub segment_max_records: Option<u64>,
 }
 
 fn default_include_offset_headers() -> bool {
@@ -530,6 +544,8 @@ impl Default for BackupOptions {
             max_concurrent_partitions: default_backup_max_concurrent_partitions(),
             poll_interval_ms: default_poll_interval_ms(),
             consumer_group_snapshot: false,
+            fetch_max_bytes: None,
+            segment_max_records: None,
         }
     }
 }
@@ -825,6 +841,22 @@ fn default_restore_checkpoint_interval_secs() -> u64 {
 }
 
 impl Config {
+    /// Parse a YAML config, collecting the paths of any keys that were
+    /// ignored during deserialization.
+    ///
+    /// The config structs do not reject unknown fields, so a typo like
+    /// `fetch_max_bytez` would otherwise be silently dropped and the
+    /// operator-provided or hand-written option would simply not apply.
+    /// Callers should surface the returned paths as warnings.
+    pub fn from_yaml_with_warnings(yaml: &str) -> crate::Result<(Self, Vec<String>)> {
+        let mut ignored = Vec::new();
+        let deserializer = serde_yaml::Deserializer::from_str(yaml);
+        let config: Config =
+            serde_ignored::deserialize(deserializer, |path| ignored.push(path.to_string()))
+                .map_err(|e| crate::Error::Config(format!("Failed to parse config: {e}")))?;
+        Ok((config, ignored))
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> crate::Result<()> {
         match self.mode {
@@ -992,6 +1024,70 @@ impl RestoreOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn backup_options_parse_fetch_max_bytes_and_segment_max_records() {
+        let yaml = "fetch_max_bytes: 16777216\nsegment_max_records: 2000000\n";
+        let opts: BackupOptions = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(opts.fetch_max_bytes, Some(16777216));
+        assert_eq!(opts.segment_max_records, Some(2_000_000));
+
+        let defaults = BackupOptions::default();
+        assert_eq!(defaults.fetch_max_bytes, None);
+        assert_eq!(defaults.segment_max_records, None);
+    }
+
+    #[test]
+    fn config_from_yaml_with_warnings_reports_unknown_keys() {
+        let yaml = r#"
+mode: backup
+backup_id: warn-test
+source:
+  bootstrap_servers:
+    - localhost:9092
+storage:
+  backend: filesystem
+  path: /tmp/warn-test
+backup:
+  segment_max_bytes: 1048576
+  fetch_max_bytez: 123
+not_a_real_section:
+  foo: 1
+"#;
+        let (config, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
+        assert_eq!(config.backup_id, "warn-test");
+        assert!(
+            warnings.iter().any(|w| w.contains("fetch_max_bytez")),
+            "expected a warning for backup.fetch_max_bytez, got {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("not_a_real_section")),
+            "expected a warning for not_a_real_section, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn config_from_yaml_with_warnings_is_quiet_for_known_keys() {
+        let yaml = r#"
+mode: backup
+backup_id: quiet-test
+source:
+  bootstrap_servers:
+    - localhost:9092
+storage:
+  backend: filesystem
+  path: /tmp/quiet-test
+backup:
+  segment_max_bytes: 1048576
+  fetch_max_bytes: 16777216
+  segment_max_records: 2000000
+"#;
+        let (_, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+    }
 
     #[test]
     fn test_connection_config_defaults() {

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -1054,6 +1054,36 @@ mod tests {
     }
 
     #[test]
+    fn pre_v0_16_config_parses_unchanged_with_no_warnings() {
+        // A config written for older versions (no v0.16.0 keys) must parse
+        // with identical semantics and produce zero warnings.
+        let yaml = r#"
+mode: backup
+backup_id: compat-test
+source:
+  bootstrap_servers:
+    - localhost:9092
+storage:
+  backend: filesystem
+  path: /tmp/compat-test
+backup:
+  compression: zstd
+  segment_max_bytes: 134217728
+  stop_at_current_offsets: true
+"#;
+        let (config, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings, got {warnings:?}"
+        );
+        let opts = config.backup.unwrap();
+        assert_eq!(opts.fetch_max_bytes, None);
+        assert_eq!(opts.segment_max_records, None);
+        assert_eq!(opts.segment_max_bytes, 134217728);
+        assert!(opts.stop_at_current_offsets);
+    }
+
+    #[test]
     fn config_from_yaml_with_warnings_reports_unknown_keys() {
         let yaml = r#"
 mode: backup

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -854,6 +854,22 @@ impl Config {
         let config: Config =
             serde_ignored::deserialize(deserializer, |path| ignored.push(path.to_string()))
                 .map_err(|e| crate::Error::Config(format!("Failed to parse config: {e}")))?;
+
+        let ignored = ignored
+            .into_iter()
+            // serde_ignored renders Option/enum layers as `?` segments
+            // (e.g. `backup.?.key`); drop them for readable key paths.
+            .map(|path| {
+                path.split('.')
+                    .filter(|segment| *segment != "?")
+                    .collect::<Vec<_>>()
+                    .join(".")
+            })
+            // The documented `logging` section is applied by the CLI layer
+            // (RUST_LOG / -v), not deserialized into this struct — not a typo.
+            .filter(|path| path != "logging" && !path.starts_with("logging."))
+            .collect();
+
         Ok((config, ignored))
     }
 
@@ -1057,8 +1073,8 @@ not_a_real_section:
         let (config, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
         assert_eq!(config.backup_id, "warn-test");
         assert!(
-            warnings.iter().any(|w| w.contains("fetch_max_bytez")),
-            "expected a warning for backup.fetch_max_bytez, got {warnings:?}"
+            warnings.iter().any(|w| w == "backup.fetch_max_bytez"),
+            "expected a clean `backup.fetch_max_bytez` path (no `?` segments), got {warnings:?}"
         );
         assert!(
             warnings.iter().any(|w| w.contains("not_a_real_section")),
@@ -1081,6 +1097,9 @@ backup:
   segment_max_bytes: 1048576
   fetch_max_bytes: 16777216
   segment_max_records: 2000000
+logging:
+  level: debug
+  format: text
 "#;
         let (_, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
         assert!(

--- a/crates/kafka-backup-core/src/segment/writer.rs
+++ b/crates/kafka-backup-core/src/segment/writer.rs
@@ -345,6 +345,36 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
+    async fn no_record_rotation_when_limit_unset() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Arc::new(FilesystemBackend::new(temp_dir.path().to_path_buf()));
+        let metrics = Arc::new(PerformanceMetrics::new());
+        // Defaults: max_segment_records is None — record count must never
+        // trigger rotation on its own (pre-v0.16.0 behavior preserved).
+        let config = SegmentWriterConfig {
+            max_segment_bytes: u64::MAX,
+            max_segment_interval_ms: u64::MAX,
+            ..SegmentWriterConfig::default()
+        };
+        let mut writer = SegmentWriter::new(config, storage, metrics);
+        for i in 0..1000 {
+            writer
+                .add_record(BinaryRecord {
+                    timestamp: 1000 + i,
+                    offset: i,
+                    key: None,
+                    value: Some(Bytes::from("v")),
+                    headers: vec![],
+                })
+                .unwrap();
+        }
+        assert!(
+            !writer.should_rotate(),
+            "record count must not trigger rotation when the limit is unset"
+        );
+    }
+
+    #[tokio::test]
     async fn rotates_at_max_segment_records() {
         let temp_dir = TempDir::new().unwrap();
         let storage = Arc::new(FilesystemBackend::new(temp_dir.path().to_path_buf()));

--- a/crates/kafka-backup-core/src/segment/writer.rs
+++ b/crates/kafka-backup-core/src/segment/writer.rs
@@ -23,6 +23,8 @@ pub struct SegmentWriterConfig {
     pub compression: CompressionType,
     /// Compression level (for zstd: 1-22, default 3)
     pub compression_level: i32,
+    /// Maximum records per segment before rotation (default: unlimited)
+    pub max_segment_records: Option<u64>,
 }
 
 impl Default for SegmentWriterConfig {
@@ -32,6 +34,7 @@ impl Default for SegmentWriterConfig {
             max_segment_interval_ms: 60_000,      // 60 seconds
             compression: CompressionType::Zstd,
             compression_level: 3,
+            max_segment_records: None,
         }
     }
 }
@@ -240,6 +243,13 @@ impl SegmentWriter {
             return true;
         }
 
+        // Check record-count threshold
+        if let Some(max_records) = self.config.max_segment_records {
+            if self.record_count >= max_records {
+                return true;
+            }
+        }
+
         // Check time threshold
         if let Some(start_time) = self.segment_start_time {
             if start_time.elapsed().as_millis() as u64 >= self.config.max_segment_interval_ms {
@@ -333,6 +343,46 @@ mod tests {
     use super::*;
     use crate::storage::FilesystemBackend;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn rotates_at_max_segment_records() {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Arc::new(FilesystemBackend::new(temp_dir.path().to_path_buf()));
+        let metrics = Arc::new(PerformanceMetrics::new());
+        let config = SegmentWriterConfig {
+            max_segment_bytes: u64::MAX,
+            max_segment_interval_ms: u64::MAX,
+            max_segment_records: Some(10),
+            ..SegmentWriterConfig::default()
+        };
+
+        let mut writer = SegmentWriter::new(config, storage, metrics);
+        for i in 0..9 {
+            writer
+                .add_record(BinaryRecord {
+                    timestamp: 1000 + i,
+                    offset: i,
+                    key: None,
+                    value: Some(Bytes::from("v")),
+                    headers: vec![],
+                })
+                .unwrap();
+        }
+        assert!(
+            !writer.should_rotate(),
+            "must not rotate below the record limit"
+        );
+        writer
+            .add_record(BinaryRecord {
+                timestamp: 2000,
+                offset: 9,
+                key: None,
+                value: Some(Bytes::from("v")),
+                headers: vec![],
+            })
+            .unwrap();
+        assert!(writer.should_rotate(), "must rotate at the record limit");
+    }
 
     #[tokio::test]
     async fn test_segment_writer_basic() {


### PR DESCRIPTION
First half of osodevops/strimzi-backup-operator#53 (Full Backup Config Options): the two options the reporter wants to tune do not exist in kafka-backup yet — their configs set them, and the config parser **silently ignored them**. This PR adds both options and makes silent-ignore impossible going forward. (The second half — a Strimzi-style `spec.backup.config` passthrough — lands in the operator.)

## Added

- **`backup.fetch_max_bytes`** — maximum bytes requested per Kafka Fetch. Previously fetches always requested `min(segment_max_bytes, 16MB)` with no independent knob. An explicit value wins over that default and is clamped to the protocol's i32 range.
- **`backup.segment_max_records`** — rotate segments once they hold N records, alongside the existing `segment_max_bytes` / `segment_max_interval_ms` thresholds.
- **Unknown-key warnings** — the config structs accept unknown fields, so a typo (or an option that doesn't exist, exactly what happened in issue #53/#52 with `fetch_max_bytes: 16777216` and `segment_max_records: 2000000`) was silently dropped while the user believed it was applied. All six CLI config-load paths now parse via `Config::from_yaml_with_warnings` (serde_ignored) and log each ignored key path:
  ```
  WARN Ignoring unknown config key `backup.fetch_max_bytez` — check for typos; see https://kafkabackup.com/reference/config-yaml
  ```

## Version

`0.16.0`: `BackupOptions` and `SegmentWriterConfig` gained public fields, which is breaking for struct-literal construction of `kafka-backup-core` types — minor bump per the repo's semver policy. Also adds the missing 0.15.13 changelog entry.

## Tests (TDD — written first, failed on main)

- `backup_options_parse_fetch_max_bytes_and_segment_max_records`
- `config_from_yaml_with_warnings_reports_unknown_keys` / `..._is_quiet_for_known_keys`
- `rotates_at_max_segment_records` (segment writer)
- `fetch_max_bytes_defaults_to_capped_segment_size`, `explicit_fetch_max_bytes_wins_over_segment_size`, `fetch_max_bytes_is_clamped_to_protocol_range` (engine)

`cargo fmt` / `clippy --all-targets -D warnings` / full suite (248 core + CLI) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
