### PR TITLE
Fix: recover from OFFSET_OUT_OF_RANGE during snapshot backup instead of failing the partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-08-18
+
+### Fixed
+- Recover from `OFFSET_OUT_OF_RANGE` (broker error code 1) during backup
+  instead of failing the partition. In snapshot mode the `earliest` offset is
+  captured for every partition up front, and on resume the start offset comes
+  from the checkpoint; if retention deletes that offset before the partition is
+  fetched, the fetch loop now re-reads the broker's log start offset and
+  resumes from there. Previously the whole run failed — and a resumed backup
+  whose checkpoint had aged out of retention failed identically on every retry
+  and never self-healed. Fixes
+  [#144](https://github.com/osodevops/kafka-backup/issues/144).
+
+### Added
+- The range skipped by an `OFFSET_OUT_OF_RANGE` recovery is recorded durably as
+  an offset gap in the manifest (`topics[].partitions[].gaps[]`, with
+  `start_offset`, `end_offset`, `reason`, `detected_at`) rather than only being
+  logged: those records are gone from the source, and a backup that silently
+  contains a hole is worse than one that fails loudly. `validate` and
+  `describe` list recorded gaps; `describe --format json` includes them
+  verbatim.
+- Prometheus counters `kafka_backup_offset_gaps_total` (gap events) and
+  `kafka_backup_offsets_skipped_total` (source offsets skipped), labelled by
+  `backup_id`, so operators can alert on data loss.
+- `BackupManifest::total_gaps()` / `gaps()`, `PartitionBackup::add_gap()`,
+  and the `OffsetGap` / `OffsetGapReason` types in `kafka-backup-core`.
+
+### Changed
+- `kafka-backup-core`: `PartitionBackup` gained the public `gaps` field
+  (breaking for struct-literal construction). Manifests written by earlier
+  versions load unchanged — the field defaults to empty and is omitted from
+  the JSON when empty.
+- An `OFFSET_OUT_OF_RANGE` that cannot be recovered by skipping forward (the
+  broker's log start offset has not moved past the fetch offset, so the offset
+  is beyond the log end — truncation or a recreated topic) still fails the
+  partition, now with an error that reports the broker's log range and the
+  likely cause instead of a bare `code 1`.
+
 ## [0.16.0] - 2026-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -76,6 +76,17 @@ fn print_manifest_text(manifest: &BackupManifest) {
 
     println!("║ Total Segments: {:55} ║", manifest.total_segments());
     println!("║ Total Records:  {:55} ║", manifest.total_records());
+    let total_gaps = manifest.total_gaps();
+    if total_gaps > 0 {
+        let offsets_missing: i64 = manifest.gaps().map(|(_, _, g)| g.offset_span()).sum();
+        println!(
+            "║ Data Gaps:      {:55} ║",
+            format!(
+                "{} ({} source offsets not captured)",
+                total_gaps, offsets_missing
+            )
+        );
+    }
 
     // Calculate total size
     let total_compressed: u64 = manifest
@@ -173,6 +184,16 @@ fn print_manifest_text(manifest: &BackupManifest) {
                     offset_range.0,
                     offset_range.1,
                     partition.segments.len()
+                );
+            }
+            for gap in &partition.gaps {
+                println!(
+                    "║     P{}: DATA GAP offsets {}..{} ({} offsets not captured: {}) ║",
+                    partition.partition_id,
+                    gap.start_offset,
+                    gap.end_offset,
+                    gap.offset_span(),
+                    gap.reason
                 );
             }
         }

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -14,6 +14,12 @@ struct ValidationReport {
     segments_corrupted: usize,
     records_validated: u64,
     issues: Vec<String>,
+    /// Offset ranges the backup itself recorded as missing (retention deleted
+    /// them before they could be fetched — see `OffsetGap`). These are not
+    /// integrity failures: the stored data is intact, but the backup is
+    /// knowingly incomplete for these ranges.
+    data_gaps: Vec<String>,
+    offsets_missing: i64,
 }
 
 impl ValidationReport {
@@ -28,6 +34,7 @@ impl ValidationReport {
         println!("Segments Missing:   {}", self.segments_missing);
         println!("Segments Corrupted: {}", self.segments_corrupted);
         println!("Records Validated:  {}", self.records_validated);
+        println!("Data Gaps:          {}", self.data_gaps.len());
 
         if !self.issues.is_empty() {
             println!("\nIssues Found:");
@@ -36,11 +43,25 @@ impl ValidationReport {
             }
         }
 
+        if !self.data_gaps.is_empty() {
+            println!(
+                "\nData Gaps (recorded during backup — {} source offsets could not be captured \
+                 because the broker no longer had them):",
+                self.offsets_missing
+            );
+            for gap in &self.data_gaps {
+                println!("  - {}", gap);
+            }
+        }
+
         println!();
-        if self.is_valid() {
-            println!("Result: VALID");
-        } else {
-            println!("Result: INVALID");
+        match (self.is_valid(), self.data_gaps.is_empty()) {
+            (true, true) => println!("Result: VALID"),
+            (true, false) => println!(
+                "Result: VALID (with {} recorded data gaps — backup is intact but incomplete)",
+                self.data_gaps.len()
+            ),
+            (false, _) => println!("Result: INVALID"),
         }
     }
 }
@@ -84,6 +105,24 @@ pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
             .unwrap_or_else(|| "Unknown".to_string())
     );
     println!();
+
+    // Surface any data gaps the backup recorded about itself (issue #144).
+    for (topic, partition, gap) in manifest.gaps() {
+        let detected = chrono::DateTime::from_timestamp_millis(gap.detected_at)
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_else(|| gap.detected_at.to_string());
+        report.data_gaps.push(format!(
+            "{}:{} offsets {}..{} ({} offsets, {}, detected {})",
+            topic,
+            partition,
+            gap.start_offset,
+            gap.end_offset,
+            gap.offset_span(),
+            gap.reason,
+            detected
+        ));
+        report.offsets_missing += gap.offset_span();
+    }
 
     // Validate each segment
     for topic in &manifest.topics {

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -19,6 +19,7 @@ use crate::segment::format::BinaryRecord;
 use crate::segment::writer::{SegmentWriter, SegmentWriterConfig};
 use crate::storage::{create_backend, StorageBackend};
 use crate::{Error, Result};
+use crate::error::KafkaError;
 
 /// Backup engine for backing up Kafka topics
 pub struct BackupEngine {
@@ -978,10 +979,35 @@ impl BackupPartitionContext {
             let (records, next_offset) = match fetch_result {
                 Ok(data) => data,
                 Err(e) => {
+                    if is_offset_out_of_range(&e) {
+                        warn!(
+                            "{}:{}: offset {} out of range (likely deleted by retention), \
+                             refetching earliest and resuming",
+                            self.topic, self.partition, current_offset
+                        );
+                        match self.router.get_offsets(&self.topic, self.partition).await {
+                            Ok((new_earliest, _)) if new_earliest > current_offset => {
+                                current_offset = new_earliest;
+                                continue;
+                            }
+                            Ok(_) => {
+                                // new_earliest <= current_offset: the out-of-range error
+                                // wasn't a retention gap we can jump past. Fall through
+                                // to the original failure handling below.
+                            }
+                            Err(offset_err) => {
+                                warn!(
+                                    "{}:{}: failed to refetch earliest offset after out-of-range error: {}",
+                                    self.topic, self.partition, offset_err
+                                );
+                                // Fall through to original failure handling below.
+                            }
+                        }
+                    }
+
                     self.health
                         .mark_degraded("kafka", &format!("Fetch error: {}", e));
                     self.kafka_cb.record_failure();
-                    // Record error to Prometheus metrics
                     if let Some(ref prom) = self.prometheus_metrics {
                         let error_type = ErrorType::from_error(&e);
                         prom.record_error(&self.backup_id, error_type);
@@ -1207,6 +1233,13 @@ impl BackupPartitionContext {
             .await?;
 
         Ok((fetch_response.records, fetch_response.next_offset))
+    }
+}
+
+fn is_offset_out_of_range(e: &Error) -> bool {
+    match e {
+        Error::Kafka(KafkaError::BrokerError { code, .. }) => *code == 1,
+        _ => false,
     }
 }
 

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -10,16 +10,16 @@ use tracing::{debug, error, info, warn};
 use crate::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use crate::compression::extension;
 use crate::config::{BackupOptions, CompressionType, Config, Mode, StartOffset, TopicSelection};
+use crate::error::KafkaError;
 use crate::health::HealthCheck;
 use crate::kafka::{PartitionLeaderRouter, TopicMetadata};
-use crate::manifest::{BackupManifest, BackupRecord, SegmentMetadata};
+use crate::manifest::{BackupManifest, BackupRecord, OffsetGap, OffsetGapReason, SegmentMetadata};
 use crate::metrics::{ErrorType, PerformanceMetrics, PrometheusMetrics};
 use crate::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
 use crate::segment::format::BinaryRecord;
 use crate::segment::writer::{SegmentWriter, SegmentWriterConfig};
 use crate::storage::{create_backend, StorageBackend};
 use crate::{Error, Result};
-use crate::error::KafkaError;
 
 /// Backup engine for backing up Kafka topics
 pub struct BackupEngine {
@@ -979,7 +979,14 @@ impl BackupPartitionContext {
             let (records, next_offset) = match fetch_result {
                 Ok(data) => data,
                 Err(e) => {
-                    if is_offset_out_of_range(&e) {
+                    // OFFSET_OUT_OF_RANGE (issue #144): the offset we want was
+                    // captured earlier (snapshot or checkpoint) and retention has
+                    // since deleted it. Re-read the broker's log start offset and
+                    // resume from there rather than failing the partition — but
+                    // record the skipped range durably first: those records are
+                    // gone from the source, and a backup that silently contains
+                    // a hole is worse than one that fails loudly.
+                    let e = if is_offset_out_of_range(&e) {
                         warn!(
                             "{}:{}: offset {} out of range (likely deleted by retention), \
                              refetching earliest and resuming",
@@ -987,23 +994,39 @@ impl BackupPartitionContext {
                         );
                         match self.router.get_offsets(&self.topic, self.partition).await {
                             Ok((new_earliest, _)) if new_earliest > current_offset => {
+                                // Only the part of the gap inside this run's target
+                                // range counts as lost *for this backup*; anything
+                                // past `end_offset` was never going to be captured.
+                                let gap_end = new_earliest.min(end_offset);
+                                self.record_offset_gap(current_offset, gap_end).await;
                                 current_offset = new_earliest;
                                 continue;
                             }
-                            Ok(_) => {
-                                // new_earliest <= current_offset: the out-of-range error
-                                // wasn't a retention gap we can jump past. Fall through
-                                // to the original failure handling below.
+                            Ok((new_earliest, new_latest)) => {
+                                // The log start offset has NOT moved past us, so this
+                                // is not a retention gap we can jump over: the offset
+                                // is beyond the log end (log truncated or topic
+                                // recreated underneath us). Not recoverable here —
+                                // fail with a message that says which case it is.
+                                out_of_range_error(
+                                    &self.topic,
+                                    self.partition,
+                                    current_offset,
+                                    new_earliest,
+                                    new_latest,
+                                )
                             }
                             Err(offset_err) => {
                                 warn!(
                                     "{}:{}: failed to refetch earliest offset after out-of-range error: {}",
                                     self.topic, self.partition, offset_err
                                 );
-                                // Fall through to original failure handling below.
+                                e
                             }
                         }
-                    }
+                    } else {
+                        e
+                    };
 
                     self.health
                         .mark_degraded("kafka", &format!("Fetch error: {}", e));
@@ -1202,6 +1225,54 @@ impl BackupPartitionContext {
         partition_backup.add_segment(segment_metadata);
     }
 
+    /// Record that offsets `[start_offset, end_offset)` are permanently missing
+    /// from this backup (issue #144): manifest entry, Prometheus counters,
+    /// snapshot progress, and a best-effort manifest save so the gap survives
+    /// a crash before the next segment flush.
+    async fn record_offset_gap(&self, start_offset: i64, end_offset: i64) {
+        let gap = OffsetGap {
+            start_offset,
+            end_offset,
+            reason: OffsetGapReason::OffsetOutOfRange,
+            detected_at: chrono::Utc::now().timestamp_millis(),
+        };
+        let span = gap.offset_span();
+        if span == 0 {
+            return;
+        }
+
+        warn!(
+            "{}:{}: recording data gap [{}, {}) — {} offsets permanently missing from backup {} \
+             (deleted from the source before they could be fetched)",
+            self.topic, self.partition, start_offset, end_offset, span, self.backup_id
+        );
+
+        {
+            let mut manifest = self.manifest.lock().await;
+            manifest
+                .get_or_create_topic(&self.topic)
+                .get_or_create_partition(self.partition)
+                .add_gap(gap);
+        }
+
+        if let Some(ref prom) = self.prometheus_metrics {
+            prom.record_offset_gap(&self.backup_id, span);
+            // The skipped span still counts towards the captured snapshot's
+            // remaining offsets, otherwise the progress gauge never reaches
+            // zero for a partition that recovered from a gap.
+            if self.target_offset.is_some() {
+                prom.advance_snapshot_progress(&self.backup_id, span);
+            }
+        }
+
+        if let Err(e) = self.manifest_persistence.save_now().await {
+            warn!(
+                "Best-effort manifest save failed for {}:{} after recording data gap: {}",
+                self.topic, self.partition, e
+            );
+        }
+    }
+
     async fn persist_progress_best_effort(&self, reason: &str) {
         if let Err(e) = self.manifest_persistence.save_now().await {
             warn!(
@@ -1236,11 +1307,44 @@ impl BackupPartitionContext {
     }
 }
 
+/// Kafka protocol error code for OFFSET_OUT_OF_RANGE.
+const OFFSET_OUT_OF_RANGE: i16 = 1;
+
+/// True if `e` is the broker rejecting a Fetch with OFFSET_OUT_OF_RANGE.
 fn is_offset_out_of_range(e: &Error) -> bool {
-    match e {
-        Error::Kafka(KafkaError::BrokerError { code, .. }) => *code == 1,
-        _ => false,
-    }
+    matches!(
+        e,
+        Error::Kafka(KafkaError::BrokerError {
+            code: OFFSET_OUT_OF_RANGE,
+            ..
+        })
+    )
+}
+
+/// Build the error for an OFFSET_OUT_OF_RANGE that cannot be recovered by
+/// skipping forward: the broker's log start offset (`earliest`) has not moved
+/// past `offset`, so the fetch position must be beyond the log end instead.
+/// Keeps error code 1 so metrics still classify it as `OffsetInvalid`.
+fn out_of_range_error(
+    topic: &str,
+    partition: i32,
+    offset: i64,
+    earliest: i64,
+    latest: i64,
+) -> Error {
+    let cause = if offset >= latest {
+        "beyond the log end offset (log truncated or topic recreated?)"
+    } else {
+        "inside the broker's reported range (leader change or replica inconsistency?)"
+    };
+    Error::Kafka(KafkaError::BrokerError {
+        code: OFFSET_OUT_OF_RANGE,
+        message: format!(
+            "Fetch offset {} for {}:{} is out of range and cannot be recovered by skipping \
+             forward: broker log range is [{}, {}), offset is {}",
+            offset, topic, partition, earliest, latest, cause
+        ),
+    })
 }
 
 /// Maximum bytes to request per Fetch call: an explicit `fetch_max_bytes`
@@ -1299,7 +1403,8 @@ async fn save_manifest_snapshot(
 ///   - Partitions only in existing → preserved
 ///   - Partitions only in current  → appended
 ///   - Partitions in both: segments deduplicated by (key, start_offset); existing wins on
-///     conflict. Output sorted by start_offset.
+///     conflict. Output sorted by start_offset. Offset gaps are unioned, deduplicated by
+///     start_offset.
 fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> BackupManifest {
     use std::collections::HashMap as HM;
 
@@ -1340,6 +1445,11 @@ fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> Bac
                         }
                     }
                     ex_part.segments.sort_by_key(|s| s.start_offset);
+                    // Gaps recorded by the current session are unioned in;
+                    // add_gap dedups by start_offset and keeps them sorted.
+                    for gap in cur_part.gaps {
+                        ex_part.add_gap(gap);
+                    }
                 } else {
                     ex_topic.partitions.push(cur_part);
                 }
@@ -1583,6 +1693,7 @@ mod tests {
         PartitionBackup {
             partition_id: id,
             segments,
+            gaps: Vec::new(),
         }
     }
 
@@ -1872,5 +1983,112 @@ mod tests {
         let merged = merge_manifests(existing, current);
         assert_eq!(merged.topics.len(), 1);
         assert_eq!(merged.topics[0].name, "orders");
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #144: OFFSET_OUT_OF_RANGE recovery
+    // ------------------------------------------------------------------
+
+    fn broker_error(code: i16) -> Error {
+        Error::Kafka(KafkaError::BrokerError {
+            code,
+            message: format!("Fetch error for t:0: code {code}"),
+        })
+    }
+
+    #[test]
+    fn test_is_offset_out_of_range_matches_only_code_1() {
+        assert!(is_offset_out_of_range(&broker_error(1)));
+        // NOT_LEADER_FOR_PARTITION and other broker codes are not retention gaps.
+        assert!(!is_offset_out_of_range(&broker_error(6)));
+        assert!(!is_offset_out_of_range(&broker_error(0)));
+        // Non-broker errors never match, even if they mention "code 1".
+        assert!(!is_offset_out_of_range(&Error::Kafka(
+            KafkaError::Protocol("code 1".to_string())
+        )));
+        assert!(!is_offset_out_of_range(&Error::Compression(
+            "code 1".to_string()
+        )));
+    }
+
+    #[test]
+    fn test_out_of_range_error_keeps_code_1_and_explains_cause() {
+        // Beyond the log end: truncation / topic recreated.
+        let e = out_of_range_error("orders", 3, 5_000, 100, 4_000);
+        assert!(is_offset_out_of_range(&e), "must still classify as code 1");
+        let msg = e.to_string();
+        assert!(msg.contains("orders:3"), "{msg}");
+        assert!(msg.contains("5000"), "{msg}");
+        assert!(msg.contains("[100, 4000)"), "{msg}");
+        assert!(msg.contains("beyond the log end"), "{msg}");
+
+        // Inside the reported range: leader change / replica inconsistency.
+        let e = out_of_range_error("orders", 3, 2_000, 100, 4_000);
+        assert!(is_offset_out_of_range(&e));
+        assert!(e.to_string().contains("inside the broker's reported range"));
+    }
+
+    fn make_gap(start: i64, end: i64) -> OffsetGap {
+        OffsetGap {
+            start_offset: start,
+            end_offset: end,
+            reason: OffsetGapReason::OffsetOutOfRange,
+            detected_at: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn test_merge_manifests_unions_and_dedups_gaps() {
+        // Existing manifest (from an earlier save in the same run, or an
+        // earlier run) already carries a gap; the current session re-detected
+        // the same gap and found a new one.
+        let mut ex_part = make_partition(0, vec![make_segment("seg-a", 200, 299)]);
+        ex_part.add_gap(make_gap(100, 200));
+        let mut existing = BackupManifest::new("test".to_string());
+        existing
+            .topics
+            .push(make_topic("orders", Some(1), vec![ex_part]));
+
+        let mut cur_part = make_partition(0, vec![make_segment("seg-b", 500, 599)]);
+        cur_part.add_gap(make_gap(100, 200)); // duplicate — must not double count
+        cur_part.add_gap(make_gap(300, 500)); // new
+        let mut current = BackupManifest::new("test".to_string());
+        current
+            .topics
+            .push(make_topic("orders", Some(1), vec![cur_part]));
+
+        let merged = merge_manifests(existing, current);
+        let part = &merged.topics[0].partitions[0];
+        assert_eq!(part.segments.len(), 2);
+        assert_eq!(
+            part.gaps,
+            vec![make_gap(100, 200), make_gap(300, 500)],
+            "gaps are unioned, deduplicated by start_offset, and sorted"
+        );
+        assert_eq!(merged.total_gaps(), 2);
+    }
+
+    #[test]
+    fn test_merge_manifests_keeps_gaps_on_new_partition() {
+        // Partition only in `current` is appended wholesale, gaps included.
+        let mut cur_part = make_partition(1, vec![make_segment("seg-b", 50, 99)]);
+        cur_part.add_gap(make_gap(0, 50));
+        let mut current = BackupManifest::new("test".to_string());
+        current
+            .topics
+            .push(make_topic("orders", Some(2), vec![cur_part]));
+
+        let mut existing = BackupManifest::new("test".to_string());
+        existing.topics.push(make_topic(
+            "orders",
+            Some(2),
+            vec![make_partition(0, vec![make_segment("seg-a", 0, 99)])],
+        ));
+
+        let merged = merge_manifests(existing, current);
+        assert_eq!(merged.total_gaps(), 1);
+        let (topic, partition, gap) = merged.gaps().next().unwrap();
+        assert_eq!((topic, partition), ("orders", 1));
+        assert_eq!(gap, &make_gap(0, 50));
     }
 }

--- a/crates/kafka-backup-core/src/lib.rs
+++ b/crates/kafka-backup-core/src/lib.rs
@@ -34,9 +34,10 @@ pub use kafka::{
 };
 pub use manifest::{
     BackupManifest, BackupRecord, ConsumerGroupOffset, ConsumerGroupOffsets, DryRunPartitionReport,
-    DryRunRepartitioningInfo, DryRunReport, DryRunTopicReport, OffsetMapping, OffsetMappingEntry,
-    OffsetPair, PartitionBackup, PartitionRestoreReport, RecordHeader, RestoreCheckpoint,
-    RestoreReport, SegmentMetadata, TopicBackup, TopicRestoreReport,
+    DryRunRepartitioningInfo, DryRunReport, DryRunTopicReport, OffsetGap, OffsetGapReason,
+    OffsetMapping, OffsetMappingEntry, OffsetPair, PartitionBackup, PartitionRestoreReport,
+    RecordHeader, RestoreCheckpoint, RestoreReport, SegmentMetadata, TopicBackup,
+    TopicRestoreReport,
 };
 pub use metrics::{
     create_instrumented_backend, ErrorType, InstrumentedStorageBackend, MetricsReport,

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -70,6 +70,30 @@ impl BackupManifest {
             .map(|p| p.segments.len())
             .sum()
     }
+
+    /// Number of recorded offset gaps across all partitions (see [`OffsetGap`]).
+    ///
+    /// Zero means the backup captured every offset it set out to. Non-zero
+    /// means the source no longer had some records by the time they were
+    /// fetched, and this backup is knowingly incomplete for those ranges.
+    pub fn total_gaps(&self) -> usize {
+        self.topics
+            .iter()
+            .flat_map(|t| &t.partitions)
+            .map(|p| p.gaps.len())
+            .sum()
+    }
+
+    /// Iterate over every recorded offset gap as `(topic, partition, gap)`.
+    pub fn gaps(&self) -> impl Iterator<Item = (&str, i32, &OffsetGap)> {
+        self.topics.iter().flat_map(|t| {
+            t.partitions.iter().flat_map(move |p| {
+                p.gaps
+                    .iter()
+                    .map(move |g| (t.name.as_str(), p.partition_id, g))
+            })
+        })
+    }
 }
 
 /// Per-topic backup metadata
@@ -103,6 +127,7 @@ impl TopicBackup {
             self.partitions.push(PartitionBackup {
                 partition_id,
                 segments: Vec::new(),
+                gaps: Vec::new(),
             });
         }
         self.partitions
@@ -120,6 +145,14 @@ pub struct PartitionBackup {
 
     /// Segments for this partition
     pub segments: Vec<SegmentMetadata>,
+
+    /// Source offset ranges this backup could not capture (see [`OffsetGap`]).
+    ///
+    /// Empty for a backup with no known data loss. Omitted from the JSON when
+    /// empty, and absent from manifests written before 0.17 — both read back
+    /// as an empty list. Sorted by `start_offset`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gaps: Vec<OffsetGap>,
 }
 
 impl PartitionBackup {
@@ -131,6 +164,75 @@ impl PartitionBackup {
     /// Add a new segment
     pub fn add_segment(&mut self, segment: SegmentMetadata) {
         self.segments.push(segment);
+    }
+
+    /// Record an offset gap, keeping `gaps` sorted and free of duplicates.
+    ///
+    /// A gap with the same `start_offset` as an existing one is ignored: the
+    /// same range can be re-detected when a run is resumed before its
+    /// checkpoint advanced past the gap, and merging manifests must not
+    /// double-count it.
+    pub fn add_gap(&mut self, gap: OffsetGap) {
+        if self.gaps.iter().any(|g| g.start_offset == gap.start_offset) {
+            return;
+        }
+        self.gaps.push(gap);
+        self.gaps.sort_by_key(|g| g.start_offset);
+    }
+}
+
+/// A contiguous range of source offsets that this backup could not capture
+/// because the broker no longer had them when the partition was fetched.
+///
+/// Recorded when the broker returns `OFFSET_OUT_OF_RANGE` for the offset the
+/// backup wanted next and its log start offset has already moved past it —
+/// typically retention (or `DeleteRecords`) deleting data between snapshot
+/// capture / checkpoint and the fetch (issue #144). The backup resumes from
+/// `end_offset`; records in `[start_offset, end_offset)` are permanently
+/// absent from this backup and cannot be recovered from the source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OffsetGap {
+    /// First missing offset (inclusive).
+    pub start_offset: i64,
+
+    /// First offset after the gap (exclusive) — the offset the backup
+    /// resumed from.
+    pub end_offset: i64,
+
+    /// Why the gap occurred.
+    pub reason: OffsetGapReason,
+
+    /// When the gap was detected (epoch milliseconds).
+    pub detected_at: i64,
+}
+
+impl OffsetGap {
+    /// Number of offsets in `[start_offset, end_offset)`.
+    ///
+    /// This is an upper bound on the number of records lost: on compacted or
+    /// transactional topics some offsets in the range may never have held a
+    /// record by the time they were deleted.
+    pub fn offset_span(&self) -> i64 {
+        (self.end_offset - self.start_offset).max(0)
+    }
+}
+
+/// Why an [`OffsetGap`] was recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OffsetGapReason {
+    /// The broker returned `OFFSET_OUT_OF_RANGE` for the requested offset and
+    /// its log start offset had advanced past it: the records were deleted by
+    /// retention or `DeleteRecords` before the backup reached them.
+    OffsetOutOfRange,
+}
+
+impl std::fmt::Display for OffsetGapReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OffsetGapReason::OffsetOutOfRange => write!(f, "offset_out_of_range"),
+        }
     }
 }
 
@@ -1169,5 +1271,107 @@ mod tests {
         let e = m.entries.get("t/0").unwrap();
         assert_eq!(e.target_first_offset, Some(5000));
         assert_eq!(e.target_last_offset, Some(5099));
+    }
+
+    // ------------------------------------------------------------------
+    // Offset gaps (issue #144)
+    // ------------------------------------------------------------------
+
+    fn gap(start: i64, end: i64) -> OffsetGap {
+        OffsetGap {
+            start_offset: start,
+            end_offset: end,
+            reason: OffsetGapReason::OffsetOutOfRange,
+            detected_at: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn offset_gap_span_is_non_negative() {
+        assert_eq!(gap(100, 250).offset_span(), 150);
+        assert_eq!(gap(100, 100).offset_span(), 0);
+        assert_eq!(gap(100, 50).offset_span(), 0);
+    }
+
+    #[test]
+    fn partition_add_gap_dedups_by_start_and_sorts() {
+        let mut manifest = BackupManifest::new("b".to_string());
+        let part = manifest
+            .get_or_create_topic("orders")
+            .get_or_create_partition(0);
+        assert!(part.gaps.is_empty());
+
+        part.add_gap(gap(300, 400));
+        part.add_gap(gap(100, 200));
+        part.add_gap(gap(100, 250)); // same start — ignored, first wins
+        assert_eq!(part.gaps, vec![gap(100, 200), gap(300, 400)]);
+
+        assert_eq!(manifest.total_gaps(), 2);
+        let collected: Vec<_> = manifest.gaps().collect();
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0].0, "orders");
+        assert_eq!(collected[0].1, 0);
+        assert_eq!(collected[0].2, &gap(100, 200));
+    }
+
+    #[test]
+    fn offset_gap_serde_round_trip() {
+        let mut manifest = BackupManifest::new("b".to_string());
+        manifest
+            .get_or_create_topic("orders")
+            .get_or_create_partition(2)
+            .add_gap(gap(100, 200));
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(json.contains("\"gaps\""), "{json}");
+        assert!(
+            json.contains("\"reason\":\"offset_out_of_range\""),
+            "reason must be a stable snake_case string: {json}"
+        );
+
+        let back: BackupManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.topics[0].partitions[0].gaps, vec![gap(100, 200)]);
+    }
+
+    #[test]
+    fn empty_gaps_are_omitted_from_json() {
+        let mut manifest = BackupManifest::new("b".to_string());
+        manifest
+            .get_or_create_topic("orders")
+            .get_or_create_partition(0);
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(
+            !json.contains("gaps"),
+            "a backup with no gaps must not advertise a gaps field: {json}"
+        );
+    }
+
+    #[test]
+    fn manifest_written_before_gaps_existed_still_parses() {
+        // Exactly what a 0.16 manifest looks like: no `gaps` key at all.
+        let legacy = r#"{
+            "backup_id": "old",
+            "created_at": 1700000000000,
+            "topics": [{
+                "name": "orders",
+                "partitions": [{
+                    "partition_id": 0,
+                    "segments": [{
+                        "key": "old/topics/orders/partition=0/segment-0.bin",
+                        "start_offset": 0,
+                        "end_offset": 99,
+                        "start_timestamp": 0,
+                        "end_timestamp": 99000,
+                        "record_count": 100,
+                        "uncompressed_size": 1,
+                        "compressed_size": 1
+                    }]
+                }]
+            }]
+        }"#;
+        let manifest: BackupManifest = serde_json::from_str(legacy).unwrap();
+        assert!(manifest.topics[0].partitions[0].gaps.is_empty());
+        assert_eq!(manifest.total_gaps(), 0);
+        assert_eq!(manifest.gaps().count(), 0);
     }
 }

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -78,6 +78,14 @@ pub struct PrometheusMetrics {
     /// Cumulative bytes backed up.
     pub bytes_total: Family<BackupLabels, Counter>,
 
+    /// Offset gaps recorded because the source no longer had the records
+    /// (issue #144). Each increment is one contiguous range skipped.
+    pub offset_gaps_total: Family<BackupLabels, Counter>,
+
+    /// Cumulative source offsets skipped across all recorded gaps. An upper
+    /// bound on records permanently missing from the backup.
+    pub offsets_skipped_total: Family<BackupLabels, Counter>,
+
     // ========================================
     // Operation Duration Metrics
     // ========================================
@@ -202,6 +210,8 @@ impl PrometheusMetrics {
         let throughput_bytes_per_sec = Family::<ThroughputLabels, Gauge<f64, AtomicU64>>::default();
         let records_total = Family::<BackupLabels, Counter>::default();
         let bytes_total = Family::<BackupLabels, Counter>::default();
+        let offset_gaps_total = Family::<BackupLabels, Counter>::default();
+        let offsets_skipped_total = Family::<BackupLabels, Counter>::default();
 
         // Operation Duration Metrics
         let backup_duration_seconds =
@@ -303,6 +313,16 @@ impl PrometheusMetrics {
             "kafka_backup_bytes",
             "Cumulative bytes backed up",
             bytes_total.clone(),
+        );
+        registry.register(
+            "kafka_backup_offset_gaps",
+            "Offset ranges skipped because the source no longer had the records",
+            offset_gaps_total.clone(),
+        );
+        registry.register(
+            "kafka_backup_offsets_skipped",
+            "Cumulative source offsets skipped across all recorded gaps",
+            offsets_skipped_total.clone(),
         );
 
         // Operation Duration Metrics
@@ -418,6 +438,8 @@ impl PrometheusMetrics {
             throughput_bytes_per_sec,
             records_total,
             bytes_total,
+            offset_gaps_total,
+            offsets_skipped_total,
             backup_duration_seconds,
             restore_duration_seconds,
             storage_write_latency_seconds,
@@ -576,6 +598,16 @@ impl PrometheusMetrics {
     pub fn inc_records(&self, backup_id: &str, count: u64) {
         let labels = BackupLabels::new(backup_id);
         self.records_total.get_or_create(&labels).inc_by(count);
+    }
+
+    /// Record an offset gap: the backup skipped `offsets_skipped` source
+    /// offsets because the broker no longer had them (issue #144).
+    pub fn record_offset_gap(&self, backup_id: &str, offsets_skipped: i64) {
+        let labels = BackupLabels::new(backup_id);
+        self.offset_gaps_total.get_or_create(&labels).inc();
+        self.offsets_skipped_total
+            .get_or_create(&labels)
+            .inc_by(offsets_skipped.max(0) as u64);
     }
 
     /// Increment cumulative bytes counter.
@@ -914,6 +946,24 @@ mod tests {
         let encoded = metrics.encode();
         assert!(encoded.contains("kafka_backup_errors"));
         assert!(encoded.contains("broker_connection"));
+    }
+
+    #[test]
+    fn test_record_offset_gap() {
+        let metrics = PrometheusMetrics::new();
+        metrics.record_offset_gap("backup-001", 150);
+        metrics.record_offset_gap("backup-001", 50);
+        metrics.record_offset_gap("backup-001", -5); // clamped to 0, still one gap event
+
+        let encoded = metrics.encode();
+        assert!(
+            encoded.contains("kafka_backup_offset_gaps_total{backup_id=\"backup-001\"} 3"),
+            "{encoded}"
+        );
+        assert!(
+            encoded.contains("kafka_backup_offsets_skipped_total{backup_id=\"backup-001\"} 200"),
+            "{encoded}"
+        );
     }
 
     #[test]

--- a/crates/kafka-backup-core/tests/integration_suite/issue_144_offset_out_of_range.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_144_offset_out_of_range.rs
@@ -1,0 +1,345 @@
+//! Issue #144 — OFFSET_OUT_OF_RANGE recovery.
+//!
+//! When retention (or `DeleteRecords`) removes the offset a backup wants next
+//! — a snapshot-captured `earliest` that aged out while the partition sat in
+//! the concurrency queue, or a checkpoint that aged out between runs — the
+//! broker rejects the Fetch with error code 1 and, before the fix, the whole
+//! partition (and therefore the run) failed. The resume case was worse: it
+//! never self-healed, because the checkpoint only advances on a successful
+//! fetch.
+//!
+//! These tests drive the same fetch-loop path deterministically with the
+//! `DeleteRecords` admin API instead of waiting on retention: back up, produce
+//! more, delete past the checkpoint, back up again. The fix must (1) complete
+//! the run, (2) resume from the broker's new log start offset, and (3) record
+//! the skipped range in the manifest so the backup is not silently holed.
+//!
+//! These tests require Docker and use Testcontainers to run a real broker.
+
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, OffsetStorageConfig, SecurityConfig,
+    TopicSelection,
+};
+use kafka_backup_core::kafka::delete_records;
+use kafka_backup_core::manifest::{BackupManifest, OffsetGapReason};
+use kafka_backup_core::storage::StorageBackendConfig;
+use kafka_backup_core::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
+
+use super::common::{generate_test_records, KafkaTestCluster};
+
+const PARTITIONS: i32 = 3; // KafkaTestCluster::create_topic always creates 3
+
+fn snapshot_backup_config(
+    bootstrap_server: &str,
+    storage_path: PathBuf,
+    offset_db_path: PathBuf,
+    backup_id: &str,
+    topic: &str,
+) -> Config {
+    Config {
+        mode: Mode::Backup,
+        backup_id: backup_id.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bootstrap_server.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![topic.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem { path: storage_path },
+        backup: Some(BackupOptions {
+            segment_max_bytes: 1024 * 1024,
+            segment_max_interval_ms: 10000,
+            compression: CompressionType::Zstd,
+            // Snapshot mode is what issue #144 was reported against; it also
+            // exercises the snapshot-progress accounting on the recovery path.
+            stop_at_current_offsets: true,
+            continuous: false,
+            ..Default::default()
+        }),
+        restore: None,
+        offset_storage: Some(OffsetStorageConfig {
+            db_path: offset_db_path,
+            ..Default::default()
+        }),
+        metrics: None,
+    }
+}
+
+async fn run_backup(config: Config) -> kafka_backup_core::Result<()> {
+    let engine = BackupEngine::new(config)
+        .await
+        .expect("Failed to create backup engine");
+    tokio::time::timeout(Duration::from_secs(90), engine.run())
+        .await
+        .expect("Backup timed out")
+}
+
+fn read_manifest(storage_dir: &TempDir, backup_id: &str) -> BackupManifest {
+    let path = storage_dir.path().join(backup_id).join("manifest.json");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read manifest {:?}: {}", path, e));
+    serde_json::from_str(&content).expect("Failed to parse manifest")
+}
+
+async fn produce_round_robin(cluster: &KafkaTestCluster, topic: &str, count: usize) {
+    let client = cluster.create_client();
+    client.connect().await.expect("Failed to connect");
+    for (i, record) in generate_test_records(count, topic).iter().enumerate() {
+        client
+            .produce(
+                topic,
+                (i as i32) % PARTITIONS,
+                vec![record.clone()],
+                -1,
+                30_000,
+            )
+            .await
+            .expect("Failed to produce");
+    }
+}
+
+/// Resume path (the permanent-wedge case from the issue triage): the
+/// checkpoint from run 1 has aged out of the log by the time run 2 starts.
+///
+/// Timeline per partition (3 partitions, records round-robined):
+///   run 1 backs up offsets 0..=19        -> checkpoint 19
+///   produce 20 more                      -> offsets 20..=39
+///   DeleteRecords(30)                    -> log start offset 30
+///   run 2 resumes at 20 -> OFFSET_OUT_OF_RANGE -> must skip to 30 and record
+///   the gap [20, 30) instead of failing (and instead of wedging forever).
+#[tokio::test]
+#[ignore] // Requires Docker
+async fn test_backup_recovers_from_offset_out_of_range_and_records_gap() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("Failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let topic = "issue-144-retention-gap";
+    let backup_id = "issue-144-backup";
+    let per_partition_run1 = 20usize;
+
+    cluster
+        .create_topic(topic, per_partition_run1 * PARTITIONS as usize)
+        .await
+        .expect("Failed to create topic");
+    sleep(Duration::from_secs(2)).await;
+
+    let storage_dir = TempDir::new().expect("storage temp dir");
+    let offset_dir = TempDir::new().expect("offset temp dir");
+    let offset_db_path = offset_dir.path().join("offsets.db");
+
+    let config = || {
+        snapshot_backup_config(
+            &cluster.bootstrap_servers,
+            storage_dir.path().to_path_buf(),
+            offset_db_path.clone(),
+            backup_id,
+            topic,
+        )
+    };
+
+    // --- Run 1: baseline, everything present ---
+    run_backup(config()).await.expect("Run 1 should succeed");
+    let manifest1 = read_manifest(&storage_dir, backup_id);
+    assert_eq!(
+        manifest1.total_records(),
+        (per_partition_run1 * PARTITIONS as usize) as i64,
+        "run 1 should capture every record"
+    );
+    assert_eq!(manifest1.total_gaps(), 0, "run 1 must not record any gap");
+
+    // --- Produce more, then delete past the checkpoint ---
+    let per_partition_run2 = 20usize;
+    produce_round_robin(&cluster, topic, per_partition_run2 * PARTITIONS as usize).await;
+    sleep(Duration::from_secs(1)).await;
+
+    let checkpoint = per_partition_run1 as i64 - 1; // 19
+    let new_log_start = 30i64; // > checkpoint + 1, < high watermark (40)
+    let client = cluster.create_client();
+    client.connect().await.expect("Failed to connect");
+    let targets: Vec<(i32, i64)> = (0..PARTITIONS).map(|p| (p, new_log_start)).collect();
+    delete_records(&client, topic, &targets, 30_000)
+        .await
+        .expect("DeleteRecords should succeed");
+
+    for p in 0..PARTITIONS {
+        let (earliest, latest) = client.get_offsets(topic, p).await.expect("get_offsets");
+        assert_eq!(earliest, new_log_start, "partition {p}: log start offset");
+        assert_eq!(
+            latest,
+            (per_partition_run1 + per_partition_run2) as i64,
+            "partition {p}: high watermark"
+        );
+    }
+
+    // --- Run 2: resumes from checkpoint 19 -> offset 20 is gone ---
+    // Before the fix this failed every partition with
+    // "Broker returned error code 1: Fetch error for <topic>:<p>: code 1"
+    // and kept failing on every retry because the checkpoint never moved.
+    run_backup(config())
+        .await
+        .expect("Run 2 must recover from OFFSET_OUT_OF_RANGE instead of failing");
+
+    let manifest2 = read_manifest(&storage_dir, backup_id);
+    let topic_backup = manifest2
+        .topics
+        .iter()
+        .find(|t| t.name == topic)
+        .expect("topic in manifest");
+    assert_eq!(topic_backup.partitions.len(), PARTITIONS as usize);
+
+    for partition in &topic_backup.partitions {
+        let p = partition.partition_id;
+
+        // Exactly one gap, with the exact bounds: [checkpoint + 1, new log start).
+        assert_eq!(
+            partition.gaps.len(),
+            1,
+            "partition {p}: expected exactly one recorded gap, got {:?}",
+            partition.gaps
+        );
+        let gap = &partition.gaps[0];
+        assert_eq!(gap.start_offset, checkpoint + 1, "partition {p}: gap start");
+        assert_eq!(gap.end_offset, new_log_start, "partition {p}: gap end");
+        assert_eq!(gap.reason, OffsetGapReason::OffsetOutOfRange);
+        assert_eq!(gap.offset_span(), new_log_start - (checkpoint + 1));
+        assert!(gap.detected_at > 0, "partition {p}: detected_at is set");
+
+        // No segment claims to hold data from inside the gap.
+        for seg in &partition.segments {
+            assert!(
+                seg.end_offset < gap.start_offset || seg.start_offset >= gap.end_offset,
+                "partition {p}: segment {}..{} overlaps recorded gap {}..{}",
+                seg.start_offset,
+                seg.end_offset,
+                gap.start_offset,
+                gap.end_offset
+            );
+        }
+
+        // Run 2 resumed exactly at the new log start offset and read to the end.
+        assert!(
+            partition
+                .segments
+                .iter()
+                .any(|s| s.start_offset == new_log_start),
+            "partition {p}: a segment should start at the new log start offset {new_log_start}; segments: {:?}",
+            partition
+                .segments
+                .iter()
+                .map(|s| (s.start_offset, s.end_offset))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            partition.last_offset(),
+            Some((per_partition_run1 + per_partition_run2) as i64 - 1),
+            "partition {p}: backed up to the high watermark"
+        );
+    }
+
+    // Records: run 1 (0..=19) + run 2 (30..=39) per partition; 20..=29 lost.
+    let expected_records = ((per_partition_run1 as i64) + (40 - new_log_start)) * PARTITIONS as i64;
+    assert_eq!(manifest2.total_records(), expected_records);
+    assert_eq!(manifest2.total_gaps(), PARTITIONS as usize);
+
+    // The checkpoint advanced past the gap — the run is no longer wedged.
+    let store = SqliteOffsetStore::new(OffsetStoreConfig {
+        db_path: offset_db_path.clone(),
+        ..Default::default()
+    })
+    .await
+    .expect("open offset store");
+    for p in 0..PARTITIONS {
+        let saved = store
+            .get_offset(backup_id, topic, p)
+            .await
+            .expect("get_offset")
+            .expect("checkpoint present");
+        assert_eq!(
+            saved,
+            (per_partition_run1 + per_partition_run2) as i64 - 1,
+            "partition {p}: checkpoint should be at the high watermark after recovery"
+        );
+    }
+    drop(store);
+
+    // --- Run 3: nothing new. Must succeed and must not duplicate or lose
+    // the recorded gaps when the manifest is merged again. ---
+    run_backup(config()).await.expect("Run 3 should succeed");
+    let manifest3 = read_manifest(&storage_dir, backup_id);
+    assert_eq!(manifest3.total_records(), expected_records);
+    assert_eq!(
+        manifest3.total_gaps(),
+        PARTITIONS as usize,
+        "gaps must survive a further manifest merge without duplication"
+    );
+    for (t, p, gap) in manifest3.gaps() {
+        assert_eq!(t, topic);
+        assert!((0..PARTITIONS).contains(&p));
+        assert_eq!(
+            (gap.start_offset, gap.end_offset),
+            (checkpoint + 1, new_log_start)
+        );
+    }
+}
+
+/// A backup whose data is fully intact must not grow a `gaps` field: the
+/// manifest format for the common case is unchanged.
+#[tokio::test]
+#[ignore] // Requires Docker
+async fn test_backup_without_data_loss_records_no_gaps() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("Failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let topic = "issue-144-no-gap";
+    cluster
+        .create_topic(topic, 30)
+        .await
+        .expect("Failed to create topic");
+    sleep(Duration::from_secs(2)).await;
+
+    let storage_dir = TempDir::new().expect("storage temp dir");
+    let offset_dir = TempDir::new().expect("offset temp dir");
+    let config = snapshot_backup_config(
+        &cluster.bootstrap_servers,
+        storage_dir.path().to_path_buf(),
+        offset_dir.path().join("offsets.db"),
+        "issue-144-clean",
+        topic,
+    );
+    run_backup(config).await.expect("backup should succeed");
+
+    let raw = std::fs::read_to_string(
+        storage_dir
+            .path()
+            .join("issue-144-clean")
+            .join("manifest.json"),
+    )
+    .expect("read manifest");
+    assert!(
+        !raw.contains("\"gaps\""),
+        "a clean backup must not serialise a gaps field: {raw}"
+    );
+    let manifest: BackupManifest = serde_json::from_str(&raw).expect("parse manifest");
+    assert_eq!(manifest.total_gaps(), 0);
+    assert_eq!(manifest.total_records(), 30);
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -9,8 +9,10 @@
 //! - TLS Security: SSL/TLS certificate handling tests
 //! - Snapshot Backup: stop_at_current_offsets feature tests
 //! - Performance Issues: Issue #29 constant lag and throughput tests
+//! - Issue #144: OFFSET_OUT_OF_RANGE recovery and data-gap recording
 
 pub mod common;
+pub mod issue_144_offset_out_of_range;
 pub mod issue_56_missing_topic;
 pub mod issue_67_fixes;
 pub mod offset_semantics;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -363,6 +363,37 @@ This ensures consistent "point-in-time" snapshots for disaster recovery, even wi
 
 > **Note:** `stop_at_current_offsets` is incompatible with `continuous: true`. Use snapshot mode for scheduled backups (CronJobs), and continuous mode for streaming replication.
 
+#### Retention deleting data before it is fetched
+
+The offsets a backup starts from are captured before the fetch happens — for
+every partition up front in snapshot mode, and from the checkpoint on resume.
+With many partitions, bounded `max_concurrent_partitions`, or a long gap
+between runs, retention can delete those offsets before the partition's turn
+comes up. The broker then rejects the fetch with `OFFSET_OUT_OF_RANGE`.
+
+The backup does **not** fail in that case. It re-reads the partition's current
+log start offset, resumes from there, and records the skipped range as an
+**offset gap** in the manifest:
+
+```json
+{
+  "partition_id": 7,
+  "segments": [ ... ],
+  "gaps": [
+    { "start_offset": 0, "end_offset": 100000,
+      "reason": "offset_out_of_range", "detected_at": 1755522569000 }
+  ]
+}
+```
+
+Records inside a gap were deleted from the source before they could be
+fetched and cannot be recovered. `kafka-backup validate` and
+`kafka-backup describe` list recorded gaps, and the
+`kafka_backup_offset_gaps_total` / `kafka_backup_offsets_skipped_total`
+counters let you alert on them. If gaps appear regularly, raise
+`max_concurrent_partitions`, shorten the interval between runs, or increase
+the topic's retention so a full run fits inside the retention window.
+
 ### Compression Options
 
 | Algorithm | Description |
@@ -525,6 +556,8 @@ metrics:
 | `kafka_backup_snapshot_records_remaining` | Gauge | Captured snapshot offset span still to process |
 | `kafka_backup_records_total` | Counter | Total records backed up |
 | `kafka_backup_bytes_total` | Counter | Total bytes backed up |
+| `kafka_backup_offset_gaps_total` | Counter | Offset ranges skipped because the source no longer had the records (see [retention gaps](#retention-deleting-data-before-it-is-fetched)) |
+| `kafka_backup_offsets_skipped_total` | Counter | Source offsets skipped across all recorded gaps |
 | `kafka_backup_compression_ratio` | Gauge | Compression efficiency |
 | `kafka_backup_storage_write_latency_seconds` | Histogram | Storage write latency |
 | `kafka_backup_storage_write_bytes_total` | Counter | Storage I/O bytes |


### PR DESCRIPTION
Fixes #144  partitions no longer fail outright when the broker returns `OFFSET_OUT_OF_RANGE` (error code 1) mid-backup due to retention deleting the snapshot-captured `earliest` offset before that partition's turn came up.


## Change

Added detection and recovery for this specific error in `backup_partition()`'s fetch loop:

```rust
Err(e) => {
    if is_offset_out_of_range(&e) {
        warn!(
            "{}:{}: offset {} out of range (likely deleted by retention), \
             refetching earliest and resuming",
            self.topic, self.partition, current_offset
        );
        match self.router.get_offsets(&self.topic, self.partition).await {
            Ok((new_earliest, _)) if new_earliest > current_offset => {
                current_offset = new_earliest;
                continue;
            }
            _ => { /* fall through to original failure handling */ }
        }
    }

    self.health.mark_degraded("kafka", &format!("Fetch error: {}", e));
    self.kafka_cb.record_failure();
    ...
    return Err(e);
}
```

with a small helper:

```rust
fn is_offset_out_of_range(e: &Error) -> bool {
    matches!(e, Error::Kafka(KafkaError::BrokerError { code: 1, .. }))
}
```

If the refetched earliest offset is still not past the point we're stuck on, or the refetch itself fails, the code falls through to the original failure handling, so genuinely unrecoverable errors still surface correctly.
