### PR TITLE
chore(deps): unpin kafka-protocol — move to crates.io 0.18.0, resume core publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.4] - 2026-08-20
+
+### Changed
+- `kafka-protocol` is now the crates.io **0.18.0** release and the temporary
+  `[patch.crates-io]` git pin from 0.17.3 has been removed. 0.18.0 contains
+  both fixes the pin carried — the record `timestampDelta` varlong decode fix
+  (kafka-protocol-rs#159, our [#150](https://github.com/osodevops/kafka-backup/issues/150))
+  and the snappy-decompression fix (kafka-protocol-rs#149) — plus the KIP-534
+  `delete_horizon` batch attribute (kafka-protocol-rs#157), which this
+  codebase already supported. Requested upstream in
+  [kafka-protocol-rs#162](https://github.com/kafka-protocol-rs/kafka-protocol-rs/issues/162).
+- **Publishing `kafka-backup-core` to crates.io resumes with this release**
+  (it was skipped for 0.17.3 while the source patch was active). Library
+  consumers no longer need a `[patch.crates-io]` entry in their workspace.
+
 ## [0.17.3] - 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1422,8 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.17.0"
-source = "git+https://github.com/kafka-protocol-rs/kafka-protocol-rs?rev=946ceb7733af0dc125fda932d0491d2efc6b477e#946ceb7733af0dc125fda932d0491d2efc6b477e"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099d5c2f1b40cd830cbf18ca4d2a0805f2875b811ca18f0372b2433e68fe2dda"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1432,7 +1433,6 @@ dependencies = [
  "flate2",
  "indexmap 2.14.0",
  "lz4",
- "paste",
  "snap",
  "uuid",
  "zstd",
@@ -1816,12 +1816,6 @@ dependencies = [
  "structmeta",
  "syn",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.3"
+version = "0.17.4"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]
@@ -15,10 +15,10 @@ repository = "https://github.com/osodevops/kafka-backup"
 homepage = "https://github.com/osodevops/kafka-backup"
 
 [workspace.dependencies]
-# Kafka protocol. See `[patch.crates-io]` at the bottom of this file: the
-# 0.17.0 release has a record-decoding bug and is patched to upstream `main`
-# until a fixed version is published (issue #150).
-kafka-protocol = "0.17"
+# Kafka protocol. 0.18.0 carries the record `timestampDelta` varlong fix
+# (kafka-protocol-rs#159) and snappy-decompression fix (kafka-protocol-rs#149)
+# that 0.17.0 was patched for (issue #150); the git patch is no longer needed.
+kafka-protocol = "0.18"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
@@ -116,23 +116,3 @@ kafka-backup-core = { path = "crates/kafka-backup-core" }
 [profile.dist]
 inherits = "release"
 lto = "thin"
-
-# --------------------------------------------------------------------------
-# Temporary source patches. Applied to every build of this workspace (the CLI
-# binaries, Docker image and Homebrew formula all come from here). They are
-# NOT part of the published `kafka-backup-core` crate: consumers building it
-# from crates.io must add the same `[patch.crates-io]` entry to their own
-# workspace until the upstream fix is released.
-# --------------------------------------------------------------------------
-[patch.crates-io]
-# kafka-protocol 0.17.0 decodes each record's `timestampDelta` as a 32-bit
-# zigzag varint (the spec says varlong), so any batch whose records span more
-# than ~24.8 days (i32::MAX ms) — e.g. 1970 placeholder timestamps mixed with
-# current ones — is misread from that record on and the fetch fails with
-# "negative record value length" / "invalid utf-8" style errors, and its
-# encoder refuses to *produce* such batches. Fixed upstream in
-# kafka-protocol-rs#159 (merged 2026-08-04) but not yet released; this rev is
-# upstream `main` (0.17.0 + #149 snappy-decompress fix, #153, #157, #159,
-# #150). Remove once kafka-protocol ≥ 0.17.1 / 0.18.0 is on crates.io.
-# Tracking: https://github.com/osodevops/kafka-backup/issues/150
-kafka-protocol = { git = "https://github.com/kafka-protocol-rs/kafka-protocol-rs", rev = "946ceb7733af0dc125fda932d0491d2efc6b477e" }

--- a/README.md
+++ b/README.md
@@ -493,12 +493,6 @@ kafka-backup is licensed under the [MIT License](LICENSE) © [OSO](https://oso.s
 
 Built with these excellent Rust crates:
 - [kafka-protocol](https://crates.io/crates/kafka-protocol) — Kafka protocol implementation
-  (currently pinned to an upstream git revision via `[patch.crates-io]`: the
-  0.17.0 release misdecodes records whose timestamps span more than ~24.8 days
-  within one batch — see [issue #150](https://github.com/osodevops/kafka-backup/issues/150).
-  If you depend on `kafka-backup-core` as a library, add the same `[patch.crates-io]`
-  entry from this repo's `Cargo.toml` to your workspace until a fixed
-  kafka-protocol is released.)
 - [object_store](https://crates.io/crates/object_store) — Cloud storage abstraction
 - [tokio](https://tokio.rs) — Async runtime
 - [zstd](https://crates.io/crates/zstd) — Compression


### PR DESCRIPTION
## Summary

Upstream shipped **kafka-protocol 0.18.0** ([kafka-protocol-rs#162](https://github.com/kafka-protocol-rs/kafka-protocol-rs/issues/162), our release request), which contains both fixes the temporary `[patch.crates-io]` git pin from #151 carried:

- record `timestampDelta` decoded as varlong (kafka-protocol-rs#159 — our #150)
- snappy-decompression corruption fix (kafka-protocol-rs#149)

This PR removes the pin and moves to the crates.io release:

- `kafka-protocol = "0.18"`, `[patch.crates-io]` section deleted
- version bump 0.17.3 → **0.17.4** (patch: dependency-only, no public API change — no kafka-protocol types appear in `kafka-backup-core`'s public API)
- README note telling library consumers to replicate the patch removed
- CHANGELOG entry added

**Publishing `kafka-backup-core` to crates.io resumes automatically with this release** — the release workflow's patch-detection step (added in #151) now finds no git patch and runs `cargo publish` again. The two failing "Dependabot Updates" runs were also caused by the git patch and should recover.

The 0.18 breaking change (KIP-534 `delete_horizon` field on `Record`, kafka-protocol-rs#157) was already handled — the pinned rev postdated it, so all `Record` construction sites already set `delete_horizon: false`.

## Validation

Diff between the previously pinned rev (`946ceb77`) and 0.18.0 is exclusively CI/dependency chores plus a macro-internal `error.rs` refactor (dropping `paste`) — no codec changes.

Run locally against the 0.18.0 content and again against the published crates.io release:

- `cargo check --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (the `gssapi` feature doesn't build on macOS locally; CI covers `--all-features`)
- `cargo test` ✅ (~430 unit tests)
- Docker integration suites (CI-identical invocations): `--test integration` ✅ and `--test integration_suite_tests --include-ignored --skip tls --skip sasl_` ✅ — 59 real-broker round-trip tests passed, including the Java-client varlong `timestampDelta` regression fixture from #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
