### PR TITLE
fix(backup): preserve null header values instead of flattening them to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-08-29
+
+### Fixed
+- **Null header values are no longer flattened to empty values on backup**
+  ([#155](https://github.com/osodevops/kafka-backup/issues/155)). Kafka
+  distinguishes a header whose value is null (`-1` length on the wire) from
+  one whose value is empty, and consumers branch on the difference.
+  `kafka/fetch.rs::convert_record` collapsed null into `[]` while turning a
+  fetched record into a `BackupRecord`, so every archive written by 0.x
+  stored such headers as empty (`value_len == 0`) and restored them as
+  empty — even though the binary segment format has always been able to
+  encode null (`value_len == -1`). Null now survives the whole path:
+  fetch → segment → restore → produce.
+- `x-original-offset` / `x-original-timestamp` header decoding on restore
+  treats a null header value as "not present" (falls back to the record's
+  own offset / timestamp) instead of trying to parse it.
+
+### Changed
+- **Breaking (library API):** `manifest::RecordHeader::value` is now
+  `Option<Vec<u8>>` — `None` is a null header value, `Some(vec![])` an empty
+  one. `RecordHeader` also derives `PartialEq` / `Eq`. Archives are
+  unaffected: binary segments already encode null as `-1`, and legacy JSON
+  segments (base64 string values) still deserialize; a null header value
+  serializes to JSON `null`.
+- **Archives written by earlier releases stay lossy for this case:** a
+  header that was null at the source is stored as empty, and nothing in the
+  archive records the difference, so no restore-side option can recover it.
+  Re-run the backup with 0.18.0 or later where the null / empty distinction
+  matters.
+
 ## [0.17.4] - 2026-08-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.4"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -1053,41 +1053,7 @@ impl BackupPartitionContext {
 
             // Convert to binary records and add to writer
             for record in &records {
-                // Start with existing headers
-                let mut headers: Vec<(String, Option<Bytes>)> = record
-                    .headers
-                    .iter()
-                    .map(|h| (h.key.clone(), Some(Bytes::from(h.value.clone()))))
-                    .collect();
-
-                // Phase 1: Add offset mapping headers if configured
-                if self.options.include_offset_headers {
-                    // Store original offset as binary i64 (8 bytes, little-endian)
-                    headers.push((
-                        "x-original-offset".to_string(),
-                        Some(Bytes::from(record.offset.to_le_bytes().to_vec())),
-                    ));
-                    // Store original timestamp as binary i64 (8 bytes, little-endian)
-                    headers.push((
-                        "x-original-timestamp".to_string(),
-                        Some(Bytes::from(record.timestamp.to_le_bytes().to_vec())),
-                    ));
-                    // Store source cluster ID if configured
-                    if let Some(ref cluster_id) = self.options.source_cluster_id {
-                        headers.push((
-                            "x-source-cluster".to_string(),
-                            Some(Bytes::from(cluster_id.as_bytes().to_vec())),
-                        ));
-                    }
-                }
-
-                let binary_record = BinaryRecord {
-                    timestamp: record.timestamp,
-                    offset: record.offset,
-                    key: record.key.as_ref().map(|k| Bytes::from(k.clone())),
-                    value: record.value.as_ref().map(|v| Bytes::from(v.clone())),
-                    headers,
-                };
+                let binary_record = to_binary_record(record, &self.options);
                 segment_writer.add_record(binary_record)?;
 
                 // Check if we should rotate
@@ -1555,10 +1521,142 @@ fn should_create_offset_store(continuous: bool, offset_storage_configured: bool)
     continuous || offset_storage_configured
 }
 
+/// Convert a fetched record into the on-disk segment representation.
+///
+/// Header values are copied as-is: a null header value stays `None` and is
+/// written with a `-1` length by the segment format (issue #155). When
+/// `include_offset_headers` is set, the Phase 1 offset-mapping headers
+/// (`x-original-offset`, `x-original-timestamp`, and `x-source-cluster` if a
+/// `source_cluster_id` is configured) are appended after the record's own
+/// headers, as binary little-endian i64 values.
+fn to_binary_record(record: &BackupRecord, options: &BackupOptions) -> BinaryRecord {
+    let mut headers: Vec<(String, Option<Bytes>)> = record
+        .headers
+        .iter()
+        .map(|h| (h.key.clone(), h.value.clone().map(Bytes::from)))
+        .collect();
+
+    if options.include_offset_headers {
+        headers.push((
+            "x-original-offset".to_string(),
+            Some(Bytes::from(record.offset.to_le_bytes().to_vec())),
+        ));
+        headers.push((
+            "x-original-timestamp".to_string(),
+            Some(Bytes::from(record.timestamp.to_le_bytes().to_vec())),
+        ));
+        if let Some(cluster_id) = &options.source_cluster_id {
+            headers.push((
+                "x-source-cluster".to_string(),
+                Some(Bytes::from(cluster_id.as_bytes().to_vec())),
+            ));
+        }
+    }
+
+    BinaryRecord {
+        timestamp: record.timestamp,
+        offset: record.offset,
+        key: record.key.as_ref().map(|k| Bytes::from(k.clone())),
+        value: record.value.as_ref().map(|v| Bytes::from(v.clone())),
+        headers,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::manifest::{PartitionBackup, TopicBackup};
+    use crate::manifest::{PartitionBackup, RecordHeader, TopicBackup};
+
+    fn record_with_headers(headers: Vec<RecordHeader>) -> BackupRecord {
+        BackupRecord {
+            key: Some(b"k".to_vec()),
+            value: Some(b"v".to_vec()),
+            headers,
+            timestamp: 1_700_000_000_000,
+            offset: 42,
+        }
+    }
+
+    fn header(key: &str, value: Option<&[u8]>) -> RecordHeader {
+        RecordHeader {
+            key: key.to_string(),
+            value: value.map(|v| v.to_vec()),
+        }
+    }
+
+    /// Issue #155: a null header value must reach the segment writer as
+    /// `None` (encoded as length -1), not be flattened into an empty value.
+    #[test]
+    fn to_binary_record_preserves_null_and_empty_header_values() {
+        let record = record_with_headers(vec![
+            header("trace-id", None),
+            header("empty", Some(b"")),
+            header("tenant", Some(b"42")),
+        ]);
+        let options = BackupOptions {
+            include_offset_headers: false,
+            ..BackupOptions::default()
+        };
+
+        let binary = to_binary_record(&record, &options);
+
+        assert_eq!(
+            binary.headers,
+            vec![
+                ("trace-id".to_string(), None),
+                ("empty".to_string(), Some(Bytes::new())),
+                ("tenant".to_string(), Some(Bytes::from_static(b"42"))),
+            ]
+        );
+        assert_eq!(binary.offset, 42);
+        assert_eq!(binary.timestamp, 1_700_000_000_000);
+        assert_eq!(binary.key.as_deref(), Some(&b"k"[..]));
+        assert_eq!(binary.value.as_deref(), Some(&b"v"[..]));
+    }
+
+    #[test]
+    fn to_binary_record_appends_offset_headers_after_user_headers() {
+        let record = record_with_headers(vec![header("trace-id", None)]);
+        let options = BackupOptions {
+            include_offset_headers: true,
+            source_cluster_id: Some("src-eu".to_string()),
+            ..BackupOptions::default()
+        };
+
+        let binary = to_binary_record(&record, &options);
+
+        let keys: Vec<&str> = binary.headers.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            keys,
+            [
+                "trace-id",
+                "x-original-offset",
+                "x-original-timestamp",
+                "x-source-cluster"
+            ]
+        );
+        assert_eq!(binary.headers[0].1, None);
+        assert_eq!(
+            binary.headers[1].1.as_deref(),
+            Some(&42i64.to_le_bytes()[..])
+        );
+        assert_eq!(
+            binary.headers[2].1.as_deref(),
+            Some(&1_700_000_000_000i64.to_le_bytes()[..])
+        );
+        assert_eq!(binary.headers[3].1.as_deref(), Some(&b"src-eu"[..]));
+    }
+
+    #[test]
+    fn to_binary_record_without_offset_headers_adds_nothing() {
+        let record = record_with_headers(vec![]);
+        let options = BackupOptions {
+            include_offset_headers: false,
+            source_cluster_id: Some("ignored".to_string()),
+            ..BackupOptions::default()
+        };
+        assert!(to_binary_record(&record, &options).headers.is_empty());
+    }
 
     #[test]
     fn fetch_max_bytes_defaults_to_capped_segment_size() {

--- a/crates/kafka-backup-core/src/kafka/fetch.rs
+++ b/crates/kafka-backup-core/src/kafka/fetch.rs
@@ -203,7 +203,9 @@ fn convert_record(record: &Record) -> BackupRecord {
         .iter()
         .map(|(key, value)| crate::manifest::RecordHeader {
             key: key.to_string(),
-            value: value.as_ref().map(|v| v.to_vec()).unwrap_or_default(),
+            // Preserve Kafka's null-vs-empty distinction (issue #155): a
+            // null header value must not be flattened into an empty one.
+            value: value.as_ref().map(|v| v.to_vec()),
         })
         .collect();
 
@@ -436,6 +438,50 @@ mod tests {
 
     fn parse(data: Vec<u8>, fetch_offset: i64) -> (Vec<BackupRecord>, i64) {
         decode_fetch_data(&Bytes::from(data), fetch_offset).expect("decode failed")
+    }
+
+    /// Issue #155: a null header value (`-1` length on the wire) must be
+    /// decoded as `None`, distinct from an empty value (`Some(vec![])`).
+    #[test]
+    fn null_and_empty_header_values_are_preserved_from_the_wire() {
+        let mut record = make_record(7);
+        record
+            .headers
+            .insert(StrBytes::from_static_str("trace-id"), None);
+        record
+            .headers
+            .insert(StrBytes::from_static_str("empty"), Some(Bytes::new()));
+        record.headers.insert(
+            StrBytes::from_static_str("tenant"),
+            Some(Bytes::from_static(b"42")),
+        );
+
+        let mut buf = BytesMut::new();
+        RecordBatchEncoder::encode(
+            &mut buf,
+            std::iter::once(&record),
+            &RecordEncodeOptions {
+                version: 2,
+                compression: Compression::None,
+            },
+        )
+        .expect("encode failed");
+
+        let (records, _) = parse(buf.to_vec(), 7);
+        assert_eq!(records.len(), 1);
+        let headers: Vec<(&str, Option<&[u8]>)> = records[0]
+            .headers
+            .iter()
+            .map(|h| (h.key.as_str(), h.value.as_deref()))
+            .collect();
+        assert_eq!(
+            headers,
+            vec![
+                ("trace-id", None),
+                ("empty", Some(&[][..])),
+                ("tenant", Some(&b"42"[..])),
+            ]
+        );
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/kafka/produce.rs
+++ b/crates/kafka-backup-core/src/kafka/produce.rs
@@ -84,7 +84,9 @@ fn build_kafka_records(records: Vec<BackupRecord>) -> Vec<Record> {
             let headers: IndexMap<StrBytes, Option<Bytes>> = r
                 .headers
                 .into_iter()
-                .map(|h| (StrBytes::from_string(h.key), Some(Bytes::from(h.value))))
+                // `None` is a null header value and must be produced as
+                // such (issue #155) — it is not the same as an empty value.
+                .map(|h| (StrBytes::from_string(h.key), h.value.map(Bytes::from)))
                 .collect();
 
             Record {
@@ -246,6 +248,7 @@ fn parse_produce_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::manifest::RecordHeader;
 
     fn make_record(timestamp: i64) -> BackupRecord {
         BackupRecord {
@@ -255,6 +258,44 @@ mod tests {
             timestamp,
             offset: 0,
         }
+    }
+
+    /// Issue #155: a null header value must be produced as null, an empty
+    /// one as empty — they are different values to a Kafka consumer.
+    #[test]
+    fn build_kafka_records_preserves_null_and_empty_header_values() {
+        let mut record = make_record(1);
+        record.headers = vec![
+            RecordHeader {
+                key: "trace-id".to_string(),
+                value: None,
+            },
+            RecordHeader {
+                key: "empty".to_string(),
+                value: Some(vec![]),
+            },
+            RecordHeader {
+                key: "tenant".to_string(),
+                value: Some(b"42".to_vec()),
+            },
+        ];
+
+        let records = build_kafka_records(vec![record]);
+        let headers = &records[0].headers;
+
+        assert_eq!(headers.len(), 3);
+        assert_eq!(
+            headers.get(&StrBytes::from_static_str("trace-id")),
+            Some(&None)
+        );
+        assert_eq!(
+            headers.get(&StrBytes::from_static_str("empty")),
+            Some(&Some(Bytes::new()))
+        );
+        assert_eq!(
+            headers.get(&StrBytes::from_static_str("tenant")),
+            Some(&Some(Bytes::from_static(b"42")))
+        );
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -306,14 +306,20 @@ pub struct BackupRecord {
 }
 
 /// Record header
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Kafka distinguishes a header whose value is **null** from one whose value
+/// is **empty**; both are legal and consumers can (and do) branch on the
+/// difference. `value` is therefore `Option<Vec<u8>>`: `None` is a null value
+/// (`-1` length on the wire and in the binary segment format),
+/// `Some(vec![])` is an empty value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordHeader {
     /// Header key
     pub key: String,
 
-    /// Header value
-    #[serde(with = "bytes_base64")]
-    pub value: Vec<u8>,
+    /// Header value (`None` = null, `Some(vec![])` = empty)
+    #[serde(with = "optional_bytes", default)]
+    pub value: Option<Vec<u8>>,
 }
 
 /// Serde helper for optional byte arrays (base64 encoded)
@@ -343,27 +349,6 @@ mod optional_bytes {
                 .map_err(serde::de::Error::custom),
             None => Ok(None),
         }
-    }
-}
-
-/// Serde helper for byte arrays (base64 encoded)
-mod bytes_base64 {
-    use base64::{engine::general_purpose::STANDARD, Engine};
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&STANDARD.encode(value))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        STANDARD.decode(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -1011,6 +996,42 @@ pub struct DryRunPartitionReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #155: a null header value must serialize as JSON `null` and
+    /// deserialize back to `None` — never collapse into an empty value.
+    #[test]
+    fn record_header_null_value_roundtrips_as_json_null() {
+        let header = RecordHeader {
+            key: "trace-id".to_string(),
+            value: None,
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"key":"trace-id","value":null}"#);
+        let back: RecordHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, header);
+    }
+
+    #[test]
+    fn record_header_empty_value_stays_distinct_from_null() {
+        let header = RecordHeader {
+            key: "empty".to_string(),
+            value: Some(Vec::new()),
+        };
+        let json = serde_json::to_string(&header).unwrap();
+        assert_eq!(json, r#"{"key":"empty","value":""}"#);
+        let back: RecordHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.value, Some(Vec::new()));
+    }
+
+    #[test]
+    fn record_header_legacy_json_segments_still_deserialize() {
+        // Legacy JSON segments (pre-binary format) always wrote a base64 string.
+        let back: RecordHeader = serde_json::from_str(r#"{"key":"k","value":"YWJj"}"#).unwrap();
+        assert_eq!(back.value.as_deref(), Some(&b"abc"[..]));
+        // A header written without the field decodes as null.
+        let back: RecordHeader = serde_json::from_str(r#"{"key":"k"}"#).unwrap();
+        assert_eq!(back.value, None);
+    }
 
     #[test]
     fn test_offset_mapping_basic() {

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -1531,52 +1531,40 @@ impl RestorePartitionContext {
         super::helpers::filter_records_by_time(records, &self.options)
     }
 
-    /// Extract source offset from record headers or fall back to record.offset
-    /// Headers can be either binary (preferred) or string encoded
+    /// Extract source offset from record headers or fall back to record.offset.
     fn extract_source_offset(&self, record: &BackupRecord) -> i64 {
-        for header in &record.headers {
-            if header.key == "x-original-offset" {
-                // Try binary format first (8 bytes, little-endian i64)
-                if header.value.len() == 8 {
-                    if let Ok(bytes) = header.value[..8].try_into() {
-                        return i64::from_le_bytes(bytes);
-                    }
-                }
-                // Fall back to string format for backwards compatibility
-                if let Ok(s) = std::str::from_utf8(&header.value) {
-                    if let Ok(offset) = s.parse::<i64>() {
-                        return offset;
-                    }
-                }
-            }
-        }
-        // No header found, use record offset
-        record.offset
+        record
+            .headers
+            .iter()
+            .filter(|h| h.key == "x-original-offset")
+            .find_map(|h| decode_i64_header(h.value.as_deref()))
+            .unwrap_or(record.offset)
     }
 
-    /// Extract source timestamp from record headers or fall back to record.timestamp
-    /// Headers can be either binary (preferred) or string encoded
+    /// Extract source timestamp from record headers or fall back to record.timestamp.
     #[allow(dead_code)]
     fn extract_source_timestamp(&self, record: &BackupRecord) -> i64 {
-        for header in &record.headers {
-            if header.key == "x-original-timestamp" {
-                // Try binary format first (8 bytes, little-endian i64)
-                if header.value.len() == 8 {
-                    if let Ok(bytes) = header.value[..8].try_into() {
-                        return i64::from_le_bytes(bytes);
-                    }
-                }
-                // Fall back to string format for backwards compatibility
-                if let Ok(s) = std::str::from_utf8(&header.value) {
-                    if let Ok(ts) = s.parse::<i64>() {
-                        return ts;
-                    }
-                }
-            }
-        }
-        // No header found, use record timestamp
-        record.timestamp
+        record
+            .headers
+            .iter()
+            .filter(|h| h.key == "x-original-timestamp")
+            .find_map(|h| decode_i64_header(h.value.as_deref()))
+            .unwrap_or(record.timestamp)
     }
+}
+
+/// Decode an `x-original-*` header value.
+///
+/// The binary little-endian i64 the backup engine writes (8 bytes) is tried
+/// first; a decimal string is accepted for backwards compatibility. A null
+/// header value (`None`) decodes to `None` so callers fall back to the
+/// record's own offset/timestamp instead of misreading it as 0.
+fn decode_i64_header(value: Option<&[u8]>) -> Option<i64> {
+    let value = value?;
+    if let Ok(bytes) = <[u8; 8]>::try_from(value) {
+        return Some(i64::from_le_bytes(bytes));
+    }
+    std::str::from_utf8(value).ok()?.parse().ok()
 }
 
 /// Pattern matching for topic names.
@@ -1656,6 +1644,20 @@ mod tests {
     use super::*;
     use crate::restore::offset_reset::{OffsetResetExecutor, OffsetResetStrategy};
     use std::collections::HashMap;
+
+    #[test]
+    fn decode_i64_header_handles_binary_string_and_null() {
+        assert_eq!(
+            decode_i64_header(Some(&12345i64.to_le_bytes())),
+            Some(12345)
+        );
+        assert_eq!(decode_i64_header(Some(b"12345")), Some(12345));
+        assert_eq!(decode_i64_header(Some(b"-7")), Some(-7));
+        assert_eq!(decode_i64_header(Some(b"")), None);
+        assert_eq!(decode_i64_header(Some(b"not-a-number")), None);
+        // Issue #155: a null header value is not 0 and must not panic.
+        assert_eq!(decode_i64_header(None), None);
+    }
 
     #[test]
     fn test_glob_match() {

--- a/crates/kafka-backup-core/src/restore/helpers.rs
+++ b/crates/kafka-backup-core/src/restore/helpers.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 use crate::compression::{decompress, detect_from_extension};
 use crate::config::{OffsetStrategy, RestoreOptions};
 use crate::manifest::{BackupRecord, RecordHeader, RestoreCheckpoint, SegmentMetadata};
-use crate::segment::format::MAGIC_BYTES;
+use crate::segment::format::{BinaryRecord, MAGIC_BYTES};
 use crate::segment::SegmentReader;
 use crate::storage::StorageBackend;
 use crate::Result;
@@ -26,20 +26,7 @@ pub async fn read_segment(
         let binary_records = reader.read_all()?;
         Ok(binary_records
             .into_iter()
-            .map(|br| BackupRecord {
-                key: br.key.map(|b| b.to_vec()),
-                value: br.value.map(|b| b.to_vec()),
-                headers: br
-                    .headers
-                    .into_iter()
-                    .map(|(k, v)| RecordHeader {
-                        key: k,
-                        value: v.map(|b| b.to_vec()).unwrap_or_default(),
-                    })
-                    .collect(),
-                timestamp: br.timestamp,
-                offset: br.offset,
-            })
+            .map(binary_to_backup_record)
             .collect())
     } else {
         // Legacy JSON format — detect compression from extension
@@ -48,6 +35,28 @@ pub async fn read_segment(
         let decompressed = decompress(&data, algo)?;
         let records: Vec<BackupRecord> = serde_json::from_slice(&decompressed)?;
         Ok(records)
+    }
+}
+
+/// Convert a binary segment record into the in-memory [`BackupRecord`].
+///
+/// Null header values (`-1` length in the segment) stay `None`: they are a
+/// different value from an empty header and must be restored as such
+/// (issue #155).
+pub(crate) fn binary_to_backup_record(br: BinaryRecord) -> BackupRecord {
+    BackupRecord {
+        key: br.key.map(|b| b.to_vec()),
+        value: br.value.map(|b| b.to_vec()),
+        headers: br
+            .headers
+            .into_iter()
+            .map(|(key, value)| RecordHeader {
+                key,
+                value: value.map(|b| b.to_vec()),
+            })
+            .collect(),
+        timestamp: br.timestamp,
+        offset: br.offset,
     }
 }
 
@@ -89,15 +98,15 @@ pub fn inject_offset_headers(
             .map(|mut r| {
                 r.headers.push(RecordHeader {
                     key: "x-original-offset".to_string(),
-                    value: r.offset.to_le_bytes().to_vec(),
+                    value: Some(r.offset.to_le_bytes().to_vec()),
                 });
                 r.headers.push(RecordHeader {
                     key: "x-original-timestamp".to_string(),
-                    value: r.timestamp.to_le_bytes().to_vec(),
+                    value: Some(r.timestamp.to_le_bytes().to_vec()),
                 });
                 r.headers.push(RecordHeader {
                     key: "x-source-partition".to_string(),
-                    value: source_partition.to_le_bytes().to_vec(),
+                    value: Some(source_partition.to_le_bytes().to_vec()),
                 });
                 r
             })
@@ -112,5 +121,157 @@ pub async fn mark_segment_completed(checkpoint: &Mutex<Option<RestoreCheckpoint>
     let mut cp = checkpoint.lock().await;
     if let Some(c) = cp.as_mut() {
         c.mark_segment_completed(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::PerformanceMetrics;
+    use crate::segment::{SegmentWriter, SegmentWriterConfig};
+    use crate::storage::MemoryBackend;
+    use bytes::Bytes;
+    use std::sync::Arc;
+
+    fn header(key: &str, value: Option<&[u8]>) -> RecordHeader {
+        RecordHeader {
+            key: key.to_string(),
+            value: value.map(|v| v.to_vec()),
+        }
+    }
+
+    #[test]
+    fn binary_to_backup_record_preserves_null_and_empty_header_values() {
+        let br = BinaryRecord {
+            timestamp: 1,
+            offset: 9,
+            key: None,
+            value: Some(Bytes::from_static(b"v")),
+            headers: vec![
+                ("trace-id".to_string(), None),
+                ("empty".to_string(), Some(Bytes::new())),
+                ("tenant".to_string(), Some(Bytes::from_static(b"42"))),
+            ],
+        };
+
+        let record = binary_to_backup_record(br);
+
+        assert_eq!(
+            record.headers,
+            vec![
+                header("trace-id", None),
+                header("empty", Some(b"")),
+                header("tenant", Some(b"42")),
+            ]
+        );
+        assert_eq!(record.key, None);
+        assert_eq!(record.value.as_deref(), Some(&b"v"[..]));
+        assert_eq!((record.timestamp, record.offset), (1, 9));
+    }
+
+    /// Issue #155 end-to-end through the segment layer: a record with a null
+    /// header value written by the segment writer must come back from
+    /// `read_segment` with that header still null (and an empty one still
+    /// empty) — for every compression codec.
+    #[tokio::test]
+    async fn read_segment_roundtrips_null_and_empty_header_values() {
+        for compression in [
+            crate::config::CompressionType::None,
+            crate::config::CompressionType::Zstd,
+            crate::config::CompressionType::Lz4,
+        ] {
+            let storage = Arc::new(MemoryBackend::new());
+            let mut writer = SegmentWriter::new(
+                SegmentWriterConfig {
+                    compression,
+                    ..SegmentWriterConfig::default()
+                },
+                storage.clone(),
+                Arc::new(PerformanceMetrics::new()),
+            );
+            writer
+                .add_record(BinaryRecord {
+                    timestamp: 1_700_000_000_000,
+                    offset: 7,
+                    key: Some(Bytes::from_static(b"k")),
+                    value: None,
+                    headers: vec![
+                        ("trace-id".to_string(), None),
+                        ("empty".to_string(), Some(Bytes::new())),
+                        ("tenant".to_string(), Some(Bytes::from_static(b"42"))),
+                    ],
+                })
+                .unwrap();
+            let segment = writer
+                .flush("topics/t/partition=0/segment-0.bin")
+                .await
+                .unwrap()
+                .expect("one record was buffered");
+
+            let records = read_segment(storage.as_ref(), &segment).await.unwrap();
+
+            assert_eq!(records.len(), 1, "{compression:?}");
+            assert_eq!(
+                records[0].headers,
+                vec![
+                    header("trace-id", None),
+                    header("empty", Some(b"")),
+                    header("tenant", Some(b"42")),
+                ],
+                "{compression:?}"
+            );
+            assert_eq!(records[0].key.as_deref(), Some(&b"k"[..]));
+            assert_eq!(records[0].value, None);
+            assert_eq!(records[0].offset, 7);
+        }
+    }
+
+    #[test]
+    fn inject_offset_headers_keeps_existing_null_header_and_appends_three() {
+        let options = RestoreOptions {
+            include_original_offset_header: true,
+            ..RestoreOptions::default()
+        };
+        let record = BackupRecord {
+            key: None,
+            value: None,
+            headers: vec![header("trace-id", None)],
+            timestamp: 1_700_000_000_000,
+            offset: 5,
+        };
+
+        let out = inject_offset_headers(vec![record], 3, &options);
+
+        let headers = &out[0].headers;
+        let keys: Vec<&str> = headers.iter().map(|h| h.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            [
+                "trace-id",
+                "x-original-offset",
+                "x-original-timestamp",
+                "x-source-partition"
+            ]
+        );
+        assert_eq!(headers[0].value, None);
+        assert_eq!(headers[1].value.as_deref(), Some(&5i64.to_le_bytes()[..]));
+        assert_eq!(
+            headers[2].value.as_deref(),
+            Some(&1_700_000_000_000i64.to_le_bytes()[..])
+        );
+        assert_eq!(headers[3].value.as_deref(), Some(&3i32.to_le_bytes()[..]));
+    }
+
+    #[test]
+    fn inject_offset_headers_is_a_no_op_when_not_configured() {
+        let record = BackupRecord {
+            key: None,
+            value: None,
+            headers: vec![header("trace-id", None)],
+            timestamp: 0,
+            offset: 0,
+        };
+        let out = inject_offset_headers(vec![record], 0, &RestoreOptions::default());
+        assert_eq!(out[0].headers, vec![header("trace-id", None)]);
     }
 }

--- a/crates/kafka-backup-core/src/segment/format.rs
+++ b/crates/kafka-backup-core/src/segment/format.rs
@@ -383,6 +383,7 @@ mod tests {
             headers: vec![
                 ("header1".to_string(), Some(Bytes::from("value1"))),
                 ("header2".to_string(), None),
+                ("header3".to_string(), Some(Bytes::new())),
             ],
         };
 
@@ -395,7 +396,9 @@ mod tests {
         assert_eq!(parsed.offset, record.offset);
         assert_eq!(parsed.key, record.key);
         assert_eq!(parsed.value, record.value);
-        assert_eq!(parsed.headers.len(), record.headers.len());
+        // Null (`None`) and empty (`Some("")`) header values are distinct and
+        // must both survive the round trip (issue #155).
+        assert_eq!(parsed.headers, record.headers);
     }
 
     #[test]

--- a/crates/kafka-backup-core/tests/integration_suite/issue_155_null_header_value.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_155_null_header_value.rs
@@ -1,0 +1,327 @@
+//! Issue #155 — a header with a **null** value must be backed up and restored
+//! as null, not as an empty value.
+//!
+//! Kafka distinguishes the two (`-1` vs `0` length on the wire) and so does
+//! the binary segment format; the loss happened in memory, in
+//! `fetch.rs::convert_record`, before the record ever reached the segment
+//! writer — so every archive written by 0.17.x carried `value_len == 0` for
+//! every null header, and no restore-side change could recover that.
+//!
+//! This test drives the whole pipeline against a real broker: produce records
+//! carrying null, empty and populated header values → `BackupEngine` →
+//! `RestoreEngine` into a mapped topic → fetch from the restored topic and
+//! compare the header lists byte-for-byte with the source.
+//!
+//! Requires Docker.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, RestoreOptions, SecurityConfig,
+    TopicSelection,
+};
+use kafka_backup_core::kafka::{KafkaClient, TopicToCreate};
+use kafka_backup_core::manifest::{BackupRecord, RecordHeader};
+use kafka_backup_core::restore::RestoreEngine;
+use kafka_backup_core::storage::StorageBackendConfig;
+
+use super::common::{create_temp_storage, KafkaTestCluster};
+
+const SOURCE_TOPIC: &str = "issue-155-src";
+const TARGET_TOPIC: &str = "issue-155-restored";
+const BACKUP_ID: &str = "issue-155-backup";
+const RECORDS: usize = 40;
+
+fn header(key: &str, value: Option<&[u8]>) -> RecordHeader {
+    RecordHeader {
+        key: key.to_string(),
+        value: value.map(|v| v.to_vec()),
+    }
+}
+
+/// Record `i` carries a null `trace-id` for even `i`, a populated one for odd
+/// `i`, always an *empty* (not null) `empty` header, and a null key / value
+/// every 7th / 11th record so the existing null handling is exercised too.
+fn source_records() -> Vec<BackupRecord> {
+    (0..RECORDS)
+        .map(|i| {
+            let trace = format!("tid-{i}");
+            BackupRecord {
+                key: (i % 7 != 0).then(|| format!("k-{i}").into_bytes()),
+                value: (i % 11 != 0).then(|| format!("v-{i}").into_bytes()),
+                headers: vec![
+                    header(
+                        "trace-id",
+                        if i % 2 == 0 {
+                            None
+                        } else {
+                            Some(trace.as_bytes())
+                        },
+                    ),
+                    header("empty", Some(b"")),
+                    header("tenant", Some(b"42")),
+                ],
+                timestamp: 1_700_000_000_000 + i as i64,
+                offset: i as i64,
+            }
+        })
+        .collect()
+}
+
+fn backup_config(bs: &str, storage: PathBuf, include_offset_headers: bool) -> Config {
+    Config {
+        mode: Mode::Backup,
+        backup_id: BACKUP_ID.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![SOURCE_TOPIC.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: Some(BackupOptions {
+            segment_max_bytes: 1024 * 1024,
+            segment_max_interval_ms: 5000,
+            compression: CompressionType::Zstd,
+            stop_at_current_offsets: true,
+            continuous: false,
+            include_offset_headers,
+            ..Default::default()
+        }),
+        restore: None,
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+fn restore_config(bs: &str, storage: PathBuf) -> Config {
+    let mut topic_mapping = HashMap::new();
+    topic_mapping.insert(SOURCE_TOPIC.to_string(), TARGET_TOPIC.to_string());
+    Config {
+        mode: Mode::Restore,
+        backup_id: BACKUP_ID.to_string(),
+        source: None,
+        target: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection::default(),
+            connection: Default::default(),
+        }),
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: None,
+        restore: Some(RestoreOptions {
+            topic_mapping,
+            create_topics: true,
+            ..RestoreOptions::default()
+        }),
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+async fn create_single_partition_topic(client: &KafkaClient, name: &str) {
+    let results = client
+        .create_topics(
+            vec![TopicToCreate {
+                name: name.to_string(),
+                num_partitions: 1,
+                replication_factor: 1,
+            }],
+            30_000,
+        )
+        .await
+        .expect("create topic");
+    assert!(
+        results.iter().all(|r| r.is_success_or_exists()),
+        "create {name}: {results:?}"
+    );
+    tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+/// Fetch every record of partition 0 in offset order.
+async fn fetch_all(client: &KafkaClient, topic: &str, expected: usize) -> Vec<BackupRecord> {
+    let mut out = Vec::new();
+    let mut offset = 0;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while out.len() < expected && tokio::time::Instant::now() < deadline {
+        let resp = client
+            .fetch(topic, 0, offset, 8 * 1024 * 1024)
+            .await
+            .expect("fetch");
+        if resp.records.is_empty() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        }
+        offset = resp.next_offset;
+        out.extend(resp.records);
+    }
+    out
+}
+
+fn header_view(r: &BackupRecord) -> Vec<(&str, Option<&[u8]>)> {
+    r.headers
+        .iter()
+        .map(|h| (h.key.as_str(), h.value.as_deref()))
+        .collect()
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_null_header_values_survive_backup_and_restore() {
+    let cluster = KafkaTestCluster::start().await.expect("start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka ready");
+    let bs = cluster.bootstrap_servers.clone();
+    let client = cluster.create_client();
+    client.connect().await.expect("connect");
+
+    // Source topic with the header mix. Produce through our own client — the
+    // produce path is one of the sites under test.
+    create_single_partition_topic(&client, SOURCE_TOPIC).await;
+    let expected = source_records();
+    client
+        .produce(SOURCE_TOPIC, 0, expected.clone(), -1, 30_000)
+        .await
+        .expect("produce");
+
+    // Sanity: the broker hands the null back as null *before* any backup ran.
+    let on_source = fetch_all(&client, SOURCE_TOPIC, RECORDS).await;
+    assert_eq!(on_source.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&on_source) {
+        assert_eq!(
+            header_view(want),
+            header_view(got),
+            "source offset {}",
+            got.offset
+        );
+    }
+    assert_eq!(
+        on_source
+            .iter()
+            .filter(|r| r.headers[0].value.is_none())
+            .count(),
+        RECORDS / 2,
+        "half the records carry a null trace-id on the source"
+    );
+
+    // Backup without Phase 1 headers so the restored header list can be
+    // compared with the source verbatim.
+    let storage = create_temp_storage();
+    let engine = BackupEngine::new(backup_config(&bs, storage.path().to_path_buf(), false))
+        .await
+        .expect("backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup");
+
+    // Restore into a fresh topic.
+    let report = tokio::time::timeout(
+        Duration::from_secs(60),
+        RestoreEngine::new(restore_config(&bs, storage.path().to_path_buf()))
+            .expect("restore engine")
+            .run(),
+    )
+    .await
+    .expect("restore timed out")
+    .expect("restore");
+    assert_eq!(report.records_restored as usize, RECORDS);
+
+    // Every restored record must carry exactly the source header list —
+    // null stays null, empty stays empty, order preserved.
+    let restored = fetch_all(&client, TARGET_TOPIC, RECORDS).await;
+    assert_eq!(restored.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&restored) {
+        assert_eq!(want.key, got.key, "key at offset {}", got.offset);
+        assert_eq!(want.value, got.value, "value at offset {}", got.offset);
+        assert_eq!(
+            header_view(want),
+            header_view(got),
+            "headers at restored offset {}",
+            got.offset
+        );
+    }
+    assert_eq!(
+        restored
+            .iter()
+            .filter(|r| r.headers[0].value.is_none())
+            .count(),
+        RECORDS / 2,
+        "null trace-id headers must not be restored as empty"
+    );
+    assert!(
+        restored
+            .iter()
+            .all(|r| r.headers[1].value.as_deref() == Some(&[][..])),
+        "empty header values must stay empty (not become null)"
+    );
+}
+
+/// With Phase 1 headers on, the backup appends its own headers *after* the
+/// record's headers; the user's null header must still be null.
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_null_header_values_survive_with_offset_headers_enabled() {
+    let cluster = KafkaTestCluster::start().await.expect("start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka ready");
+    let bs = cluster.bootstrap_servers.clone();
+    let client = cluster.create_client();
+    client.connect().await.expect("connect");
+
+    create_single_partition_topic(&client, SOURCE_TOPIC).await;
+    let expected = source_records();
+    client
+        .produce(SOURCE_TOPIC, 0, expected.clone(), -1, 30_000)
+        .await
+        .expect("produce");
+
+    let storage = create_temp_storage();
+    let engine = BackupEngine::new(backup_config(&bs, storage.path().to_path_buf(), true))
+        .await
+        .expect("backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup");
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        RestoreEngine::new(restore_config(&bs, storage.path().to_path_buf()))
+            .expect("restore engine")
+            .run(),
+    )
+    .await
+    .expect("restore timed out")
+    .expect("restore");
+
+    let restored = fetch_all(&client, TARGET_TOPIC, RECORDS).await;
+    assert_eq!(restored.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&restored) {
+        let got_headers = header_view(got);
+        assert_eq!(
+            &got_headers[..3],
+            &header_view(want)[..],
+            "user headers first, verbatim (offset {})",
+            got.offset
+        );
+        let extra: Vec<&str> = got_headers[3..].iter().map(|(k, _)| *k).collect();
+        assert_eq!(extra, ["x-original-offset", "x-original-timestamp"]);
+        assert_eq!(
+            got_headers[3].1,
+            Some(&want.offset.to_le_bytes()[..]),
+            "x-original-offset is the source offset (offset {})",
+            got.offset
+        );
+    }
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -12,11 +12,13 @@
 //! - Issue #144: OFFSET_OUT_OF_RANGE recovery and data-gap recording
 //! - Issue #146: connection-error classification and reconnect (no Docker)
 //! - Issue #148: consumer group offsets applied in Phase 3 after restore
+//! - Issue #155: null header values survive backup and restore
 
 pub mod common;
 pub mod issue_144_offset_out_of_range;
 pub mod issue_146_connection_errors;
 pub mod issue_148_offset_reset_after_restore;
+pub mod issue_155_null_header_value;
 pub mod issue_56_missing_topic;
 pub mod issue_67_fixes;
 pub mod offset_semantics;

--- a/crates/kafka-backup-core/tests/produce_debug.rs
+++ b/crates/kafka-backup-core/tests/produce_debug.rs
@@ -374,7 +374,7 @@ async fn test_produce_from_backup_segment() {
                 .into_iter()
                 .map(|(k, v)| RecordHeader {
                     key: k,
-                    value: v.map(|b| b.to_vec()).unwrap_or_default(),
+                    value: v.map(|b| b.to_vec()),
                 })
                 .collect(),
             timestamp: br.timestamp,

--- a/crates/kafka-backup-core/tests/unit_suite/backup.rs
+++ b/crates/kafka-backup-core/tests/unit_suite/backup.rs
@@ -103,11 +103,11 @@ fn encode_record_preserves_headers() {
     let headers = vec![
         RecordHeader {
             key: "x-correlation-id".to_string(),
-            value: b"abc123".to_vec(),
+            value: Some(b"abc123".to_vec()),
         },
         RecordHeader {
             key: "x-source".to_string(),
-            value: b"service-a".to_vec(),
+            value: Some(b"service-a".to_vec()),
         },
     ];
 
@@ -131,12 +131,15 @@ fn encode_record_with_large_headers() {
     let large_header_value = vec![0u8; 1024 * 100]; // 100KB header
     let headers = vec![RecordHeader {
         key: "big-header".to_string(),
-        value: large_header_value.clone(),
+        value: Some(large_header_value.clone()),
     }];
 
     let record = create_test_record_with_headers(headers);
 
-    assert_eq!(record.headers[0].value.len(), large_header_value.len());
+    assert_eq!(
+        record.headers[0].value.as_ref().map(Vec::len),
+        Some(large_header_value.len())
+    );
 }
 
 // ============================================================================
@@ -327,11 +330,31 @@ fn record_with_binary_key() {
 fn record_with_empty_header_value() {
     let headers = vec![RecordHeader {
         key: "empty-value".to_string(),
-        value: vec![],
+        value: Some(vec![]),
     }];
 
     let record = create_test_record_with_headers(headers);
-    assert!(record.headers[0].value.is_empty());
+    assert_eq!(record.headers[0].value, Some(vec![]));
+}
+
+/// Issue #155: Kafka distinguishes a null header value from an empty one.
+#[test]
+fn record_with_null_header_value_is_distinct_from_empty() {
+    let headers = vec![
+        RecordHeader {
+            key: "null-value".to_string(),
+            value: None,
+        },
+        RecordHeader {
+            key: "empty-value".to_string(),
+            value: Some(vec![]),
+        },
+    ];
+
+    let record = create_test_record_with_headers(headers);
+    assert_eq!(record.headers[0].value, None);
+    assert_eq!(record.headers[1].value, Some(vec![]));
+    assert_ne!(record.headers[0].value, record.headers[1].value);
 }
 
 #[test]
@@ -340,11 +363,11 @@ fn record_with_duplicate_header_keys() {
     let headers = vec![
         RecordHeader {
             key: "x-tag".to_string(),
-            value: b"tag1".to_vec(),
+            value: Some(b"tag1".to_vec()),
         },
         RecordHeader {
             key: "x-tag".to_string(),
-            value: b"tag2".to_vec(),
+            value: Some(b"tag2".to_vec()),
         },
     ];
 

--- a/crates/kafka-backup-core/tests/unit_suite/restore.rs
+++ b/crates/kafka-backup-core/tests/unit_suite/restore.rs
@@ -237,7 +237,7 @@ fn offset_mapping_header_application() {
     // Add original offset header (as restore engine does)
     record.headers.push(RecordHeader {
         key: "x-original-offset".to_string(),
-        value: record.offset.to_string().into_bytes(),
+        value: Some(record.offset.to_string().into_bytes()),
     });
 
     assert!(record.headers.iter().any(|h| h.key == "x-original-offset"));
@@ -246,7 +246,7 @@ fn offset_mapping_header_application() {
         .iter()
         .find(|h| h.key == "x-original-offset")
         .unwrap();
-    assert_eq!(offset_header.value, b"12345".to_vec());
+    assert_eq!(offset_header.value.as_deref(), Some(&b"12345"[..]));
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn offset_mapping_preserves_existing_headers() {
         value: Some(b"value".to_vec()),
         headers: vec![RecordHeader {
             key: "existing-header".to_string(),
-            value: b"existing-value".to_vec(),
+            value: Some(b"existing-value".to_vec()),
         }],
         timestamp: 1672531200000,
         offset: 100,
@@ -265,7 +265,7 @@ fn offset_mapping_preserves_existing_headers() {
     // Add offset header
     record.headers.push(RecordHeader {
         key: "x-original-offset".to_string(),
-        value: b"100".to_vec(),
+        value: Some(b"100".to_vec()),
     });
 
     assert_eq!(record.headers.len(), 2);

--- a/docs/restore_guide.md
+++ b/docs/restore_guide.md
@@ -43,6 +43,34 @@ The Kafka Backup Restore Engine enables recovery of backed-up topics with:
 | Checkpointing | Resume after failures without re-processing |
 | Pattern Matching | Glob and regex topic filtering |
 
+### Record Fidelity
+
+A restored record carries the source record's key, value, timestamp and
+headers verbatim:
+
+| Field | Preserved | Notes |
+|-------|-----------|-------|
+| Key | ✅ | A null key stays null; an empty key stays empty |
+| Value | ✅ | A null value (tombstone) stays null; an empty value stays empty |
+| Timestamp | ✅ | Re-produced as the record's create timestamp |
+| Headers | ✅ | Order preserved. A **null** header value stays null and an **empty** one stays empty — they are different values to a consumer ([#155](https://github.com/osodevops/kafka-backup/issues/155), fixed in 0.18.0) |
+| Offset | ➖ | Offsets are assigned by the target cluster; see [Consumer Offset Management](#consumer-offset-management) for mapping them back |
+
+Things that can make a restored record differ from its source:
+
+- **Injected headers.** `backup.include_offset_headers` (default `true`) adds
+  `x-original-offset` and `x-original-timestamp` to every *archived* record;
+  set it to `false` on the backup for a header-for-header identical archive.
+  On the restore side, `include_original_offset_header: true` or
+  `consumer_group_strategy: header-based` add `x-original-offset`,
+  `x-original-timestamp` and `x-source-partition` to every produced record.
+- **Duplicate header keys** (two headers with the same key on one record) are
+  currently collapsed to the last one at backup time
+  ([#156](https://github.com/osodevops/kafka-backup/issues/156)).
+- **Archives written before 0.18.0** store a null header value as an empty
+  one; nothing in those archives records the difference, so re-run the
+  backup with 0.18.0 or later where it matters.
+
 ---
 
 ## Restore Modes


### PR DESCRIPTION
Closes #155

## What was wrong

Kafka distinguishes a header whose value is **null** (`-1` length on the wire) from one whose value is **empty**, and consumers branch on the difference. As @izmal's follow-up correctly pinned down, the loss was on the **backup** path: `kafka/fetch.rs::convert_record` did

```rust
value: value.as_ref().map(|v| v.to_vec()).unwrap_or_default(),
```

because `manifest::RecordHeader::value` was a plain `Vec<u8>` and could not represent null. The segment format has always been able to encode null (`value_len == -1`) — it was just never handed one.

Reproduced on `main` with an independent confluent-kafka producer (40 records, 20 with a null `trace-id`), parsing the segment bytes directly:

```
archive (before):  trace-id  empty(0)   20      <- no null(-1) at all
restore (before):  20/40 records differ — trace-id None → b''
```

## The fix

- `RecordHeader::value` is now `Option<Vec<u8>>` (`None` = null, `Some(vec![])` = empty). Serde: `null` ↔ `None`; legacy JSON segments (base64 strings) still deserialize.
- Every site that wrapped/flattened the value now carries the `Option` through: `fetch::convert_record`, `backup::engine` (extracted into a testable `to_binary_record`), `restore::helpers::read_segment` (extracted `binary_to_backup_record`) and `inject_offset_headers`, `produce::build_kafka_records`.
- `x-original-offset` / `x-original-timestamp` decoding on restore is a single `decode_i64_header` that treats a null value as absent (falls back to the record's own offset) instead of parsing it.

**Breaking library API change** (public field type) → version bump to **0.18.0**. `RecordHeader` also gains `PartialEq`/`Eq`. The operator does not touch `RecordHeader` directly, so its bump is dependency-only.

## Tests (TDD — each site has a unit test that fails on `main`)

- `fetch.rs`: encode a v2 batch with null / empty / populated headers → decode → `None` / `Some([])` / `Some(b"42")`.
- `backup/engine.rs`: `to_binary_record` preserves null & empty; appends Phase 1 headers after user headers; adds nothing when off.
- `restore/helpers.rs`: `binary_to_backup_record`; **segment write → `read_segment` round trip for `none`/`zstd`/`lz4`**; `inject_offset_headers` keeps an existing null header.
- `produce.rs`: `build_kafka_records` emits `None` for null, `Some(empty)` for empty.
- `manifest.rs`: JSON `null` round trip, empty stays distinct, legacy base64 string still decodes.
- `segment/format.rs`: round-trip assertion strengthened to compare the full header list.
- `restore/engine.rs`: `decode_i64_header` binary / string / null.
- New Docker-backed E2E `issue_155_null_header_value.rs` (2 tests: with and without `include_offset_headers`) — **passing locally** in 15s.

## Verification

Independent of the test suite, with the fixed CLI against a real broker:

```
archive (after):   trace-id  null(-1)   20
                   trace-id  5B/6B      20
restore (after):   IDENTICAL (40/40 identical) — trace-id on restored: {'null': 20, 'bytes': 20}
```

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`: clean.

## Also found while verifying

Duplicate header keys on one record are collapsed at backup time because kafka-protocol models `Record.headers` as an `IndexMap`. Filed separately as #156 rather than widening this change; the restore guide now has a "Record Fidelity" section documenting what is preserved and this limitation.

## Note for existing archives

Archives written by ≤ 0.17.4 store null header values as empty and nothing in them records the difference, so no restore-side option can recover it — re-run the backup on 0.18.0+ where it matters. Called out in the CHANGELOG and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya4R9LzZbzFG79JV4FUGxK
