### PR TITLE
fix(deps): pin kafka-protocol to upstream main — record timestampDelta is a varlong (#150)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,10 +292,28 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
 
+      # Issue #150: while the workspace Cargo.toml carries a `[patch.crates-io]`
+      # git override for kafka-protocol, the packaged crate cannot be built
+      # against the crates.io release it declares (`cargo publish` verifies the
+      # package in isolation and ignores workspace patches), so publishing
+      # kafka-backup-core is skipped. This resumes automatically once the patch
+      # is removed, i.e. once a fixed kafka-protocol is on crates.io.
+      - name: Check for kafka-protocol source patch
+        id: patch
+        run: |
+          if grep -Eq '^\s*kafka-protocol\s*=\s*\{[^}]*git\s*=' Cargo.toml; then
+            echo "active=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::kafka-protocol is patched to a git revision; skipping crates.io publish of kafka-backup-core (see issue #150)"
+          else
+            echo "active=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Verify package is publishable
+        if: steps.patch.outputs.active != 'true'
         run: cargo publish -p kafka-backup-core --dry-run
 
       - name: Publish kafka-backup-core to crates.io
+        if: steps.patch.outputs.active != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p kafka-backup-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - 2026-08-18
+
+### Fixed
+- Backups no longer fail — and restores no longer refuse — on record batches
+  whose records' timestamps span more than ~24.8 days (`i32::MAX` ms), e.g.
+  1970-01-01 placeholder timestamps mixed with current ones. `kafka-protocol`
+  0.17.0 decodes each record's `timestampDelta` as a 32-bit varint (the wire
+  format is a varlong), so from the first such record on every field was
+  misread and the fetch failed with errors like `Failed to decode records:
+  Unexpected negative record value length (-54 bytes)` or `invalid utf-8
+  sequence`, permanently failing the partition; its encoder also refused to
+  produce such batches. `kafka-protocol` is now pinned via `[patch.crates-io]`
+  to upstream `main` (`946ceb77`), which carries the fix
+  (kafka-protocol-rs#159) and a snappy-decompression corruption fix
+  (kafka-protocol-rs#149). Fixes
+  [#150](https://github.com/osodevops/kafka-backup/issues/150).
+
+### Changed
+- All artifacts built from this repository (CLI binaries, Docker image,
+  Homebrew formula) carry the pinned kafka-protocol. The published
+  `kafka-backup-core` crate cannot be built against the crates.io
+  kafka-protocol 0.17.0 it declares, so **publishing kafka-backup-core to
+  crates.io is skipped while the patch is active** (the release workflow
+  detects the patch and skips the job; it resumes automatically once a fixed
+  kafka-protocol is on crates.io and the patch is removed). Library consumers
+  should depend on this repository by git and/or add the same
+  `[patch.crates-io]` entry to their workspace.
+- Restore still splits produced batches so no batch spans more than
+  `i32::MAX` ms; this is no longer required by the pinned encoder but keeps
+  restores working when built against the unpatched crate.
+
 ## [0.17.2] - 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1423,8 +1423,7 @@ dependencies = [
 [[package]]
 name = "kafka-protocol"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66292444a1cd4d430d450d472c30cba839d0724229aba2d79affffcf901516e2"
+source = "git+https://github.com/kafka-protocol-rs/kafka-protocol-rs?rev=946ceb7733af0dc125fda932d0491d2efc6b477e#946ceb7733af0dc125fda932d0491d2efc6b477e"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.2"
+version = "0.17.3"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]
@@ -15,7 +15,9 @@ repository = "https://github.com/osodevops/kafka-backup"
 homepage = "https://github.com/osodevops/kafka-backup"
 
 [workspace.dependencies]
-# Kafka protocol
+# Kafka protocol. See `[patch.crates-io]` at the bottom of this file: the
+# 0.17.0 release has a record-decoding bug and is patched to upstream `main`
+# until a fixed version is published (issue #150).
 kafka-protocol = "0.17"
 
 # Async runtime
@@ -114,3 +116,23 @@ kafka-backup-core = { path = "crates/kafka-backup-core" }
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# --------------------------------------------------------------------------
+# Temporary source patches. Applied to every build of this workspace (the CLI
+# binaries, Docker image and Homebrew formula all come from here). They are
+# NOT part of the published `kafka-backup-core` crate: consumers building it
+# from crates.io must add the same `[patch.crates-io]` entry to their own
+# workspace until the upstream fix is released.
+# --------------------------------------------------------------------------
+[patch.crates-io]
+# kafka-protocol 0.17.0 decodes each record's `timestampDelta` as a 32-bit
+# zigzag varint (the spec says varlong), so any batch whose records span more
+# than ~24.8 days (i32::MAX ms) — e.g. 1970 placeholder timestamps mixed with
+# current ones — is misread from that record on and the fetch fails with
+# "negative record value length" / "invalid utf-8" style errors, and its
+# encoder refuses to *produce* such batches. Fixed upstream in
+# kafka-protocol-rs#159 (merged 2026-08-04) but not yet released; this rev is
+# upstream `main` (0.17.0 + #149 snappy-decompress fix, #153, #157, #159,
+# #150). Remove once kafka-protocol ≥ 0.17.1 / 0.18.0 is on crates.io.
+# Tracking: https://github.com/osodevops/kafka-backup/issues/150
+kafka-protocol = { git = "https://github.com/kafka-protocol-rs/kafka-protocol-rs", rev = "946ceb7733af0dc125fda932d0491d2efc6b477e" }

--- a/README.md
+++ b/README.md
@@ -493,6 +493,12 @@ kafka-backup is licensed under the [MIT License](LICENSE) © [OSO](https://oso.s
 
 Built with these excellent Rust crates:
 - [kafka-protocol](https://crates.io/crates/kafka-protocol) — Kafka protocol implementation
+  (currently pinned to an upstream git revision via `[patch.crates-io]`: the
+  0.17.0 release misdecodes records whose timestamps span more than ~24.8 days
+  within one batch — see [issue #150](https://github.com/osodevops/kafka-backup/issues/150).
+  If you depend on `kafka-backup-core` as a library, add the same `[patch.crates-io]`
+  entry from this repo's `Cargo.toml` to your workspace until a fixed
+  kafka-protocol is released.)
 - [object_store](https://crates.io/crates/object_store) — Cloud storage abstraction
 - [tokio](https://tokio.rs) — Async runtime
 - [zstd](https://crates.io/crates/zstd) — Compression

--- a/crates/kafka-backup-core/src/kafka/fetch.rs
+++ b/crates/kafka-backup-core/src/kafka/fetch.rs
@@ -391,6 +391,7 @@ mod tests {
         Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
             producer_id: NO_PRODUCER_ID,
             producer_epoch: NO_PRODUCER_EPOCH,
@@ -549,5 +550,80 @@ mod tests {
         let (records, next_offset) = parse(Vec::new(), 42);
         assert!(records.is_empty());
         assert_eq!(next_offset, 42);
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #150: per-record timestampDelta is a varlong on the wire.
+    // ------------------------------------------------------------------
+
+    /// One v2 record batch exactly as Apache Kafka's Java client
+    /// (kafka-clients 4.3.1) produced it and the broker stored it: 20
+    /// uncompressed records on partition 0, alternating a 1970-01-01
+    /// placeholder timestamp (0) with "now" (1787086231121 + i). The batch's
+    /// base timestamp is 0, so every odd record's `timestampDelta` is
+    /// ~1.79e12 ms — far beyond `i32::MAX` — and is encoded as a **6-byte**
+    /// zigzag varlong (record 1: `a2 d9 9e ea 82 68`).
+    ///
+    /// kafka-protocol 0.17.0 decoded that field as a 5-byte-capped `VarInt`,
+    /// consumed 5 of the 6 bytes, and misread every field after it
+    /// ("Unexpected negative record value length (-54 bytes)", "invalid
+    /// utf-8 …"). Captured from the broker log segment (on-disk v2 format is
+    /// identical to the Fetch wire format); CRC is intact.
+    const JAVA_WIDE_TIMESTAMP_BATCH_HEX: &str = concat!(
+        "0000000000000000000001b7000000000269f94cec0000000000130000000000000000000001",
+        "a016a3d66300000000000003eb0000000000000000001420000000046b301076302d65706f63",
+        "68002600a2d99eea826802046b310c76312d6e6f770020000004046b321076322d65706f6368",
+        "002600a6d99eea826806046b330c76332d6e6f770020000008046b341076342d65706f636800",
+        "2600aad99eea82680a046b350c76352d6e6f77002000000c046b361076362d65706f63680026",
+        "00aed99eea82680e046b370c76372d6e6f770020000010046b381076382d65706f6368002600",
+        "b2d99eea826812046b390c76392d6e6f770024000014066b3130127631302d65706f6368002a",
+        "00b6d99eea826816066b31310e7631312d6e6f770024000018066b3132127631322d65706f63",
+        "68002a00bad99eea82681a066b31330e7631332d6e6f77002400001c066b3134127631342d65",
+        "706f6368002a00bed99eea82681e066b31350e7631352d6e6f770024000020066b3136127631",
+        "362d65706f6368002a00c2d99eea826822066b31370e7631372d6e6f770024000024066b3138",
+        "127631382d65706f6368002a00c6d99eea826826066b31390e7631392d6e6f7700"
+    );
+
+    #[test]
+    fn decodes_java_batch_whose_records_span_decades() {
+        let raw = hex_to_bytes(JAVA_WIDE_TIMESTAMP_BATCH_HEX);
+        assert_eq!(raw.len(), 451, "fixture is a single 451-byte batch");
+
+        let (records, next_offset) =
+            decode_fetch_data(&raw, 0).expect("batch produced by the Java client must decode");
+
+        assert_eq!(records.len(), 20);
+        assert_eq!(next_offset, 20);
+        let now = 1_787_086_231_121i64; // record 1's CreateTime as reported by kafka-console-consumer
+        for (i, r) in records.iter().enumerate() {
+            assert_eq!(r.offset, i as i64);
+            let expected_ts = if i % 2 == 0 { 0 } else { now + (i as i64 - 1) };
+            assert_eq!(r.timestamp, expected_ts, "record {i} timestamp");
+            assert_eq!(
+                r.key.as_deref(),
+                Some(format!("k{i}").as_bytes()),
+                "record {i} key"
+            );
+            let expected_value = format!("v{i}{}", if i % 2 == 0 { "-epoch" } else { "-now" });
+            assert_eq!(
+                r.value.as_deref(),
+                Some(expected_value.as_bytes()),
+                "record {i} value"
+            );
+            assert!(r.headers.is_empty());
+        }
+        // Sanity: the delta really is beyond i32 — this is the case that broke.
+        assert!(records[1].timestamp - records[0].timestamp > i32::MAX as i64);
+    }
+
+    fn hex_to_bytes(hex: &str) -> Bytes {
+        let clean: String = hex.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(clean.len() % 2, 0);
+        Bytes::from(
+            (0..clean.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&clean[i..i + 2], 16).expect("hex"))
+                .collect::<Vec<u8>>(),
+        )
     }
 }

--- a/crates/kafka-backup-core/src/kafka/produce.rs
+++ b/crates/kafka-backup-core/src/kafka/produce.rs
@@ -31,9 +31,14 @@ pub struct ProduceResponse {
     pub sub_batch_offsets: Vec<(i64, usize)>,
 }
 
-/// Max timestamp delta within a single record batch.
-/// Record batch v2 stores timestamp deltas as i32 (milliseconds).
-/// i32::MAX ≈ 24.8 days.
+/// Max timestamp delta within a single produced record batch.
+///
+/// The wire format stores each record's timestamp delta as a varlong, so a
+/// batch may legally span any range. This limit exists because
+/// kafka-protocol's `RecordBatchEncoder` up to and including the 0.17.0
+/// crates.io release refuses to encode deltas outside `i32` ("Timestamps
+/// within batch are too far apart"); splitting keeps restores working even
+/// when built against that release. i32::MAX ms ≈ 24.8 days.
 const MAX_TIMESTAMP_DELTA_MS: i64 = i32::MAX as i64;
 
 /// Split records into sub-batches where all timestamps within a sub-batch
@@ -85,6 +90,9 @@ fn build_kafka_records(records: Vec<BackupRecord>) -> Vec<Record> {
             Record {
                 transactional: false,
                 control: false,
+                // KIP-534 batch attribute; only set by the broker's log cleaner
+                // on tombstone/abort-marker batches, never on produced records.
+                delete_horizon: false,
                 partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
                 producer_id: NO_PRODUCER_ID,
                 producer_epoch: NO_PRODUCER_EPOCH,
@@ -403,5 +411,31 @@ mod tests {
             }
         }
         assert_eq!(record_idx, 50);
+    }
+
+    /// Issue #150: the encoder must accept records whose timestamps are more
+    /// than i32::MAX ms apart within one batch and write the delta as a
+    /// varlong (kafka-protocol 0.17.0 bailed with "Timestamps within batch
+    /// are too far apart"); the decoder must read it back exactly.
+    #[test]
+    fn test_encoder_round_trips_timestamp_delta_beyond_i32() {
+        use kafka_protocol::records::{RecordBatchDecoder, RecordBatchEncoder};
+
+        let now = 1_787_086_231_121i64;
+        let kafka_records = build_kafka_records(vec![make_record(0), make_record(now)]);
+        let options = RecordEncodeOptions {
+            version: 2,
+            compression: Compression::None,
+        };
+        let mut buf = BytesMut::new();
+        RecordBatchEncoder::encode(&mut buf, kafka_records.iter(), &options)
+            .expect("batch spanning decades must encode (varlong timestampDelta)");
+
+        let mut read_buf = buf.freeze();
+        let batches = RecordBatchDecoder::decode_all(&mut read_buf).unwrap();
+        assert_eq!(batches.len(), 1);
+        let ts: Vec<i64> = batches[0].records.iter().map(|r| r.timestamp).collect();
+        assert_eq!(ts, vec![0, now]);
+        assert!(now > i32::MAX as i64);
     }
 }

--- a/crates/kafka-backup-core/tests/produce_debug.rs
+++ b/crates/kafka-backup-core/tests/produce_debug.rs
@@ -52,6 +52,7 @@ async fn test_produce_with_no_constants() {
     let records = [Record {
         transactional: false,
         control: false,
+        delete_horizon: false,
         partition_leader_epoch: NO_PARTITION_LEADER_EPOCH, // -1
         producer_id: NO_PRODUCER_ID,                       // -1
         producer_epoch: NO_PRODUCER_EPOCH,                 // -1
@@ -100,6 +101,7 @@ async fn test_produce_with_zero_epoch() {
         Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0, // <-- 0 instead of -1
             producer_id: -1,
             producer_epoch: -1,
@@ -114,6 +116,7 @@ async fn test_produce_with_zero_epoch() {
         Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: -1,
             producer_epoch: -1,
@@ -234,6 +237,7 @@ async fn test_batch_sequence_fix() {
         .map(|i| Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
             producer_id: NO_PRODUCER_ID,
             producer_epoch: NO_PRODUCER_EPOCH,
@@ -270,6 +274,7 @@ async fn test_batch_sequence_fix() {
         .map(|i| Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
             producer_id: NO_PRODUCER_ID,
             producer_epoch: NO_PRODUCER_EPOCH,
@@ -306,6 +311,7 @@ async fn test_batch_sequence_fix() {
         .map(|i| Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: NO_PARTITION_LEADER_EPOCH,
             producer_id: NO_PRODUCER_ID,
             producer_epoch: NO_PRODUCER_EPOCH,


### PR DESCRIPTION
Fixes #150.

## Problem

`kafka-protocol` 0.17.0 decodes each record's `timestampDelta` as a 32-bit zigzag varint (5-byte cap); the Kafka wire format is a **varlong**. Any batch whose records' timestamps differ from the batch base timestamp by more than `i32::MAX` ms (~24.8 days) — e.g. 1970-01-01 placeholder timestamps mixed with current ones — has that field encoded in 6+ bytes by every spec-compliant producer, so the decoder consumed 5 of them and misread every field after it. Backups of such partitions failed **permanently** (decode errors are not retried); the crate's encoder also refused to *produce* such batches. Fixed upstream in [kafka-protocol-rs#159](https://github.com/kafka-protocol-rs/kafka-protocol-rs/pull/159) (merged 2026-08-04, by the reporter), not yet released.

## Reproduction (before considering the fix)

Java `kafka-clients` 4.3.1 producer writing 20 records into **one** batch on the local broker, alternating `CreateTime:0` and `CreateTime:1787086231121+i` (record 1's delta on the wire is the 6-byte varlong `a2 d9 9e ea 82 68`; `kafka-console-consumer` reads them fine). Backup with the current release:

```
kafka-backup 0.17.2
ERROR Error backing up issue-150-wide:0: Kafka error: Protocol error: Failed to decode records: Unexpected negative record value length (-54 bytes)
ERROR 1 of 1 partition backup tasks failed        exit=1
```

Same batch bytes fed to a scratch crate pinned to crates.io `kafka-protocol =0.17.0`: `DECODE FAILED: Unexpected negative record value length (-54 bytes)`.

## Fix

- `[patch.crates-io] kafka-protocol = { git = "https://github.com/kafka-protocol-rs/kafka-protocol-rs", rev = "946ceb7733af0dc125fda932d0491d2efc6b477e" }` — upstream `main` = 0.17.0 + #149 (snappy-decompress corruption fix), #153, #157 (KIP-534 `delete_horizon`), #159 (this fix), #150. Every artifact built from this workspace (CLI, Docker, Homebrew, cargo-dist) carries it. Our `Record` literals gain `delete_horizon: false`.
- Restore keeps splitting produced batches at `i32::MAX` ms (no longer required by the pinned encoder, but keeps restores working when built against the unpatched crate); the comment that blamed the wire format is corrected.

With the fix, the same backup: exit 0, segment `start_ts=0 end_ts=1787086231139`; restoring it (encoder path, varlong deltas) and reading with the Java consumer gives back 10 × `0` and the 10 distinct current timestamps — exact fidelity.

## crates.io publish

`cargo publish` verifies the packaged crate **in isolation against the crates.io kafka-protocol 0.17.0 it declares** — workspace `[patch]` entries are not applied — and 0.17.0 lacks `delete_horizon`, so `cargo publish --dry-run` fails (verified locally). A published crate could not carry the fix anyway, and crates.io consumption of `kafka-backup-core` is negligible (0 reverse deps, ~15 downloads/version). The release job now **detects the git override and skips the crates.io publish with a warning** while it is present; `host`/Homebrew/Docker/announce are unaffected, and publishing resumes automatically once the patch is removed. Documented in CHANGELOG + README (library consumers: depend by git and/or add the same `[patch]`).

Alternative I did *not* take: a fork branch (`0.17.0` + only #159 cherry-picked, no API change) would keep the published crate compilable — but that means a new public repo; happy to switch if preferred.

## Tests

- `fetch::tests::decodes_java_batch_whose_records_span_decades` — the 451-byte batch exactly as the Java client produced it (captured from the broker log; CRC intact) must decode through `decode_fetch_data` with every offset/timestamp/key/value intact. Fails on 0.17.0 with the same error.
- `produce::tests::test_encoder_round_trips_timestamp_delta_beyond_i32` — encoder accepts a > i32 delta (0.17.0 bailed) and round-trips it.

Local CI checklist green: fmt, clippy `-D warnings --all-features`, 290 lib + 89 unit + integration, `produce_debug` compiles; Docker-backed subset and a local `docker build` in progress at push time.

Version 0.17.3.
