### PR TITLE
Fix: expand is_connection_error to catch Windows Winsock connection-abort errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#146](https://github.com/osodevops/kafka-backup/issues/146).
 - Connection I/O errors are now attributed as `broker_connection` in
   `kafka_backup_errors_total` instead of `unknown`.
+- `PartitionLeaderRouter::fetch` (the backup path) now retries connection
+  errors up to 5 times with linear back-off, dropping cached broker
+  connections in between — the same policy `produce` and `delete_records`
+  already had. `KafkaClient::send_request` still reconnects and retries once
+  immediately; the router loop covers a proxy or broker resetting connections
+  for longer than that single retry, which previously failed the partition and
+  the whole run.
 
 ### Added
 - `KafkaError::ConnectionIo { operation, kind, raw_os_error, message }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-08-18
+
+### Fixed
+- Connection-loss detection no longer depends on the wording of the OS error
+  message. `KafkaClient::send_request` (reconnect + retry once) and the
+  partition router's produce / delete-records retry loops classified a failed
+  socket read or write by substring-matching `io::Error`'s Display text, which
+  is localized and platform-specific: Windows' `WSAECONNABORTED`
+  ("An established connection was aborted by the software in your host
+  machine. (os error 10053)"), `WSAECONNRESET` (10054) and `WSAETIMEDOUT`
+  (10060) never matched — nor did Unix `ETIMEDOUT` ("Operation timed out" /
+  "Connection timed out") or `ENOTCONN` — so a dropped connection failed the
+  whole backup or restore, sometimes hours in. I/O failures on the broker
+  connection are now surfaced as `KafkaError::ConnectionIo`, which preserves
+  the `std::io::ErrorKind` and raw OS error code, and a single shared
+  classifier (`kafka::is_connection_error`) decides by kind / code —
+  `ConnectionAborted`, `ConnectionReset`, `ConnectionRefused`, `BrokenPipe`,
+  `NotConnected`, `TimedOut`, `UnexpectedEof`, `NetworkDown`,
+  `NetworkUnreachable`, `HostUnreachable`, plus the Winsock codes `std` leaves
+  uncategorized (`WSAENETRESET`, `WSAESHUTDOWN`) and, on Windows,
+  `ERROR_NETNAME_DELETED` / `ERROR_SEM_TIMEOUT`. A message-based fallback is
+  kept for errors still built as `KafkaError::Protocol(String)`. Fixes
+  [#146](https://github.com/osodevops/kafka-backup/issues/146).
+- Connection I/O errors are now attributed as `broker_connection` in
+  `kafka_backup_errors_total` instead of `unknown`.
+
+### Added
+- `KafkaError::ConnectionIo { operation, kind, raw_os_error, message }`
+  (`KafkaError` is `#[non_exhaustive]`, so this is additive) and the public
+  `kafka::is_connection_error` / `kafka::is_connection_io_kind` helpers.
+  `kafka::is_connection_error_public` remains as an alias.
+
+### Changed
+- Socket I/O failures on a broker connection now render as
+  `Connection error during <operation> (<ErrorKind>): <os message>` instead of
+  `Protocol error: Failed to <operation>: <os message>`. Update any log-based
+  alerting that matched the old prefix.
+
 ## [0.17.0] - 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/error.rs
+++ b/crates/kafka-backup-core/src/error.rs
@@ -81,6 +81,26 @@ pub enum KafkaError {
     #[error("Broker returned error code {code}: {message}")]
     BrokerError { code: i16, message: String },
 
+    /// I/O failure on an established broker connection: sending a request,
+    /// reading a response, or one of our own request timeouts.
+    ///
+    /// Carries the [`std::io::ErrorKind`] and raw OS error code so callers can
+    /// decide whether the connection is lost without parsing the OS message —
+    /// which is localized (`FormatMessageW` on Windows, `strerror_r` on Unix)
+    /// and differs per platform (issue #146). Use
+    /// [`crate::kafka::is_connection_error`] rather than matching on `message`.
+    #[error("Connection error during {operation} ({kind:?}): {message}")]
+    ConnectionIo {
+        /// What the client was doing, e.g. `"send request"`.
+        operation: String,
+        /// `io::Error::kind()`; `TimedOut` for the client's own request timeouts.
+        kind: std::io::ErrorKind,
+        /// `io::Error::raw_os_error()` when the OS supplied one (errno / Winsock code).
+        raw_os_error: Option<i32>,
+        /// The OS or library message, for logs and operators.
+        message: String,
+    },
+
     /// Timeout
     #[error("Operation timed out: {0}")]
     Timeout(String),

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -499,12 +499,17 @@ impl KafkaClient {
     fn is_connection_error(error: &crate::Error) -> bool {
         match error {
             crate::Error::Kafka(KafkaError::Protocol(msg)) => {
-                msg.contains("Broken pipe")
-                    || msg.contains("early eof")
-                    || msg.contains("Connection reset")
-                    || msg.contains("Not connected")
-                    || msg.contains("connection abort")
-                    || msg.contains("timed out after")
+                let msg_lower = msg.to_lowercase();
+                msg_lower.contains("broken pipe")
+                    || msg_lower.contains("early eof")
+                    || msg_lower.contains("connection reset")
+                    || msg_lower.contains("not connected")
+                    || msg_lower.contains("connection abort")
+                    || msg_lower.contains("aborted")          // catches "was aborted by the software"
+                    || msg_lower.contains("timed out after")
+                    || msg_lower.contains("os error 10053")   // WSAECONNABORTED (Windows)
+                    || msg_lower.contains("os error 10054")   // WSAECONNRESET (Windows)
+                    || msg_lower.contains("os error 10060")   // WSAETIMEDOUT (Windows)
             }
             _ => false,
         }

--- a/crates/kafka-backup-core/src/kafka/client.rs
+++ b/crates/kafka-backup-core/src/kafka/client.rs
@@ -31,6 +31,7 @@ use crate::config::{KafkaConfig, SaslMechanism, SecurityProtocol};
 use crate::error::KafkaError;
 use crate::Result;
 
+use super::connection_error::{connection_io_error, request_timeout_error};
 use super::metadata::{BrokerMetadata, TopicMetadata};
 use super::FetchResponse;
 use super::ProduceResponse;
@@ -457,9 +458,10 @@ impl KafkaClient {
 
     /// Send a request and receive a response.
     ///
-    /// On connection errors (broken pipe, early eof), automatically reconnects
+    /// On connection errors (connection reset/aborted, broken pipe, EOF,
+    /// timeouts — see [`super::connection_error`]), automatically reconnects
     /// and retries once. This handles TCP connections dropped by cloud Kafka
-    /// providers during idle periods.
+    /// providers during idle periods and by Windows Winsock (issue #146).
     ///
     /// Note: Reconnection with retry is skipped for SASL auth requests to avoid
     /// infinite recursion (connect -> authenticate -> send_request -> reconnect -> connect...).
@@ -496,23 +498,12 @@ impl KafkaClient {
     }
 
     /// Check if an error is a connection-level error that warrants reconnection.
+    ///
+    /// Delegates to [`super::connection_error::is_connection_error`], which
+    /// classifies by `io::ErrorKind` / OS error code rather than message text
+    /// (issue #146).
     fn is_connection_error(error: &crate::Error) -> bool {
-        match error {
-            crate::Error::Kafka(KafkaError::Protocol(msg)) => {
-                let msg_lower = msg.to_lowercase();
-                msg_lower.contains("broken pipe")
-                    || msg_lower.contains("early eof")
-                    || msg_lower.contains("connection reset")
-                    || msg_lower.contains("not connected")
-                    || msg_lower.contains("connection abort")
-                    || msg_lower.contains("aborted")          // catches "was aborted by the software"
-                    || msg_lower.contains("timed out after")
-                    || msg_lower.contains("os error 10053")   // WSAECONNABORTED (Windows)
-                    || msg_lower.contains("os error 10054")   // WSAECONNRESET (Windows)
-                    || msg_lower.contains("os error 10060")   // WSAETIMEDOUT (Windows)
-            }
-            _ => false,
-        }
+        super::connection_error::is_connection_error(error)
     }
 
     /// Reconnect to the Kafka cluster, dropping the existing connection.
@@ -583,9 +574,12 @@ impl KafkaClient {
     {
         let api_version = self.get_api_version(api_key);
         let mut conn = self.connection.lock().await;
-        let conn = conn
-            .as_mut()
-            .ok_or_else(|| KafkaError::Protocol("Not connected".to_string()))?;
+        let conn = conn.as_mut().ok_or_else(|| KafkaError::ConnectionIo {
+            operation: "send request".to_string(),
+            kind: std::io::ErrorKind::NotConnected,
+            raw_os_error: None,
+            message: "Not connected".to_string(),
+        })?;
 
         send_rpc_on_stream(&mut conn.stream, api_key, api_version, buf).await
     }
@@ -737,18 +731,23 @@ pub(super) async fn send_rpc_on_stream<Resp>(
 where
     Resp: Decodable + Default,
 {
+    // I/O failures keep their `io::ErrorKind` / OS code (issue #146) so the
+    // reconnect path can classify them without parsing localized OS text.
     timeout(
         Duration::from_secs(WRITE_TIMEOUT_SECS),
         stream.write_all(buf),
     )
     .await
     .map_err(|_| {
-        KafkaError::Protocol(format!(
-            "Request timed out after {}s sending to broker",
-            WRITE_TIMEOUT_SECS
-        ))
+        request_timeout_error(
+            "send request",
+            format!(
+                "Request timed out after {}s sending to broker",
+                WRITE_TIMEOUT_SECS
+            ),
+        )
     })?
-    .map_err(|e| KafkaError::Protocol(format!("Failed to send request: {}", e)))?;
+    .map_err(|e| connection_io_error("send request", &e))?;
 
     let mut len_buf = [0u8; 4];
     timeout(
@@ -757,12 +756,15 @@ where
     )
     .await
     .map_err(|_| {
-        KafkaError::Protocol(format!(
-            "Request timed out after {}s waiting for broker response",
-            RESPONSE_TIMEOUT_SECS
-        ))
+        request_timeout_error(
+            "read response length",
+            format!(
+                "Request timed out after {}s waiting for broker response",
+                RESPONSE_TIMEOUT_SECS
+            ),
+        )
     })?
-    .map_err(|e| KafkaError::Protocol(format!("Failed to read response length: {}", e)))?;
+    .map_err(|e| connection_io_error("read response length", &e))?;
     let response_len = i32::from_be_bytes(len_buf) as usize;
 
     trace!("Receiving response: len={}", response_len);
@@ -774,12 +776,15 @@ where
     )
     .await
     .map_err(|_| {
-        KafkaError::Protocol(format!(
-            "Response body read timed out after {}s",
-            RESPONSE_TIMEOUT_SECS
-        ))
+        request_timeout_error(
+            "read response body",
+            format!(
+                "Response body read timed out after {}s",
+                RESPONSE_TIMEOUT_SECS
+            ),
+        )
     })?
-    .map_err(|e| KafkaError::Protocol(format!("Failed to read response body: {}", e)))?;
+    .map_err(|e| connection_io_error("read response body", &e))?;
 
     let mut response_bytes = Bytes::from(response_buf);
     let response_header_version = api_key.response_header_version(api_version);

--- a/crates/kafka-backup-core/src/kafka/connection_error.rs
+++ b/crates/kafka-backup-core/src/kafka/connection_error.rs
@@ -1,0 +1,312 @@
+//! Connection-loss classification (issue #146).
+//!
+//! Single source of truth for "is this error a lost or unusable broker
+//! connection that warrants reconnecting and retrying?" — used by
+//! `KafkaClient::send_request` (reconnect + retry once) and by the
+//! `PartitionLeaderRouter` produce / delete-records loops (bounded retries
+//! with backoff).
+//!
+//! Classification is **structural**: it reads the [`std::io::ErrorKind`] and
+//! raw OS error code preserved in [`KafkaError::ConnectionIo`]. It never
+//! decides based on the OS message text, because that text is localized
+//! (`FormatMessageW` on Windows follows the UI language; `strerror_r` on Unix
+//! follows `LC_MESSAGES`) and worded differently on every platform — e.g.
+//! `WSAECONNABORTED` reads *"An established connection was aborted by the
+//! software in your host machine. (os error 10053)"* on an English Windows,
+//! which is what the old substring matcher missed.
+//!
+//! A message-based fallback is kept for the legacy [`KafkaError::Protocol`]
+//! form so errors constructed by older code paths (and tests) still classify.
+
+use std::io;
+
+use crate::error::KafkaError;
+
+/// Windows Winsock / Win32 codes that mean the connection is gone but that
+/// `std` maps to `ErrorKind::Uncategorized` (so `kind()` alone would miss
+/// them). Winsock codes are ≥ 10000 and never collide with Unix errno values,
+/// so matching them unconditionally is safe on every platform.
+const WINSOCK_CONNECTION_LOST: &[i32] = &[
+    10052, // WSAENETRESET   — network dropped the connection on reset
+    10053, // WSAECONNABORTED — aborted by the local stack (also mapped by kind)
+    10054, // WSAECONNRESET  — forcibly closed by the remote host (also mapped by kind)
+    10057, // WSAENOTCONN    — socket is not connected (also mapped by kind)
+    10058, // WSAESHUTDOWN   — socket already shut down in that direction
+    10060, // WSAETIMEDOUT   — timed out (also mapped by kind)
+    10061, // WSAECONNREFUSED (also mapped by kind)
+];
+
+/// Small Win32 codes that share their numeric range with Unix errno, so they
+/// are only consulted when running on Windows.
+#[cfg(windows)]
+const WIN32_CONNECTION_LOST: &[i32] = &[
+    64,  // ERROR_NETNAME_DELETED — "The specified network name is no longer available"
+    121, // ERROR_SEM_TIMEOUT      — TCP send/receive timeout surfaced as a semaphore timeout
+];
+
+/// True if an I/O failure with this kind / OS code means the broker
+/// connection is lost or unusable, so the caller should reconnect and retry
+/// rather than fail.
+pub fn is_connection_io_kind(kind: io::ErrorKind, raw_os_error: Option<i32>) -> bool {
+    use io::ErrorKind::*;
+    match kind {
+        ConnectionAborted | ConnectionReset | ConnectionRefused | BrokenPipe | NotConnected
+        | TimedOut | UnexpectedEof | NetworkDown | NetworkUnreachable | HostUnreachable => true,
+        _ => match raw_os_error {
+            Some(code) => {
+                #[cfg(windows)]
+                if WIN32_CONNECTION_LOST.contains(&code) {
+                    return true;
+                }
+                WINSOCK_CONNECTION_LOST.contains(&code)
+            }
+            None => false,
+        },
+    }
+}
+
+/// True if `error` is a connection-level failure that warrants reconnecting
+/// and retrying the request.
+pub fn is_connection_error(error: &crate::Error) -> bool {
+    match error {
+        crate::Error::Kafka(KafkaError::ConnectionIo {
+            kind, raw_os_error, ..
+        }) => is_connection_io_kind(*kind, *raw_os_error),
+        crate::Error::Kafka(KafkaError::Protocol(msg)) => is_legacy_connection_message(msg),
+        _ => false,
+    }
+}
+
+/// Message-based fallback for the legacy `Protocol(String)` form.
+///
+/// Matches the client's own wording ("timed out after", "Not connected",
+/// tokio's "early eof"), the English Unix `strerror` texts, and the
+/// non-localized `(os error N)` suffix Rust appends for the Winsock codes.
+/// Deliberately does **not** match a bare "aborted": that word appears in
+/// unrelated protocol text (aborted transactions) and would misclassify a
+/// decode failure as a connection loss.
+fn is_legacy_connection_message(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("broken pipe")
+        || m.contains("early eof")
+        || m.contains("connection reset")
+        || m.contains("not connected")
+        || m.contains("connection abort")
+        || m.contains("connection was aborted")
+        || m.contains("forcibly closed")
+        || m.contains("timed out")
+        || WINSOCK_CONNECTION_LOST
+            .iter()
+            .any(|code| m.contains(&format!("(os error {code})")))
+}
+
+/// Build the error for an I/O failure during `operation` on the broker
+/// connection, preserving the kind and OS code for classification.
+pub(crate) fn connection_io_error(operation: &str, e: &io::Error) -> KafkaError {
+    KafkaError::ConnectionIo {
+        operation: operation.to_string(),
+        kind: e.kind(),
+        raw_os_error: e.raw_os_error(),
+        message: e.to_string(),
+    }
+}
+
+/// Build the error for one of the client's own request timeouts.
+pub(crate) fn request_timeout_error(operation: &str, message: String) -> KafkaError {
+    KafkaError::ConnectionIo {
+        operation: operation.to_string(),
+        kind: io::ErrorKind::TimedOut,
+        raw_os_error: None,
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+    use io::ErrorKind;
+
+    fn conn_io(kind: ErrorKind, raw: Option<i32>) -> Error {
+        Error::Kafka(KafkaError::ConnectionIo {
+            operation: "send request".into(),
+            kind,
+            raw_os_error: raw,
+            message: "irrelevant — classification must not read this".into(),
+        })
+    }
+
+    fn protocol(msg: &str) -> Error {
+        Error::Kafka(KafkaError::Protocol(msg.to_string()))
+    }
+
+    #[test]
+    fn structured_kinds_that_mean_connection_lost() {
+        for kind in [
+            ErrorKind::ConnectionAborted,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionRefused,
+            ErrorKind::BrokenPipe,
+            ErrorKind::NotConnected,
+            ErrorKind::TimedOut,
+            ErrorKind::UnexpectedEof,
+            ErrorKind::NetworkDown,
+            ErrorKind::NetworkUnreachable,
+            ErrorKind::HostUnreachable,
+        ] {
+            assert!(is_connection_error(&conn_io(kind, None)), "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn structured_kinds_that_are_not_connection_errors() {
+        for kind in [
+            ErrorKind::InvalidData,
+            ErrorKind::InvalidInput,
+            ErrorKind::PermissionDenied,
+            ErrorKind::NotFound,
+            ErrorKind::Other,
+            ErrorKind::Interrupted,
+            ErrorKind::WouldBlock,
+        ] {
+            assert!(!is_connection_error(&conn_io(kind, None)), "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn winsock_codes_classify_even_when_kind_is_uncategorized() {
+        // WSAENETRESET / WSAESHUTDOWN are not mapped to a specific ErrorKind by
+        // std, so only the raw code identifies them.
+        for code in [10052, 10053, 10054, 10057, 10058, 10060, 10061] {
+            assert!(
+                is_connection_error(&conn_io(ErrorKind::Other, Some(code))),
+                "winsock {code}"
+            );
+        }
+        // Unrelated Winsock codes stay unclassified.
+        assert!(!is_connection_error(&conn_io(
+            ErrorKind::Other,
+            Some(10013)
+        ))); // WSAEACCES
+        assert!(!is_connection_error(&conn_io(
+            ErrorKind::Other,
+            Some(10048)
+        ))); // WSAEADDRINUSE
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn win32_small_codes_classify_on_windows_only() {
+        assert!(is_connection_error(&conn_io(ErrorKind::Other, Some(64))));
+        assert!(is_connection_error(&conn_io(ErrorKind::Other, Some(121))));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn win32_small_codes_are_ignored_off_windows() {
+        // 64 is ENONET on Linux / EHOSTDOWN on macOS; without a mapped kind we
+        // do not guess.
+        assert!(!is_connection_error(&conn_io(ErrorKind::Other, Some(64))));
+        assert!(!is_connection_error(&conn_io(ErrorKind::Other, Some(121))));
+    }
+
+    #[test]
+    fn real_io_errors_round_trip_through_constructor() {
+        let e = io::Error::new(ErrorKind::ConnectionAborted, "boom");
+        let err = Error::Kafka(connection_io_error("send request", &e));
+        assert!(is_connection_error(&err));
+        let text = err.to_string();
+        assert!(text.contains("send request"), "{text}");
+        assert!(text.contains("ConnectionAborted"), "{text}");
+        assert!(text.contains("boom"), "{text}");
+
+        // A raw OS error keeps its code. ECONNRESET differs per platform, so
+        // just check the plumbing.
+        let e = io::Error::from_raw_os_error(10054);
+        let KafkaError::ConnectionIo { raw_os_error, .. } = connection_io_error("read", &e) else {
+            panic!("expected ConnectionIo");
+        };
+        assert_eq!(raw_os_error, Some(10054));
+    }
+
+    #[test]
+    fn request_timeouts_are_connection_errors() {
+        let err = Error::Kafka(request_timeout_error(
+            "read response length",
+            "Request timed out after 60s waiting for broker response".into(),
+        ));
+        assert!(is_connection_error(&err));
+    }
+
+    /// The exact texts `format!("Failed to …: {}", io_err)` produced before
+    /// the structured variant existed, on each platform. All must classify
+    /// via the legacy fallback — including the Windows texts that motivated
+    /// issue #146 and the localized (German) variant, which only the
+    /// `(os error N)` suffix identifies.
+    #[test]
+    fn legacy_protocol_messages_still_classify() {
+        let positives = [
+            // Windows (English UI)
+            "Failed to send request: An established connection was aborted by the software in your host machine. (os error 10053)",
+            "Failed to read response length: An existing connection was forcibly closed by the remote host. (os error 10054)",
+            "Failed to read response body: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond. (os error 10060)",
+            "Failed to send request: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied. (os error 10057)",
+            "Failed to send request: A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call. (os error 10058)",
+            // Windows (German UI) — only the numeric suffix is stable
+            "Failed to send request: Eine bestehende Verbindung wurde softwaregesteuert durch den Hostcomputer abgebrochen. (os error 10053)",
+            // macOS
+            "Failed to read response length: Connection reset by peer (os error 54)",
+            "Failed to send request: Software caused connection abort (os error 53)",
+            "Failed to send request: Broken pipe (os error 32)",
+            "Failed to send request: Socket is not connected (os error 57)",
+            "Failed to read response length: Operation timed out (os error 60)",
+            // Linux
+            "Failed to read response length: Connection reset by peer (os error 104)",
+            "Failed to read response length: Connection timed out (os error 110)",
+            "Failed to send request: Transport endpoint is not connected (os error 107)",
+            // tokio / client-internal
+            "Failed to read response length: early eof",
+            "Request timed out after 60s waiting for broker response",
+            "Response body read timed out after 60s",
+            "Not connected",
+        ];
+        for msg in positives {
+            assert!(
+                is_connection_error(&protocol(msg)),
+                "should classify: {msg}"
+            );
+        }
+
+        let negatives = [
+            "Failed to decode response: DecodeError",
+            "Failed to encode request: EncodeError",
+            // Contains "aborted" but is not a connection error — a bare
+            // "aborted" substring match would get this wrong.
+            "Failed to decode response: aborted transaction marker missing",
+            "Unsupported API version",
+        ];
+        for msg in negatives {
+            assert!(
+                !is_connection_error(&protocol(msg)),
+                "must not classify: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn other_error_variants_are_never_connection_errors() {
+        assert!(!is_connection_error(&Error::Kafka(
+            KafkaError::BrokerError {
+                code: 6,
+                message: "not leader".into(),
+            }
+        )));
+        assert!(!is_connection_error(&Error::Kafka(
+            KafkaError::ConnectionFailed {
+                broker: "b:9092".into(),
+                message: "refused".into(),
+            }
+        )));
+        assert!(!is_connection_error(&Error::Compression("zstd".into())));
+    }
+}

--- a/crates/kafka-backup-core/src/kafka/mod.rs
+++ b/crates/kafka-backup-core/src/kafka/mod.rs
@@ -2,6 +2,7 @@
 
 mod admin;
 mod client;
+pub mod connection_error;
 pub mod consumer_groups;
 mod fetch;
 mod metadata;
@@ -16,6 +17,7 @@ pub use admin::{
     ConfigEntry, ConfigOp, ConfigResourceType, CreateTopicResult, TopicToCreate,
 };
 pub use client::{KafkaClient, RESPONSE_TIMEOUT_SECS, WRITE_TIMEOUT_SECS};
+pub use connection_error::{is_connection_error, is_connection_io_kind};
 pub use consumer_groups::{
     commit_offsets, describe_groups, fetch_offsets, find_group_coordinator, list_groups,
     offsets_for_times, CommittedOffset, ConsumerGroup, ConsumerGroupDescription,
@@ -34,9 +36,8 @@ pub use sasl::{
 #[cfg(feature = "gssapi")]
 pub use sasl::{GssapiPlugin, GssapiPluginError, GssapiPluginFactory};
 
-/// Public test helper: returns true if `error` is a connection-level error that
-/// the client classifies as retriable (broken pipe, timeout, etc.).
-/// Exposed for integration tests that verify the timeout classification path.
+/// Backwards-compatible alias for [`is_connection_error`], kept for callers
+/// and tests written against the earlier name.
 pub fn is_connection_error_public(error: &crate::Error) -> bool {
-    KafkaClient::is_connection_error_pub(error)
+    is_connection_error(error)
 }

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -898,18 +898,11 @@ fn group_partition_offsets_by_leader(
 }
 
 /// Check if an error is a connection-level error that warrants a retry.
+///
+/// Shares the classifier with `KafkaClient::send_request` (issue #146) so the
+/// produce / delete-records retry loops recognise the same set of failures.
 fn is_connection_error(error: &crate::Error) -> bool {
-    match error {
-        crate::Error::Kafka(KafkaError::Protocol(msg)) => {
-            msg.contains("Broken pipe")
-                || msg.contains("early eof")
-                || msg.contains("Connection reset")
-                || msg.contains("Not connected")
-                || msg.contains("connection abort")
-                || msg.contains("timed out after")
-        }
-        _ => false,
-    }
+    super::connection_error::is_connection_error(error)
 }
 
 /// Check if an error is a NOT_LEADER_FOR_PARTITION error (code 6).

--- a/crates/kafka-backup-core/src/kafka/partition_router.rs
+++ b/crates/kafka-backup-core/src/kafka/partition_router.rs
@@ -321,8 +321,18 @@ impl PartitionLeaderRouter {
 
     /// Fetch records from a partition, routing to the correct leader.
     ///
-    /// This method handles NOT_LEADER_FOR_PARTITION errors by refreshing
-    /// metadata and retrying once.
+    /// Handles the same two failure classes as [`Self::produce`]:
+    ///
+    /// 1. `NOT_LEADER_FOR_PARTITION` (error code 6): refreshes the partition-leader
+    ///    cache and retries once.
+    ///
+    /// 2. Connection errors (see [`super::connection_error`]): retries up to
+    ///    `MAX_CONNECTION_RETRIES` times with linear back-off, dropping the cached
+    ///    broker connections in between. `KafkaClient::send_request` already
+    ///    reconnects and retries once *immediately*; this loop covers blips that
+    ///    outlast that single retry — a proxy or broker resetting connections
+    ///    for a second or two would otherwise fail the partition, and with it
+    ///    the whole backup, hours in (issue #146).
     pub async fn fetch(
         &self,
         topic: &str,
@@ -330,28 +340,42 @@ impl PartitionLeaderRouter {
         offset: i64,
         max_bytes: i32,
     ) -> Result<FetchResponse> {
-        // First attempt
-        match self
-            .fetch_internal(topic, partition, offset, max_bytes)
-            .await
-        {
-            Ok(response) => Ok(response),
-            Err(e) if is_not_leader_error(&e) => {
-                // Refresh metadata and retry
-                warn!(
-                    "NOT_LEADER_FOR_PARTITION error for {}/{}, refreshing metadata",
-                    topic, partition
-                );
-                self.refresh_partition_leader(topic, partition).await?;
+        const MAX_CONNECTION_RETRIES: u32 = 5;
 
-                // Clear cached connection for old leader
-                self.clear_connection_cache().await;
+        let mut connection_attempts = 0;
 
-                // Retry with new leader
-                self.fetch_internal(topic, partition, offset, max_bytes)
-                    .await
+        loop {
+            match self
+                .fetch_internal(topic, partition, offset, max_bytes)
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(e) if is_not_leader_error(&e) => {
+                    // Refresh metadata and retry once with the new leader
+                    warn!(
+                        "NOT_LEADER_FOR_PARTITION error for {}/{}, refreshing metadata",
+                        topic, partition
+                    );
+                    self.refresh_partition_leader(topic, partition).await?;
+                    self.clear_connection_cache().await;
+                    return self
+                        .fetch_internal(topic, partition, offset, max_bytes)
+                        .await;
+                }
+                Err(e)
+                    if is_connection_error(&e) && connection_attempts < MAX_CONNECTION_RETRIES =>
+                {
+                    connection_attempts += 1;
+                    let backoff = Duration::from_millis(500 * connection_attempts as u64);
+                    warn!(
+                        "Connection error fetching {}/{} (attempt {}/{}), retrying after {:?}: {}",
+                        topic, partition, connection_attempts, MAX_CONNECTION_RETRIES, backoff, e
+                    );
+                    self.clear_connection_cache().await;
+                    tokio::time::sleep(backoff).await;
+                }
+                Err(e) => return Err(e),
             }
-            Err(e) => Err(e),
         }
     }
 

--- a/crates/kafka-backup-core/src/metrics/labels.rs
+++ b/crates/kafka-backup-core/src/metrics/labels.rs
@@ -308,6 +308,7 @@ impl ErrorType {
     fn classify_kafka_error(error: &crate::error::KafkaError) -> Self {
         match error {
             crate::error::KafkaError::ConnectionFailed { .. } => ErrorType::BrokerConnection,
+            crate::error::KafkaError::ConnectionIo { .. } => ErrorType::BrokerConnection,
             crate::error::KafkaError::Protocol(_) => ErrorType::Unknown,
             crate::error::KafkaError::BrokerError { code, .. } => {
                 // Classify based on Kafka error codes
@@ -422,6 +423,20 @@ mod tests {
         assert_eq!(ErrorType::BrokerConnection.as_str(), "broker_connection");
         assert_eq!(ErrorType::StorageIo.as_str(), "storage_io");
         assert_eq!(ErrorType::Auth.as_str(), "auth");
+    }
+
+    #[test]
+    fn connection_io_errors_count_as_broker_connection() {
+        // Issue #146: I/O failures on the broker socket used to surface as
+        // `Protocol(String)` and were counted as `unknown` in
+        // kafka_backup_errors_total. The structured variant is attributable.
+        let err = crate::Error::Kafka(crate::error::KafkaError::ConnectionIo {
+            operation: "send request".into(),
+            kind: std::io::ErrorKind::ConnectionAborted,
+            raw_os_error: Some(10053),
+            message: "An established connection was aborted by the software in your host machine. (os error 10053)".into(),
+        });
+        assert_eq!(ErrorType::from_error(&err), ErrorType::BrokerConnection);
     }
 
     #[test]

--- a/crates/kafka-backup-core/tests/integration_suite/issue_146_connection_errors.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_146_connection_errors.rs
@@ -1,0 +1,202 @@
+//! Issue #146 — connection-error classification drives reconnect-and-retry.
+//!
+//! `KafkaClient::send_request` reconnects and retries once when a request
+//! fails with a connection-level error. Before the fix that decision was made
+//! by substring-matching the OS error *message*, which is localized and
+//! platform-specific — Windows' `WSAECONNABORTED` / `WSAECONNRESET` texts
+//! never matched, so a dropped socket failed the whole run. Classification is
+//! now structural (`io::ErrorKind` + raw OS code, see
+//! `kafka::connection_error`).
+//!
+//! These tests exercise the *whole* path with real sockets and real OS
+//! errors, in-process and without Docker: a tiny broker mock accepts the
+//! client, kills the first connection in a scripted way (TCP RST → `ECONNRESET`
+//! / `WSAECONNRESET`, or a clean FIN → `UnexpectedEof`), and answers
+//! `Metadata` on the next one. The client must classify, reconnect, retry,
+//! and succeed. Because the classification is by kind, the same test is
+//! meaningful on Linux, macOS and Windows.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use kafka_protocol::messages::metadata_response::MetadataResponseBroker;
+use kafka_protocol::messages::{ApiKey, BrokerId, MetadataResponse};
+use kafka_protocol::protocol::StrBytes;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use kafka_backup_core::config::{KafkaConfig, SecurityConfig, TopicSelection};
+use kafka_backup_core::error::KafkaError;
+use kafka_backup_core::kafka::{is_connection_error, KafkaClient};
+
+use super::sasl_mock_broker::{read_request, write_response};
+
+/// How the mock kills a connection after reading one request.
+#[derive(Clone, Copy, Debug)]
+enum Kill {
+    /// `SO_LINGER = 0` then drop: the peer sees a TCP RST, i.e.
+    /// `ECONNRESET` on Unix / `WSAECONNRESET` (10054) on Windows.
+    Reset,
+    /// Plain drop: the peer sees FIN, i.e. `UnexpectedEof` ("early eof")
+    /// from tokio's `read_exact`.
+    Close,
+}
+
+struct FlakyBroker {
+    addr: std::net::SocketAddr,
+    connections: Arc<AtomicUsize>,
+    handle: JoinHandle<()>,
+}
+
+impl FlakyBroker {
+    /// Start a mock that kills the first `kill_first_n` connections after
+    /// reading one request, then serves `Metadata` normally on any further
+    /// connection.
+    async fn start(kill: Kill, kill_first_n: usize) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let addr = listener.local_addr().expect("local addr");
+        let connections = Arc::new(AtomicUsize::new(0));
+        let counter = connections.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                if n <= kill_first_n {
+                    tokio::spawn(kill_after_one_request(stream, kill));
+                } else {
+                    tokio::spawn(serve_metadata(stream, addr));
+                }
+            }
+        });
+        Self {
+            addr,
+            connections,
+            handle,
+        }
+    }
+
+    fn connections(&self) -> usize {
+        self.connections.load(Ordering::SeqCst)
+    }
+
+    async fn shutdown(self) {
+        self.handle.abort();
+        let _ = self.handle.await;
+    }
+}
+
+async fn kill_after_one_request(mut stream: TcpStream, kill: Kill) {
+    // Read (and ignore) exactly one request so the client is parked in
+    // `read_exact` waiting for the response when the socket dies.
+    let _ = read_request(&mut stream).await;
+    match kill {
+        Kill::Reset => {
+            let sock = socket2::SockRef::from(&stream);
+            sock.set_linger(Some(Duration::ZERO))
+                .expect("set SO_LINGER=0 to force RST");
+            drop(stream);
+        }
+        Kill::Close => drop(stream),
+    }
+}
+
+async fn serve_metadata(mut stream: TcpStream, addr: std::net::SocketAddr) {
+    while let Some((api_key, api_version, correlation_id, _body)) = read_request(&mut stream).await
+    {
+        match api_key {
+            ApiKey::Metadata => {
+                let resp = MetadataResponse::default()
+                    .with_brokers(vec![MetadataResponseBroker::default()
+                        .with_node_id(BrokerId(1))
+                        .with_host(StrBytes::from_string(addr.ip().to_string()))
+                        .with_port(i32::from(addr.port()))])
+                    .with_controller_id(BrokerId(1))
+                    .with_topics(vec![]);
+                write_response(&mut stream, api_key, api_version, correlation_id, &resp).await;
+            }
+            other => panic!("mock broker: unexpected request {other:?}"),
+        }
+    }
+}
+
+fn client_for(addr: &std::net::SocketAddr) -> KafkaClient {
+    KafkaClient::new(KafkaConfig {
+        bootstrap_servers: vec![addr.to_string()],
+        security: SecurityConfig::default(),
+        topics: TopicSelection::default(),
+        connection: Default::default(),
+    })
+}
+
+async fn run_metadata_against(
+    kill: Kill,
+    kill_first_n: usize,
+) -> (kafka_backup_core::Result<usize>, usize) {
+    let broker = FlakyBroker::start(kill, kill_first_n).await;
+    let client = client_for(&broker.addr);
+    client.connect().await.expect("initial TCP connect");
+
+    let result = tokio::time::timeout(Duration::from_secs(20), client.fetch_metadata(None))
+        .await
+        .expect("fetch_metadata should not hang")
+        .map(|topics| topics.len());
+
+    let connections = broker.connections();
+    broker.shutdown().await;
+    (result, connections)
+}
+
+/// TCP RST mid-request → `ConnectionReset` → reconnect → retry succeeds.
+#[tokio::test]
+async fn test_reconnects_after_tcp_reset() {
+    let (result, connections) = run_metadata_against(Kill::Reset, 1).await;
+    assert!(
+        result.is_ok(),
+        "request after a TCP reset should be retried on a fresh connection, got {result:?}"
+    );
+    assert_eq!(connections, 2, "one killed connection + one reconnect");
+}
+
+/// Clean FIN mid-request → `UnexpectedEof` → reconnect → retry succeeds.
+#[tokio::test]
+async fn test_reconnects_after_peer_close() {
+    let (result, connections) = run_metadata_against(Kill::Close, 1).await;
+    assert!(
+        result.is_ok(),
+        "request after a peer close should be retried on a fresh connection, got {result:?}"
+    );
+    assert_eq!(connections, 2, "one killed connection + one reconnect");
+}
+
+/// When the retry also dies, the error that surfaces is the structured
+/// `ConnectionIo` carrying the real `io::ErrorKind` — classifiable without
+/// reading the (localized) message — and it names the operation.
+#[tokio::test]
+async fn test_surfaced_error_is_structured_and_classifiable() {
+    let (result, connections) = run_metadata_against(Kill::Reset, 2).await;
+    let err = result.expect_err("both attempts were reset, so the request must fail");
+    assert_eq!(connections, 2, "send_request retries exactly once");
+    assert!(
+        is_connection_error(&err),
+        "surfaced error must classify as a connection error: {err}"
+    );
+    match &err {
+        kafka_backup_core::Error::Kafka(KafkaError::ConnectionIo {
+            operation, kind, ..
+        }) => {
+            assert_eq!(operation, "read response length");
+            assert!(
+                matches!(
+                    kind,
+                    std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::UnexpectedEof
+                ),
+                "unexpected kind {kind:?} (a RST normally surfaces as ConnectionReset; some \
+                 stacks deliver EOF first)"
+            );
+        }
+        other => panic!("expected KafkaError::ConnectionIo, got {other:?}"),
+    }
+}

--- a/crates/kafka-backup-core/tests/integration_suite/issue_146_connection_errors.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_146_connection_errors.rs
@@ -20,15 +20,18 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use kafka_protocol::messages::metadata_response::MetadataResponseBroker;
-use kafka_protocol::messages::{ApiKey, BrokerId, MetadataResponse};
+use kafka_protocol::messages::fetch_response::{FetchableTopicResponse, PartitionData};
+use kafka_protocol::messages::metadata_response::{
+    MetadataResponseBroker, MetadataResponsePartition, MetadataResponseTopic,
+};
+use kafka_protocol::messages::{ApiKey, BrokerId, FetchResponse, MetadataResponse, TopicName};
 use kafka_protocol::protocol::StrBytes;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 
 use kafka_backup_core::config::{KafkaConfig, SecurityConfig, TopicSelection};
 use kafka_backup_core::error::KafkaError;
-use kafka_backup_core::kafka::{is_connection_error, KafkaClient};
+use kafka_backup_core::kafka::{is_connection_error, KafkaClient, PartitionLeaderRouter};
 
 use super::sasl_mock_broker::{read_request, write_response};
 
@@ -42,6 +45,8 @@ enum Kill {
     /// from tokio's `read_exact`.
     Close,
 }
+
+const TOPIC: &str = "issue-146-topic";
 
 struct FlakyBroker {
     addr: std::net::SocketAddr,
@@ -78,6 +83,38 @@ impl FlakyBroker {
         }
     }
 
+    /// Start a mock that always serves `Metadata` (one topic, one partition,
+    /// itself as leader) but kills the connection on the first
+    /// `kill_first_n_fetches` `Fetch` requests it sees, then answers `Fetch`
+    /// with an empty partition. Drives the router's fetch retry loop the way
+    /// a proxy or broker resetting connections for a while would.
+    async fn start_killing_fetches(kill: Kill, kill_first_n_fetches: usize) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let addr = listener.local_addr().expect("local addr");
+        let connections = Arc::new(AtomicUsize::new(0));
+        let counter = connections.clone();
+        let fetch_kills_left = Arc::new(AtomicUsize::new(kill_first_n_fetches));
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                counter.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(serve_metadata_and_fetch(
+                    stream,
+                    addr,
+                    kill,
+                    fetch_kills_left.clone(),
+                ));
+            }
+        });
+        Self {
+            addr,
+            connections,
+            handle,
+        }
+    }
+
     fn connections(&self) -> usize {
         self.connections.load(Ordering::SeqCst)
     }
@@ -88,10 +125,7 @@ impl FlakyBroker {
     }
 }
 
-async fn kill_after_one_request(mut stream: TcpStream, kill: Kill) {
-    // Read (and ignore) exactly one request so the client is parked in
-    // `read_exact` waiting for the response when the socket dies.
-    let _ = read_request(&mut stream).await;
+fn kill_stream(stream: TcpStream, kill: Kill) {
     match kill {
         Kill::Reset => {
             let sock = socket2::SockRef::from(&stream);
@@ -103,18 +137,43 @@ async fn kill_after_one_request(mut stream: TcpStream, kill: Kill) {
     }
 }
 
+async fn kill_after_one_request(mut stream: TcpStream, kill: Kill) {
+    // Read (and ignore) exactly one request so the client is parked in
+    // `read_exact` waiting for the response when the socket dies.
+    let _ = read_request(&mut stream).await;
+    kill_stream(stream, kill);
+}
+
+fn metadata_response(addr: std::net::SocketAddr, with_topic: bool) -> MetadataResponse {
+    let topics = if with_topic {
+        vec![MetadataResponseTopic::default()
+            .with_error_code(0)
+            .with_name(Some(TopicName(StrBytes::from_static_str(TOPIC))))
+            .with_is_internal(false)
+            .with_partitions(vec![MetadataResponsePartition::default()
+                .with_error_code(0)
+                .with_partition_index(0)
+                .with_leader_id(BrokerId(1))
+                .with_replica_nodes(vec![BrokerId(1)])
+                .with_isr_nodes(vec![BrokerId(1)])])]
+    } else {
+        vec![]
+    };
+    MetadataResponse::default()
+        .with_brokers(vec![MetadataResponseBroker::default()
+            .with_node_id(BrokerId(1))
+            .with_host(StrBytes::from_string(addr.ip().to_string()))
+            .with_port(i32::from(addr.port()))])
+        .with_controller_id(BrokerId(1))
+        .with_topics(topics)
+}
+
 async fn serve_metadata(mut stream: TcpStream, addr: std::net::SocketAddr) {
     while let Some((api_key, api_version, correlation_id, _body)) = read_request(&mut stream).await
     {
         match api_key {
             ApiKey::Metadata => {
-                let resp = MetadataResponse::default()
-                    .with_brokers(vec![MetadataResponseBroker::default()
-                        .with_node_id(BrokerId(1))
-                        .with_host(StrBytes::from_string(addr.ip().to_string()))
-                        .with_port(i32::from(addr.port()))])
-                    .with_controller_id(BrokerId(1))
-                    .with_topics(vec![]);
+                let resp = metadata_response(addr, false);
                 write_response(&mut stream, api_key, api_version, correlation_id, &resp).await;
             }
             other => panic!("mock broker: unexpected request {other:?}"),
@@ -122,13 +181,56 @@ async fn serve_metadata(mut stream: TcpStream, addr: std::net::SocketAddr) {
     }
 }
 
-fn client_for(addr: &std::net::SocketAddr) -> KafkaClient {
-    KafkaClient::new(KafkaConfig {
+async fn serve_metadata_and_fetch(
+    mut stream: TcpStream,
+    addr: std::net::SocketAddr,
+    kill: Kill,
+    fetch_kills_left: Arc<AtomicUsize>,
+) {
+    while let Some((api_key, api_version, correlation_id, _body)) = read_request(&mut stream).await
+    {
+        match api_key {
+            ApiKey::Metadata => {
+                let resp = metadata_response(addr, true);
+                write_response(&mut stream, api_key, api_version, correlation_id, &resp).await;
+            }
+            ApiKey::Fetch => {
+                let kill_this = fetch_kills_left
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                    .is_ok();
+                if kill_this {
+                    kill_stream(stream, kill);
+                    return;
+                }
+                let resp =
+                    FetchResponse::default().with_responses(vec![FetchableTopicResponse::default(
+                    )
+                    .with_topic(TopicName(StrBytes::from_static_str(TOPIC)))
+                    .with_partitions(vec![PartitionData::default()
+                        .with_partition_index(0)
+                        .with_error_code(0)
+                        .with_high_watermark(0)
+                        .with_last_stable_offset(0)
+                        .with_log_start_offset(0)
+                        .with_records(None)])]);
+                write_response(&mut stream, api_key, api_version, correlation_id, &resp).await;
+            }
+            other => panic!("mock broker: unexpected request {other:?}"),
+        }
+    }
+}
+
+fn client_config(addr: &std::net::SocketAddr) -> KafkaConfig {
+    KafkaConfig {
         bootstrap_servers: vec![addr.to_string()],
         security: SecurityConfig::default(),
         topics: TopicSelection::default(),
         connection: Default::default(),
-    })
+    }
+}
+
+fn client_for(addr: &std::net::SocketAddr) -> KafkaClient {
+    KafkaClient::new(client_config(addr))
 }
 
 async fn run_metadata_against(
@@ -199,4 +301,35 @@ async fn test_surfaced_error_is_structured_and_classifiable() {
         }
         other => panic!("expected KafkaError::ConnectionIo, got {other:?}"),
     }
+}
+
+/// The router's fetch loop must outlast a reset window longer than the
+/// client's single immediate reconnect: three consecutive `Fetch`s die
+/// (initial + `send_request`'s retry + the router's first retry) before the
+/// broker behaves again. This is the backup path — before the loop existed a
+/// proxy or broker resetting connections for a second or two failed the
+/// partition and the whole run.
+#[tokio::test]
+async fn test_router_fetch_survives_repeated_connection_resets() {
+    let broker = FlakyBroker::start_killing_fetches(Kill::Reset, 3).await;
+    let router = PartitionLeaderRouter::new(client_config(&broker.addr))
+        .await
+        .expect("router bootstrap via Metadata");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        router.fetch(TOPIC, 0, 0, 1024 * 1024),
+    )
+    .await
+    .expect("fetch should not hang");
+
+    let connections = broker.connections();
+    broker.shutdown().await;
+
+    let resp = result.expect("fetch should succeed once the resets stop");
+    assert!(resp.records.is_empty());
+    assert!(
+        connections >= 4,
+        "expected bootstrap + at least three killed fetch connections + one good one, saw {connections}"
+    );
 }

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -10,9 +10,11 @@
 //! - Snapshot Backup: stop_at_current_offsets feature tests
 //! - Performance Issues: Issue #29 constant lag and throughput tests
 //! - Issue #144: OFFSET_OUT_OF_RANGE recovery and data-gap recording
+//! - Issue #146: connection-error classification and reconnect (no Docker)
 
 pub mod common;
 pub mod issue_144_offset_out_of_range;
+pub mod issue_146_connection_errors;
 pub mod issue_56_missing_topic;
 pub mod issue_67_fixes;
 pub mod offset_semantics;

--- a/crates/kafka-backup-core/tests/integration_suite/sasl_mock_broker.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/sasl_mock_broker.rs
@@ -152,7 +152,10 @@ async fn serve_connection(
     }
 }
 
-async fn read_request(stream: &mut TcpStream) -> Option<(ApiKey, i16, i32, Bytes)> {
+/// Read one Kafka request frame: `(api_key, api_version, correlation_id, body)`.
+/// Returns `None` on EOF or a short read. Shared with the connection-error
+/// mock in `issue_146_connection_errors`.
+pub async fn read_request(stream: &mut TcpStream) -> Option<(ApiKey, i16, i32, Bytes)> {
     let mut len_buf = [0u8; 4];
     if stream.read_exact(&mut len_buf).await.is_err() {
         return None;
@@ -190,7 +193,8 @@ fn decode_authenticate_body(body: &Bytes, api_version: i16) -> Vec<u8> {
     req.auth_bytes.to_vec()
 }
 
-async fn write_response<Resp: Encodable>(
+/// Frame and write one Kafka response for `correlation_id`.
+pub async fn write_response<Resp: Encodable>(
     stream: &mut TcpStream,
     api_key: ApiKey,
     api_version: i16,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,6 +112,56 @@ source:
     ssl_ca_location: /etc/kafka/certs/ca.pem
 ```
 
+### Connection Options
+
+TCP-level settings for the source (and, for restore, the target) cluster.
+All are optional and live under `source.connection` / `target.connection`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `connection.tcp_keepalive` | bool | `true` | Send TCP keepalive probes so idle connections are not silently dropped by NATs, load balancers or cloud Kafka front-ends |
+| `connection.keepalive_time_secs` | integer | `60` | Idle time before the first keepalive probe |
+| `connection.keepalive_interval_secs` | integer | `20` | Interval between keepalive probes |
+| `connection.tcp_nodelay` | bool | `true` | Disable Nagle's algorithm (lower request latency) |
+| `connection.connections_per_broker` | integer | `4` | TCP connections kept per broker; concurrent partitions share them, so raise this on high-latency links |
+
+```yaml
+source:
+  bootstrap_servers: ["kafka1.example.com:9092"]
+  connection:
+    tcp_keepalive: true
+    keepalive_time_secs: 30
+    keepalive_interval_secs: 10
+    connections_per_broker: 8
+```
+
+#### Connection loss and automatic reconnect
+
+A dropped or reset broker connection does not fail a run. When a request
+fails with a connection-level error the client reconnects (TCP, TLS and SASL
+again) and retries the request once, immediately; the backup fetch path,
+restore produce path and record purging additionally retry up to 5 times with
+linear back-off (0.5 s, 1 s, … 2.5 s), so a broker or proxy that resets
+connections for a few seconds is ridden out. What counts as a connection-level
+error is decided from the OS error *kind* and code — connection reset,
+aborted or refused, broken pipe, not connected, timed out, unexpected EOF,
+network/host unreachable, and the Windows Winsock equivalents (`10052`,
+`10053`, `10054`, `10057`, `10058`, `10060`, `10061`) — not from the error
+message text, which is localized and differs per platform.
+
+You will see it in the logs as:
+
+```
+WARN kafka_backup_core::kafka::client: Connection error on Fetch request, reconnecting and retrying: Kafka error: Connection error during read response length (ConnectionReset): Connection reset by peer (os error 104)
+WARN kafka_backup_core::kafka::partition_router: Connection error fetching orders/3 (attempt 1/5), retrying after 500ms: ...
+```
+
+Such errors are counted under `error_type="broker_connection"` in
+`kafka_backup_errors_total`. If a run still fails after the retries, the
+outage lasted longer than the retry window (roughly 8 s per request); check
+broker availability and the keepalive settings above, and simply re-run — a
+backup resumes from its checkpoint.
+
 ### TLS/SSL Configuration
 
 kafka-backup supports TLS encryption for Kafka connections, including custom CA certificates and mutual TLS (mTLS) authentication.


### PR DESCRIPTION
Fixes #146  `is_connection_error()` now correctly classifies Windows `os error 10053` (and related Winsock errors) as connection-level failures eligible for the existing reconnect-and-retry logic in `send_request`, instead of letting them propagate as fatal errors.


## Change

```rust
fn is_connection_error(error: &crate::Error) -> bool {
    match error {
        crate::Error::Kafka(KafkaError::Protocol(msg)) => {
            let msg_lower = msg.to_lowercase();
            msg_lower.contains("broken pipe")
                || msg_lower.contains("early eof")
                || msg_lower.contains("connection reset")
                || msg_lower.contains("not connected")
                || msg_lower.contains("connection abort")
                || msg_lower.contains("aborted")
                || msg_lower.contains("timed out after")
                || msg_lower.contains("os error 10053") // WSAECONNABORTED
                || msg_lower.contains("os error 10054") // WSAECONNRESET
                || msg_lower.contains("os error 10060") // WSAETIMEDOUT
        }
        _ => false,
    }
}
```

Lowercasing the whole message once also makes the pre-existing checks more robust against any casing variance, in addition to fixing the immediate reported case.
