### PR TITLE
Fix: automatically commit consumer group offset resets at the end of restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-08-18
+
+### Fixed
+- `kafka-backup restore` now applies consumer group offsets on the target when
+  the configuration asks for it (`reset_consumer_offsets: true`, or
+  `auto_consumer_groups: true` with the backup's consumer-groups snapshot).
+  Previously only `three-phase-restore` (and the Kubernetes operator) ran
+  Phase 3; plain `restore` built the offset mapping, logged
+  "imported N consumer group offsets" and "Restore completed successfully",
+  and discarded it — no groups were created on the target. Fixes
+  [#148](https://github.com/osodevops/kafka-backup/issues/148).
+- A failed offset reset after an otherwise successful restore now makes
+  `restore` exit non-zero, and the reset summary is printed. Offset commit
+  failures name the Kafka error and what to do about it — in particular
+  `error code 25 (UNKNOWN_MEMBER_ID: the group has active members on the
+  target; stop those consumers, then re-run the reset)`.
+
+### Added
+- `ThreePhaseRestore::run_offset_reset_phase(&RestoreReport)` and
+  `OffsetResetPhaseOutcome` — Phase 3 as a reusable step for a completed
+  Phase 2 restore; `run_all_phases`, the `restore` command and the operator
+  all go through it, so offsets are applied exactly once per run.
+  `ThreePhaseRestore::wants_offset_reset(&RestoreOptions)`.
+- `restore::offset_reset::describe_offset_commit_error(code)`.
+
+### Changed
+- The restore engine (Phase 2) still never commits consumer offsets; it now
+  logs "Offset mapping ready for N consumer group(s); offsets are applied in
+  Phase 3" when a reset is configured, so library callers running the engine
+  directly are pointed at `run_offset_reset_phase`. Documented in
+  `docs/restore_guide.md` and `docs/configuration.md`.
+
 ## [0.17.1] - 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/src/commands/restore.rs
+++ b/crates/kafka-backup-cli/src/commands/restore.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
+use kafka_backup_core::restore::{OffsetResetPhaseOutcome, ThreePhaseRestore};
 use kafka_backup_core::{restore::RestoreEngine, Config, PrometheusMetrics};
 use std::sync::Arc;
 use tokio::sync::broadcast;
-use tracing::info;
+use tracing::{info, warn};
 
 pub async fn run(config_path: &str) -> Result<()> {
     info!("Loading configuration from: {}", config_path);
@@ -22,6 +23,19 @@ pub async fn run(config_path: &str) -> Result<()> {
 
     let metrics_server =
         super::metrics_runtime::RunningMetricsServer::start(&metrics_config, prometheus_metrics);
+
+    // Phase 3 (consumer group offset reset) is applied after the data restore
+    // when the configuration asks for it. The engine itself never commits
+    // offsets — see `ThreePhaseRestore::run_offset_reset_phase` (issue #148).
+    let wants_offset_reset = config
+        .restore
+        .as_ref()
+        .is_some_and(ThreePhaseRestore::wants_offset_reset);
+    let orchestrator = if wants_offset_reset {
+        Some(ThreePhaseRestore::new(config.clone())?)
+    } else {
+        None
+    };
 
     // Run the restore engine
     let engine = RestoreEngine::new(config)?;
@@ -43,7 +57,77 @@ pub async fn run(config_path: &str) -> Result<()> {
     }
     signal_task.abort(); // Clean up signal watcher if operation finished normally
 
-    result?;
+    let report = result?;
+
+    if let Some(orchestrator) = orchestrator {
+        info!(
+            "Applying consumer group offset reset (Phase 3) for {} group(s)",
+            report.resolved_consumer_groups.len()
+        );
+        let outcome = orchestrator.run_offset_reset_phase(&report).await?;
+        print_offset_reset_summary(&outcome);
+        if !outcome.success() {
+            anyhow::bail!(
+                "Restore completed but consumer group offset reset failed — see the errors above \
+                 (offsets on the target were not, or only partly, reset)"
+            );
+        }
+    }
+
     info!("Restore completed successfully");
     Ok(())
+}
+
+/// Print a compact Phase 3 summary so an operator can see at a glance whether
+/// consumer group offsets were actually applied.
+fn print_offset_reset_summary(outcome: &OffsetResetPhaseOutcome) {
+    println!();
+    println!("=== Consumer Group Offset Reset (Phase 3) ===");
+    match (&outcome.plan, &outcome.report) {
+        (None, _) => {
+            println!("No consumer groups in scope; nothing to reset.");
+        }
+        (Some(plan), None) => {
+            println!(
+                "Planned only (dry run): {} group(s), {} partition(s)",
+                plan.groups.len(),
+                plan.groups.iter().map(|g| g.partition_count).sum::<usize>()
+            );
+        }
+        (Some(plan), Some(report)) => {
+            println!(
+                "Groups: {}   Partitions reset: {}   Errors: {}",
+                plan.groups.len(),
+                report.partitions_reset,
+                report.errors.len()
+            );
+            for group in &plan.groups {
+                println!(
+                    "  - {} ({} partition(s){})",
+                    group.group_id,
+                    group.partition_count,
+                    if group.complete {
+                        ""
+                    } else {
+                        ", incomplete mapping"
+                    }
+                );
+            }
+            for err in &report.errors {
+                println!("  ! {}", err);
+            }
+            println!(
+                "Result: {}",
+                if report.success {
+                    "APPLIED"
+                } else {
+                    "FAILED (target offsets not, or only partly, reset)"
+                }
+            );
+        }
+    }
+    for w in &outcome.warnings {
+        warn!("{}", w);
+    }
+    println!();
 }

--- a/crates/kafka-backup-cli/src/main.rs
+++ b/crates/kafka-backup-cli/src/main.rs
@@ -38,7 +38,9 @@ enum Commands {
         config: String,
     },
 
-    /// Restore Kafka topics from a backup with optional PITR filtering
+    /// Restore Kafka topics from a backup with optional PITR filtering and,
+    /// when `reset_consumer_offsets` / `auto_consumer_groups` is set, consumer
+    /// group offset reset on the target after the data restore
     #[command(
         after_help = "Examples:\n  kafka-backup restore --config restore.yaml\n  kafka-backup validate-restore --config restore.yaml   # dry-run first"
     )]

--- a/crates/kafka-backup-core/src/lib.rs
+++ b/crates/kafka-backup-core/src/lib.rs
@@ -63,5 +63,7 @@ pub use restore::{
         RestoreWithRollbackStatus, RollbackResult, RollbackStatus, StorageBackendSnapshotStore,
         VerificationResult,
     },
-    three_phase::{Phase1ValidationReport, ThreePhaseReport, ThreePhaseRestore},
+    three_phase::{
+        OffsetResetPhaseOutcome, Phase1ValidationReport, ThreePhaseReport, ThreePhaseRestore,
+    },
 };

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -18,6 +18,7 @@ use crate::manifest::{
 use crate::metrics::PerformanceMetrics;
 use crate::storage::{create_backend, StorageBackend};
 use crate::{Error, Result};
+use crate::restore::offset_reset::{OffsetResetExecutor, OffsetResetReport, OffsetResetStrategy};
 
 /// Progress update sent during restore
 #[derive(Debug, Clone)]
@@ -742,6 +743,34 @@ impl RestoreEngine {
 
         let offset_mapping = self.offset_mapping.lock().await.clone();
 
+        // Automatically reset consumer group offsets on the target cluster once
+        // the in-memory offset mapping is complete. This uses the already-connected
+        // target router and the accurate detailed per-record mapping built during
+        // this restore run, rather than requiring a separate `offset-reset execute`
+        // CLI invocation with a possibly-stale/manifest-only mapping.
+        if restore_options.reset_consumer_offsets && !restore_options.consumer_groups.is_empty() {
+            match self
+                .execute_consumer_group_offset_reset(&offset_mapping, &restore_options)
+                .await
+            {
+                Ok(reset_report) => {
+                    info!(
+                        "Consumer group offset reset: {} partitions reset across {} groups",
+                        reset_report.partitions_reset,
+                        reset_report.groups_reset.len()
+                    );
+                    if !reset_report.success {
+                        for err in &reset_report.errors {
+                            warn!("Offset reset error: {}", err);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Consumer group offset reset failed (non-fatal): {}", e);
+                }
+            }
+        }
+
         let report = RestoreReport {
             backup_id: self.config.backup_id.clone(),
             dry_run: false,
@@ -1252,6 +1281,39 @@ impl RestoreEngine {
         }
 
         Ok(())
+    }
+
+    async fn execute_consumer_group_offset_reset(
+        &self,
+        offset_mapping: &crate::manifest::OffsetMapping,
+        restore_options: &RestoreOptions,
+    ) -> crate::Result<OffsetResetReport> {
+        let router = self
+            .router
+            .read()
+            .await
+            .clone()
+            .ok_or_else(|| Error::Config("Router not initialized".to_string()))?;
+
+        let target = self.config.target.as_ref().unwrap();
+        let executor =
+            OffsetResetExecutor::new_with_router(router, target.bootstrap_servers.clone());
+
+        let plan = executor
+            .generate_plan(
+                offset_mapping,
+                &restore_options.consumer_groups,
+                OffsetResetStrategy::Auto,
+            )
+            .await?;
+
+        info!(
+        "Generated automatic offset reset plan for {} groups with {} total partitions",
+        plan.groups.len(),
+        plan.groups.iter().map(|g| g.partition_count).sum::<usize>()
+    );
+
+        executor.execute_plan(&plan).await
     }
 }
 

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -18,7 +18,6 @@ use crate::manifest::{
 use crate::metrics::PerformanceMetrics;
 use crate::storage::{create_backend, StorageBackend};
 use crate::{Error, Result};
-use crate::restore::offset_reset::{OffsetResetExecutor, OffsetResetReport, OffsetResetStrategy};
 
 /// Progress update sent during restore
 #[derive(Debug, Clone)]
@@ -743,32 +742,17 @@ impl RestoreEngine {
 
         let offset_mapping = self.offset_mapping.lock().await.clone();
 
-        // Automatically reset consumer group offsets on the target cluster once
-        // the in-memory offset mapping is complete. This uses the already-connected
-        // target router and the accurate detailed per-record mapping built during
-        // this restore run, rather than requiring a separate `offset-reset execute`
-        // CLI invocation with a possibly-stale/manifest-only mapping.
+        // Phase 2 ends here. The engine deliberately never commits consumer
+        // offsets — Phase 3 (`ThreePhaseRestore::run_offset_reset_phase`) does,
+        // exactly once, from the mapping in the returned report. The `restore`
+        // and `three-phase-restore` commands run it automatically when
+        // `reset_consumer_offsets` / `auto_consumer_groups` is set (issue #148).
         if restore_options.reset_consumer_offsets && !restore_options.consumer_groups.is_empty() {
-            match self
-                .execute_consumer_group_offset_reset(&offset_mapping, &restore_options)
-                .await
-            {
-                Ok(reset_report) => {
-                    info!(
-                        "Consumer group offset reset: {} partitions reset across {} groups",
-                        reset_report.partitions_reset,
-                        reset_report.groups_reset.len()
-                    );
-                    if !reset_report.success {
-                        for err in &reset_report.errors {
-                            warn!("Offset reset error: {}", err);
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!("Consumer group offset reset failed (non-fatal): {}", e);
-                }
-            }
+            info!(
+                "Offset mapping ready for {} consumer group(s); offsets are applied in Phase 3 \
+                 (not by the restore engine)",
+                restore_options.consumer_groups.len()
+            );
         }
 
         let report = RestoreReport {
@@ -1281,39 +1265,6 @@ impl RestoreEngine {
         }
 
         Ok(())
-    }
-
-    async fn execute_consumer_group_offset_reset(
-        &self,
-        offset_mapping: &crate::manifest::OffsetMapping,
-        restore_options: &RestoreOptions,
-    ) -> crate::Result<OffsetResetReport> {
-        let router = self
-            .router
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| Error::Config("Router not initialized".to_string()))?;
-
-        let target = self.config.target.as_ref().unwrap();
-        let executor =
-            OffsetResetExecutor::new_with_router(router, target.bootstrap_servers.clone());
-
-        let plan = executor
-            .generate_plan(
-                offset_mapping,
-                &restore_options.consumer_groups,
-                OffsetResetStrategy::Auto,
-            )
-            .await?;
-
-        info!(
-        "Generated automatic offset reset plan for {} groups with {} total partitions",
-        plan.groups.len(),
-        plan.groups.iter().map(|g| g.partition_count).sum::<usize>()
-    );
-
-        executor.execute_plan(&plan).await
     }
 }
 

--- a/crates/kafka-backup-core/src/restore/mod.rs
+++ b/crates/kafka-backup-core/src/restore/mod.rs
@@ -25,4 +25,6 @@ pub use offset_rollback::{
     RestoreWithRollbackStatus, RollbackResult, RollbackStatus, StorageBackendSnapshotStore,
     VerificationResult,
 };
-pub use three_phase::{Phase1ValidationReport, ThreePhaseReport, ThreePhaseRestore};
+pub use three_phase::{
+    OffsetResetPhaseOutcome, Phase1ValidationReport, ThreePhaseReport, ThreePhaseRestore,
+};

--- a/crates/kafka-backup-core/src/restore/offset_reset.rs
+++ b/crates/kafka-backup-core/src/restore/offset_reset.rs
@@ -433,8 +433,11 @@ impl OffsetResetExecutor {
             } else {
                 partitions_failed += 1;
                 errors.push(format!(
-                    "{}:{}:{} - error code {}",
-                    plan.group_id, topic, partition, error_code
+                    "{}:{}:{} - {}",
+                    plan.group_id,
+                    topic,
+                    partition,
+                    describe_offset_commit_error(error_code)
                 ));
             }
         }
@@ -638,6 +641,46 @@ impl OffsetResetPlanBuilder {
             source_cluster_id: self.offset_mapping.source_cluster_id,
             target_bootstrap_servers: self.bootstrap_servers,
         }
+    }
+}
+
+/// Human-readable description of an `OffsetCommit` partition error code,
+/// with the operator action for the cases a restore is likely to hit.
+///
+/// Error code 25 in particular is what the coordinator returns for a
+/// generation-less commit to a group that still has active members — the
+/// usual reason a post-restore reset fails.
+pub fn describe_offset_commit_error(code: i16) -> String {
+    let (name, hint) = match code {
+        25 => (
+            "UNKNOWN_MEMBER_ID",
+            "the group has active members on the target; stop those consumers, then re-run the reset",
+        ),
+        22 => (
+            "ILLEGAL_GENERATION",
+            "the group is active or rebalancing on the target; stop its consumers first",
+        ),
+        27 => (
+            "REBALANCE_IN_PROGRESS",
+            "the group is rebalancing on the target; wait for it to settle or stop its consumers",
+        ),
+        14 => ("COORDINATOR_LOAD_IN_PROGRESS", "the group coordinator is still loading; retry"),
+        15 => ("COORDINATOR_NOT_AVAILABLE", "the group coordinator is unavailable; retry"),
+        16 => ("NOT_COORDINATOR", "the coordinator moved; retry"),
+        3 => (
+            "UNKNOWN_TOPIC_OR_PARTITION",
+            "the target topic/partition does not exist; check topic_mapping / create_topics",
+        ),
+        12 => ("OFFSET_METADATA_TOO_LARGE", "commit metadata exceeds the broker limit"),
+        29 => ("TOPIC_AUTHORIZATION_FAILED", "the restore principal lacks access to the topic"),
+        30 => ("GROUP_AUTHORIZATION_FAILED", "the restore principal lacks access to the group"),
+        69 => ("GROUP_ID_NOT_FOUND", "the group does not exist on the target"),
+        _ => ("", ""),
+    };
+    if name.is_empty() {
+        format!("error code {code}")
+    } else {
+        format!("error code {code} ({name}: {hint})")
     }
 }
 
@@ -902,5 +945,74 @@ mod tests {
                 ("orders".to_string(), 1, 42, Some("snapshot".to_string())),
             ]
         );
+    }
+
+    /// A committer that rejects every partition with a fixed error code, as the
+    /// coordinator does (25 = UNKNOWN_MEMBER_ID) when the group still has
+    /// active members on the target.
+    struct RejectingCommitter(i16);
+
+    #[async_trait::async_trait]
+    impl OffsetCommitter for RejectingCommitter {
+        async fn commit_offsets(
+            &self,
+            _group_id: &str,
+            offsets: &[(String, i32, i64, Option<String>)],
+        ) -> Result<Vec<(String, i32, i16)>> {
+            Ok(offsets
+                .iter()
+                .map(|(topic, partition, _, _)| (topic.clone(), *partition, self.0))
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_plan_reports_failure_with_descriptive_error() {
+        let executor = OffsetResetExecutor {
+            client: None,
+            committer: Some(std::sync::Arc::new(RejectingCommitter(25))),
+            bootstrap_servers: vec!["kafka:9092".to_string()],
+        };
+        let plan = OffsetResetPlan {
+            groups: vec![GroupResetPlan {
+                group_id: "issue148-app".to_string(),
+                partitions: vec![PartitionResetPlan {
+                    topic: "orders".to_string(),
+                    partition: 0,
+                    source_offset: 43,
+                    target_offset: 43,
+                    timestamp: 1000,
+                    metadata: None,
+                }],
+                partition_count: 1,
+                complete: true,
+            }],
+            generated_at: 0,
+            strategy: "Auto".to_string(),
+            dry_run: false,
+            backup_id: None,
+            source_cluster_id: None,
+            target_bootstrap_servers: vec![],
+        };
+
+        let report = executor.execute_plan(&plan).await.unwrap();
+        assert!(!report.success, "a rejected commit must not report success");
+        assert_eq!(report.partitions_reset, 0);
+        assert_eq!(report.errors.len(), 1);
+        let err = &report.errors[0];
+        assert!(err.contains("issue148-app:orders:0"), "{err}");
+        assert!(err.contains("error code 25"), "{err}");
+        assert!(err.contains("UNKNOWN_MEMBER_ID"), "{err}");
+        assert!(err.contains("active members"), "{err}");
+    }
+
+    #[test]
+    fn describe_offset_commit_error_covers_common_codes_and_falls_back() {
+        assert!(describe_offset_commit_error(25).contains("UNKNOWN_MEMBER_ID"));
+        assert!(describe_offset_commit_error(22).contains("ILLEGAL_GENERATION"));
+        assert!(describe_offset_commit_error(27).contains("REBALANCE_IN_PROGRESS"));
+        assert!(describe_offset_commit_error(3).contains("UNKNOWN_TOPIC_OR_PARTITION"));
+        assert!(describe_offset_commit_error(30).contains("GROUP_AUTHORIZATION_FAILED"));
+        assert_eq!(describe_offset_commit_error(999), "error code 999");
     }
 }

--- a/crates/kafka-backup-core/src/restore/three_phase.rs
+++ b/crates/kafka-backup-core/src/restore/three_phase.rs
@@ -47,7 +47,7 @@
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use crate::config::Config;
+use crate::config::{Config, RestoreOptions};
 use crate::kafka::{KafkaClient, PartitionLeaderRouter};
 use crate::manifest::{OffsetMapping, RestoreReport};
 use crate::Result;
@@ -88,10 +88,51 @@ pub struct ThreePhaseReport {
     pub warnings: Vec<String>,
 }
 
+/// Result of running Phase 3 (consumer group offset reset) for a completed
+/// Phase 2 restore — see [`ThreePhaseRestore::run_offset_reset_phase`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OffsetResetPhaseOutcome {
+    /// The plan that was generated, if any consumer groups were in scope.
+    pub plan: Option<OffsetResetPlan>,
+    /// The execution report, if the plan was applied (not in dry-run mode).
+    pub report: Option<OffsetResetReport>,
+    /// Non-fatal notes: skipped repartitioned topics, dry-run, groups
+    /// configured without `reset_consumer_offsets`, …
+    pub warnings: Vec<String>,
+}
+
+impl OffsetResetPhaseOutcome {
+    /// True when nothing was applied *or* everything that was applied
+    /// succeeded. A run that applied a plan with any commit failure is
+    /// **not** a success — the restore's exit status must reflect that.
+    pub fn success(&self) -> bool {
+        self.report.as_ref().map(|r| r.success).unwrap_or(true)
+    }
+
+    /// True when offsets were actually committed to the target.
+    pub fn applied(&self) -> bool {
+        self.report.is_some()
+    }
+}
+
 impl ThreePhaseRestore {
     /// Create a new three-phase restore orchestrator
     pub fn new(config: Config) -> Result<Self> {
         Ok(Self { config })
+    }
+
+    /// True if this restore configuration asks for consumer group offsets to
+    /// be applied after the data restore — either explicitly
+    /// (`reset_consumer_offsets: true`) or implicitly via the backup's
+    /// consumer-groups snapshot (`auto_consumer_groups: true`).
+    ///
+    /// The restore *engine* never commits offsets (Phase 2 must not touch
+    /// `__consumer_offsets`); callers that run the engine directly and want
+    /// the documented behaviour of those flags must follow it with
+    /// [`Self::run_offset_reset_phase`]. `kafka-backup restore` and
+    /// `three-phase-restore` do this automatically (issue #148).
+    pub fn wants_offset_reset(restore_options: &RestoreOptions) -> bool {
+        restore_options.reset_consumer_offsets || restore_options.auto_consumer_groups
     }
 
     /// Run all three phases
@@ -115,72 +156,9 @@ impl ThreePhaseRestore {
             restore_report.offset_mapping.detailed_mapping_count()
         );
 
-        // Warn about repartitioned topics — offset reset is not supported for them
-        let restore_options = self.config.restore.clone().unwrap_or_default();
-        if !restore_options.repartitioning.is_empty() {
-            let topics: Vec<&String> = restore_options.repartitioning.keys().collect();
-            warn!(
-                "Repartitioned topics {:?} will be skipped during Phase 3 offset reset \
-                 (source→target offset mapping is not available for repartitioned data)",
-                topics
-            );
-            warnings.push(format!(
-                "Repartitioned topics skipped for offset reset: {:?}",
-                topics
-            ));
-        }
-
-        // Phase 3: Offset Reset (if consumer groups configured)
-        // Use resolved_consumer_groups from the restore report — this includes
-        // groups auto-loaded from snapshot by the engine (auto_consumer_groups).
-        // The config's consumer_groups list may be empty if auto_consumer_groups
-        // was used, because the engine resolves groups at runtime.
-        let effective_consumer_groups = if !restore_report.resolved_consumer_groups.is_empty() {
-            restore_report.resolved_consumer_groups.clone()
-        } else {
-            restore_options.consumer_groups.clone()
-        };
-        let effective_reset = restore_options.reset_consumer_offsets
-            || (restore_options.auto_consumer_groups && !effective_consumer_groups.is_empty());
-        let (offset_reset_plan, offset_reset_report) = if effective_reset
-            && !effective_consumer_groups.is_empty()
-        {
-            info!("Phase 3: Generating and applying offset reset plan...");
-
-            let strategy = match restore_options.dry_run {
-                true => OffsetResetStrategy::DryRun,
-                false => OffsetResetStrategy::Auto,
-            };
-
-            let plan = self
-                .generate_offset_reset_plan(
-                    &restore_report.offset_mapping,
-                    &effective_consumer_groups,
-                    strategy,
-                )
-                .await?;
-
-            let report = if strategy != OffsetResetStrategy::DryRun {
-                Some(self.apply_offset_reset(&plan).await?)
-            } else {
-                warnings
-                    .push("Phase 3 ran in dry-run mode, offsets not actually reset".to_string());
-                None
-            };
-
-            (Some(plan), report)
-        } else {
-            if !effective_consumer_groups.is_empty()
-                && !restore_options.reset_consumer_offsets
-                && !restore_options.auto_consumer_groups
-            {
-                warnings.push(
-                    "Consumer groups specified but reset_consumer_offsets=false, skipping Phase 3"
-                        .to_string(),
-                );
-            }
-            (None, None)
-        };
+        let outcome = self.run_offset_reset_phase(&restore_report).await?;
+        warnings.extend(outcome.warnings);
+        let (offset_reset_plan, offset_reset_report) = (outcome.plan, outcome.report);
 
         let total_duration_ms = start_time.elapsed().as_millis() as u64;
         let success = restore_report.errors.is_empty()
@@ -212,6 +190,99 @@ impl ThreePhaseRestore {
         }
 
         Ok(report)
+    }
+
+    /// Run Phase 3 for a completed Phase 2 restore: generate the consumer group
+    /// offset reset plan from the report's offset mapping and apply it to the
+    /// target cluster (or only plan it, in dry-run mode).
+    ///
+    /// Groups come from `restore_report.resolved_consumer_groups` — which
+    /// includes groups the engine auto-loaded from the backup's snapshot
+    /// (`auto_consumer_groups`) — falling back to the configured
+    /// `consumer_groups`. Nothing is applied unless the configuration asks for
+    /// it (see [`Self::wants_offset_reset`]); repartitioned topics are skipped
+    /// with a warning because no source→target offset mapping exists for them.
+    ///
+    /// This is the single place Phase 3 happens: `run_all_phases`, the
+    /// `restore` CLI command and the operator all go through it, so offsets
+    /// are applied exactly once per run.
+    pub async fn run_offset_reset_phase(
+        &self,
+        restore_report: &RestoreReport,
+    ) -> Result<OffsetResetPhaseOutcome> {
+        let restore_options = self.config.restore.clone().unwrap_or_default();
+        let mut warnings = Vec::new();
+
+        // Warn about repartitioned topics — offset reset is not supported for them
+        if !restore_options.repartitioning.is_empty() {
+            let topics: Vec<&String> = restore_options.repartitioning.keys().collect();
+            warn!(
+                "Repartitioned topics {:?} will be skipped during Phase 3 offset reset \
+                 (source→target offset mapping is not available for repartitioned data)",
+                topics
+            );
+            warnings.push(format!(
+                "Repartitioned topics skipped for offset reset: {:?}",
+                topics
+            ));
+        }
+
+        // Use resolved_consumer_groups from the restore report — this includes
+        // groups auto-loaded from snapshot by the engine (auto_consumer_groups).
+        // The config's consumer_groups list may be empty if auto_consumer_groups
+        // was used, because the engine resolves groups at runtime.
+        let effective_consumer_groups = if !restore_report.resolved_consumer_groups.is_empty() {
+            restore_report.resolved_consumer_groups.clone()
+        } else {
+            restore_options.consumer_groups.clone()
+        };
+        let effective_reset = restore_options.reset_consumer_offsets
+            || (restore_options.auto_consumer_groups && !effective_consumer_groups.is_empty());
+
+        if !effective_reset || effective_consumer_groups.is_empty() {
+            if !effective_consumer_groups.is_empty()
+                && !restore_options.reset_consumer_offsets
+                && !restore_options.auto_consumer_groups
+            {
+                warnings.push(
+                    "Consumer groups specified but reset_consumer_offsets=false, skipping Phase 3"
+                        .to_string(),
+                );
+            }
+            return Ok(OffsetResetPhaseOutcome {
+                plan: None,
+                report: None,
+                warnings,
+            });
+        }
+
+        info!("Phase 3: Generating and applying offset reset plan...");
+
+        let strategy = match restore_options.dry_run {
+            true => OffsetResetStrategy::DryRun,
+            false => OffsetResetStrategy::Auto,
+        };
+
+        let plan = self
+            .generate_offset_reset_plan(
+                &restore_report.offset_mapping,
+                &effective_consumer_groups,
+                strategy,
+            )
+            .await?;
+
+        let report = if strategy != OffsetResetStrategy::DryRun {
+            Some(self.apply_offset_reset(&plan).await?)
+        } else {
+            warnings.push("Phase 3 ran in dry-run mode, offsets not actually reset".to_string());
+            None
+        };
+
+        Ok(OffsetResetPhaseOutcome {
+            plan: Some(plan),
+            report,
+            warnings,
+        })
     }
 
     /// Run Phase 2: Restore data and collect offset mapping
@@ -336,5 +407,136 @@ mod tests {
         let config = test_config();
         let result = ThreePhaseRestore::new(config);
         assert!(result.is_ok());
+    }
+
+    fn restore_report_with_groups(groups: &[&str]) -> RestoreReport {
+        RestoreReport {
+            backup_id: "test-backup".to_string(),
+            dry_run: false,
+            start_time: 0,
+            end_time: 0,
+            duration_ms: 0,
+            topics_restored: vec![],
+            segments_processed: 0,
+            records_restored: 0,
+            bytes_restored: 0,
+            throughput_records_per_sec: 0.0,
+            throughput_bytes_per_sec: 0.0,
+            errors: vec![],
+            offset_mapping: OffsetMapping::new(),
+            resolved_consumer_groups: groups.iter().map(|g| g.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn wants_offset_reset_follows_either_flag() {
+        use crate::config::RestoreOptions;
+        let mut opts = RestoreOptions::default();
+        assert!(!ThreePhaseRestore::wants_offset_reset(&opts));
+        opts.reset_consumer_offsets = true;
+        assert!(ThreePhaseRestore::wants_offset_reset(&opts));
+        opts.reset_consumer_offsets = false;
+        opts.auto_consumer_groups = true;
+        assert!(ThreePhaseRestore::wants_offset_reset(&opts));
+    }
+
+    /// No consumer groups in scope → Phase 3 is a no-op: no plan, no report,
+    /// counts as success, and — crucially — no network access is attempted
+    /// (the test config has no target cluster).
+    #[tokio::test]
+    async fn offset_reset_phase_is_noop_without_groups() {
+        let mut config = test_config();
+        config.restore = Some(crate::config::RestoreOptions {
+            reset_consumer_offsets: true,
+            ..Default::default()
+        });
+        let orchestrator = ThreePhaseRestore::new(config).unwrap();
+        let outcome = orchestrator
+            .run_offset_reset_phase(&restore_report_with_groups(&[]))
+            .await
+            .unwrap();
+        assert!(outcome.plan.is_none());
+        assert!(outcome.report.is_none());
+        assert!(!outcome.applied());
+        assert!(outcome.success());
+        assert!(outcome.warnings.is_empty());
+    }
+
+    /// Groups resolved (e.g. from the snapshot) but neither flag set → skipped
+    /// with an explicit warning rather than silently.
+    #[tokio::test]
+    async fn offset_reset_phase_warns_when_groups_present_but_reset_not_requested() {
+        let mut config = test_config();
+        config.restore = Some(crate::config::RestoreOptions::default());
+        let orchestrator = ThreePhaseRestore::new(config).unwrap();
+        let outcome = orchestrator
+            .run_offset_reset_phase(&restore_report_with_groups(&["orders-app"]))
+            .await
+            .unwrap();
+        assert!(outcome.plan.is_none());
+        assert!(!outcome.applied());
+        assert!(outcome.success());
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(outcome.warnings[0].contains("reset_consumer_offsets=false"));
+    }
+
+    /// Dry run: a plan is generated (offline — no target needed) but nothing
+    /// is applied, and the outcome says so.
+    #[tokio::test]
+    async fn offset_reset_phase_plans_only_in_dry_run() {
+        let mut config = test_config();
+        config.restore = Some(crate::config::RestoreOptions {
+            reset_consumer_offsets: true,
+            dry_run: true,
+            consumer_groups: vec!["orders-app".to_string()],
+            ..Default::default()
+        });
+        let orchestrator = ThreePhaseRestore::new(config).unwrap();
+        let outcome = orchestrator
+            .run_offset_reset_phase(&restore_report_with_groups(&[]))
+            .await
+            .unwrap();
+        let plan = outcome
+            .plan
+            .as_ref()
+            .expect("dry run still produces a plan");
+        assert!(plan.dry_run);
+        assert_eq!(plan.groups.len(), 1);
+        assert!(outcome.report.is_none());
+        assert!(!outcome.applied());
+        assert!(outcome.success());
+        assert!(outcome.warnings.iter().any(|w| w.contains("dry-run")));
+    }
+
+    #[test]
+    fn outcome_success_reflects_applied_report() {
+        use crate::restore::offset_reset::OffsetResetReport;
+        let ok = OffsetResetPhaseOutcome {
+            plan: None,
+            report: Some(OffsetResetReport {
+                executed_at: 0,
+                groups_reset: vec![],
+                partitions_reset: 3,
+                errors: vec![],
+                success: true,
+                duration_ms: 0,
+            }),
+            warnings: vec![],
+        };
+        assert!(ok.applied() && ok.success());
+
+        let failed = OffsetResetPhaseOutcome {
+            plan: None,
+            report: Some(OffsetResetReport {
+                executed_at: 0,
+                groups_reset: vec![],
+                partitions_reset: 0,
+                errors: vec!["g:t:0 - error code 25 (UNKNOWN_MEMBER_ID: …)".to_string()],
+                success: false,
+                duration_ms: 0,
+            }),
+            warnings: vec![],
+        };
+        assert!(failed.applied() && !failed.success());
     }
 }

--- a/crates/kafka-backup-core/tests/integration_suite/issue_148_offset_reset_after_restore.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_148_offset_reset_after_restore.rs
@@ -1,0 +1,293 @@
+//! Issue #148 — consumer group offsets must actually be applied after a restore
+//! that asks for it (`reset_consumer_offsets` / `auto_consumer_groups`), and the
+//! layering must hold: the restore *engine* (Phase 2) never commits offsets;
+//! `ThreePhaseRestore::run_offset_reset_phase` (Phase 3) does — exactly once —
+//! from the mapping the engine returns. `kafka-backup restore` and
+//! `three-phase-restore` both go through that one method.
+//!
+//! Single-broker Testcontainers cluster: the "source" and "target" are the same
+//! broker, so the restore maps `orders → orders-restored` and Phase 3 commits
+//! the group's offsets against the restored topic. The source topic's offsets
+//! must stay untouched.
+//!
+//! These tests require Docker.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, RestoreOptions, SecurityConfig,
+    TopicSelection,
+};
+use kafka_backup_core::kafka::{fetch_offsets, KafkaClient, PartitionLeaderRouter};
+use kafka_backup_core::restore::{RestoreEngine, ThreePhaseRestore};
+use kafka_backup_core::storage::StorageBackendConfig;
+
+use super::common::{create_temp_storage, KafkaTestCluster};
+
+const SOURCE_TOPIC: &str = "issue-148-orders";
+const TARGET_TOPIC: &str = "issue-148-orders-restored";
+const GROUP: &str = "issue-148-app";
+const BACKUP_ID: &str = "issue-148-backup";
+/// Committed source offsets per partition (3 partitions, 20 records each).
+const SOURCE_COMMITS: [(i32, i64); 3] = [(0, 5), (1, 12), (2, 20)];
+
+fn backup_config(bs: &str, storage: PathBuf) -> Config {
+    Config {
+        mode: Mode::Backup,
+        backup_id: BACKUP_ID.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![SOURCE_TOPIC.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: Some(BackupOptions {
+            segment_max_bytes: 1024 * 1024,
+            segment_max_interval_ms: 5000,
+            compression: CompressionType::Zstd,
+            stop_at_current_offsets: true,
+            continuous: false,
+            include_offset_headers: true,
+            consumer_group_snapshot: true,
+            ..Default::default()
+        }),
+        restore: None,
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+fn restore_config(bs: &str, storage: PathBuf, auto_consumer_groups: bool) -> Config {
+    let mut topic_mapping = HashMap::new();
+    topic_mapping.insert(SOURCE_TOPIC.to_string(), TARGET_TOPIC.to_string());
+    Config {
+        mode: Mode::Restore,
+        backup_id: BACKUP_ID.to_string(),
+        source: None,
+        target: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection::default(),
+            connection: Default::default(),
+        }),
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: None,
+        restore: Some(RestoreOptions {
+            topic_mapping,
+            create_topics: true,
+            auto_consumer_groups,
+            ..RestoreOptions::default()
+        }),
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+/// Seed committed offsets for `GROUP` through the coordinator-aware router
+/// path (retries the transient NOT_COORDINATOR / COORDINATOR_LOAD_IN_PROGRESS
+/// a fresh broker returns while `__consumer_offsets` is being created).
+async fn seed_group_offsets(bs: &str, offsets: &[(String, i32, i64, Option<String>)]) {
+    let router = PartitionLeaderRouter::new(KafkaConfig {
+        bootstrap_servers: vec![bs.to_string()],
+        security: SecurityConfig::default(),
+        topics: TopicSelection::default(),
+        connection: Default::default(),
+    })
+    .await
+    .expect("router");
+    for attempt in 1..=10 {
+        let results = router
+            .commit_group_offsets(GROUP, offsets)
+            .await
+            .expect("commit_group_offsets");
+        if results.iter().all(|(_, _, code)| *code == 0) {
+            return;
+        }
+        if attempt == 10 {
+            panic!("seeding group offsets failed: {results:?}");
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Committed offsets of `GROUP` on `topic`, keyed by partition; partitions
+/// without a commit are reported by the broker as -1 and omitted here.
+async fn committed(client: &KafkaClient, topic: &str) -> HashMap<i32, i64> {
+    // `None` = every topic the group has offsets for (an explicit topic list
+    // with no partition indexes returns nothing from the broker).
+    fetch_offsets(client, GROUP, None)
+        .await
+        .expect("fetch_offsets")
+        .into_iter()
+        .filter(|o| o.topic == topic && o.offset >= 0)
+        .map(|o| (o.partition, o.offset))
+        .collect()
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_restore_applies_consumer_group_offsets_in_phase_3_exactly_once() {
+    let cluster = KafkaTestCluster::start().await.expect("start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka ready");
+    let bs = cluster.bootstrap_servers.clone();
+
+    // Source topic: 3 partitions × 20 records, and a group with committed offsets.
+    cluster
+        .create_topic(SOURCE_TOPIC, 60)
+        .await
+        .expect("create source topic");
+    let client = cluster.create_client();
+    client.connect().await.expect("connect");
+    let commits: Vec<(String, i32, i64, Option<String>)> = SOURCE_COMMITS
+        .iter()
+        .map(|(p, o)| (SOURCE_TOPIC.to_string(), *p, *o, None))
+        .collect();
+    seed_group_offsets(&bs, &commits).await;
+    sleep(Duration::from_secs(1)).await;
+    let source_before = committed(&client, SOURCE_TOPIC).await;
+    assert_eq!(source_before.len(), 3, "seeded offsets: {source_before:?}");
+
+    // Backup with the consumer-groups snapshot.
+    let storage = create_temp_storage();
+    let engine = BackupEngine::new(backup_config(&bs, storage.path().to_path_buf()))
+        .await
+        .expect("backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup");
+    assert!(
+        storage
+            .path()
+            .join(BACKUP_ID)
+            .join("consumer-groups-snapshot.json")
+            .exists(),
+        "backup must write the consumer-groups snapshot"
+    );
+
+    // Phase 2 only: the engine restores data and builds the mapping — and must
+    // NOT touch consumer offsets, even with auto_consumer_groups set.
+    let config = restore_config(&bs, storage.path().to_path_buf(), true);
+    let report = tokio::time::timeout(
+        Duration::from_secs(60),
+        RestoreEngine::new(config.clone())
+            .expect("restore engine")
+            .run(),
+    )
+    .await
+    .expect("restore timed out")
+    .expect("restore");
+    assert_eq!(report.records_restored, 60);
+    assert_eq!(
+        report.resolved_consumer_groups,
+        vec![GROUP.to_string()],
+        "engine resolves the group from the snapshot"
+    );
+    sleep(Duration::from_secs(1)).await;
+    assert!(
+        committed(&client, TARGET_TOPIC).await.is_empty(),
+        "Phase 2 must not commit consumer offsets on the target topic"
+    );
+
+    // Phase 3: apply. This is what `restore` and `three-phase-restore` run.
+    let orchestrator = ThreePhaseRestore::new(config).expect("orchestrator");
+    assert!(ThreePhaseRestore::wants_offset_reset(
+        &orchestrator_restore_options(&bs, storage.path().to_path_buf())
+    ));
+    let outcome = orchestrator
+        .run_offset_reset_phase(&report)
+        .await
+        .expect("phase 3");
+    assert!(outcome.applied(), "offsets should have been applied");
+    assert!(outcome.success(), "phase 3 errors: {:?}", outcome.report);
+    let phase3 = outcome.report.as_ref().unwrap();
+    assert_eq!(phase3.partitions_reset, 3);
+    assert!(phase3.errors.is_empty(), "{:?}", phase3.errors);
+    sleep(Duration::from_secs(1)).await;
+
+    // The target topic was created empty, so translated offsets equal the
+    // source offsets; the source topic's commits are untouched.
+    let expected: HashMap<i32, i64> = SOURCE_COMMITS.iter().copied().collect();
+    assert_eq!(committed(&client, TARGET_TOPIC).await, expected);
+    assert_eq!(committed(&client, SOURCE_TOPIC).await, source_before);
+
+    // Applying the same plan again is idempotent (same offsets, still success).
+    let again = orchestrator
+        .run_offset_reset_phase(&report)
+        .await
+        .expect("phase 3 again");
+    assert!(again.success());
+    assert_eq!(again.report.unwrap().partitions_reset, 3);
+    sleep(Duration::from_secs(1)).await;
+    assert_eq!(committed(&client, TARGET_TOPIC).await, expected);
+}
+
+/// Without either flag, a restore neither resolves groups nor touches offsets,
+/// and Phase 3 is a no-op — the documented opt-in holds.
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_restore_without_reset_flags_leaves_consumer_offsets_alone() {
+    let cluster = KafkaTestCluster::start().await.expect("start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka ready");
+    let bs = cluster.bootstrap_servers.clone();
+
+    cluster
+        .create_topic(SOURCE_TOPIC, 30)
+        .await
+        .expect("create source topic");
+    let client = cluster.create_client();
+    client.connect().await.expect("connect");
+    seed_group_offsets(&bs, &[(SOURCE_TOPIC.to_string(), 0, 3, None)]).await;
+    sleep(Duration::from_secs(1)).await;
+    assert_eq!(committed(&client, SOURCE_TOPIC).await.get(&0), Some(&3));
+
+    let storage = create_temp_storage();
+    let engine = BackupEngine::new(backup_config(&bs, storage.path().to_path_buf()))
+        .await
+        .expect("backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup");
+
+    let config = restore_config(&bs, storage.path().to_path_buf(), false);
+    let report = tokio::time::timeout(
+        Duration::from_secs(60),
+        RestoreEngine::new(config.clone())
+            .expect("restore engine")
+            .run(),
+    )
+    .await
+    .expect("restore timed out")
+    .expect("restore");
+    assert!(report.resolved_consumer_groups.is_empty());
+
+    let outcome = ThreePhaseRestore::new(config)
+        .expect("orchestrator")
+        .run_offset_reset_phase(&report)
+        .await
+        .expect("phase 3");
+    assert!(!outcome.applied());
+    assert!(outcome.plan.is_none());
+    sleep(Duration::from_secs(1)).await;
+    assert!(committed(&client, TARGET_TOPIC).await.is_empty());
+}
+
+fn orchestrator_restore_options(bs: &str, storage: PathBuf) -> RestoreOptions {
+    restore_config(bs, storage, true).restore.unwrap()
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -11,10 +11,12 @@
 //! - Performance Issues: Issue #29 constant lag and throughput tests
 //! - Issue #144: OFFSET_OUT_OF_RANGE recovery and data-gap recording
 //! - Issue #146: connection-error classification and reconnect (no Docker)
+//! - Issue #148: consumer group offsets applied in Phase 3 after restore
 
 pub mod common;
 pub mod issue_144_offset_out_of_range;
 pub mod issue_146_connection_errors;
+pub mod issue_148_offset_reset_after_restore;
 pub mod issue_56_missing_topic;
 pub mod issue_67_fixes;
 pub mod offset_semantics;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -682,8 +682,16 @@ restore:
 |--------|------|----------|---------|-------------|
 | `consumer_group_strategy` | string | No | `skip` | Offset handling strategy |
 | `consumer_groups` | list[string] | No | `[]` | Consumer groups to process |
-| `reset_consumer_offsets` | bool | No | `false` | Actually reset offsets |
+| `reset_consumer_offsets` | bool | No | `false` | Commit translated offsets for `consumer_groups` on the target after the data restore (Phase 3) |
+| `auto_consumer_groups` | bool | No | `false` | Load the groups (and their offsets) from the backup's `consumer-groups-snapshot.json`; implies `reset_consumer_offsets` |
 | `offset_report` | string | No | - | Path to write offset report |
+
+`reset_consumer_offsets` / `auto_consumer_groups` are honoured by
+`kafka-backup restore` and `kafka-backup three-phase-restore` alike: the data
+restore runs first, then the offsets are applied exactly once from the mapping
+built during that run. A failed reset (e.g. the group still has active
+consumers on the target — `error code 25`) makes the command exit non-zero.
+See [Automatic Offset Reset](restore_guide.md#automatic-offset-reset-dangerous).
 
 #### Consumer Group Strategies
 

--- a/docs/restore_guide.md
+++ b/docs/restore_guide.md
@@ -585,7 +585,34 @@ restore:
     - another-group
 ```
 
+or, to take the groups from the snapshot the backup wrote
+(`backup.consumer_group_snapshot: true` or `kafka-backup snapshot-groups`):
+
+```yaml
+restore:
+  auto_consumer_groups: true   # implies reset_consumer_offsets
+```
+
 **WARNING**: This modifies `__consumer_offsets` on the target cluster. Only use with explicit understanding of the implications.
+
+How it is applied:
+
+1. The data restore runs first and builds the source→target offset mapping
+   (the restore engine itself never touches `__consumer_offsets`).
+2. Once all data is restored, `kafka-backup restore` (and
+   `kafka-backup three-phase-restore`, which is the explicit equivalent)
+   generates the offset reset plan from that mapping and commits the
+   translated offsets to the target — once. A `Consumer Group Offset Reset
+   (Phase 3)` summary is printed with the groups, partitions and any errors.
+3. If any commit fails the command **exits non-zero** even though the data
+   restore succeeded, so automation notices. The most common failure is
+   `error code 25 (UNKNOWN_MEMBER_ID …)`: the group still has active
+   consumers on the target. Stop them, then re-run the reset with
+   `kafka-backup offset-reset execute` (or the restore again — re-applying
+   the same offsets is idempotent).
+
+Consumer groups on the target must be **inactive** when the offsets are
+applied — the same rule MirrorMaker 2 and Confluent Replicator follow.
 
 ---
 


### PR DESCRIPTION
Fixes #148  `restore` now actually commits consumer group offset resets to the target cluster automatically when `reset_consumer_offsets: true` is set, instead of only building an in-memory mapping that was previously discarded at the end of the run.

The config flags `reset_consumer_offsets` and `auto_consumer_groups` strongly imply full automation ("Reset offsets after restore"), and the tool already has complete, tested machinery for this (`restore::offset_reset::OffsetResetExecutor`) — but `run_internal()` never called it. Achieving an actual reset required a separate `offset-reset execute` CLI invocation, which itself only works correctly if a `restore-report.json`/`offset-mapping.json` was previously saved; otherwise it silently falls back to a much weaker manifest-only mapping with no real per-record offset translation.

## Change

Added a new method on `RestoreEngine`:

```rust
async fn execute_consumer_group_offset_reset(
    &self,
    offset_mapping: &crate::manifest::OffsetMapping,
    restore_options: &RestoreOptions,
) -> crate::Result<OffsetResetReport> {
    let router = self.router.read().await.clone()
        .ok_or_else(|| Error::Config("Router not initialized".to_string()))?;

    let target = self.config.target.as_ref().unwrap();
    let executor = OffsetResetExecutor::new_with_router(router, target.bootstrap_servers.clone());

    let plan = executor
        .generate_plan(offset_mapping, &restore_options.consumer_groups, OffsetResetStrategy::Auto)
        .await?;

    executor.execute_plan(&plan).await
}
```

and call it at the end of `run_internal()`, right after the in-memory offset mapping is finalized:

```rust
if restore_options.reset_consumer_offsets && !restore_options.consumer_groups.is_empty() {
    match self.execute_consumer_group_offset_reset(&offset_mapping, &restore_options).await {
        Ok(reset_report) => {
            info!(
                "Consumer group offset reset: {} partitions reset across {} groups",
                reset_report.partitions_reset, reset_report.groups_reset.len()
            );
            if !reset_report.success {
                for err in &reset_report.errors {
                    warn!("Offset reset error: {}", err);
                }
            }
        }
        Err(e) => warn!("Consumer group offset reset failed (non-fatal): {}", e),
    }
}
```

This reuses the already-connected, already-authenticated target `PartitionLeaderRouter` (no new client, no bootstrap-server mismatch risk) and the accurate, detailed per-record offset mapping built live during this exact restore run — strictly more correct than reloading from disk afterward. Failures are logged as non-fatal warnings rather than failing an otherwise-successful restore.

## Testing

Ran a restore with `reset_consumer_offsets: true` and `auto_consumer_groups: true` against a snapshot of 58 consumer group offsets. Confirmed via `kafka-consumer-groups.bat --describe` on the target cluster that groups now exist with correctly translated offsets, matching each group's logical position from the source cluster — no separate manual `offset-reset execute` invocation required.

