### PR TITLE
feat(restore): strip_offset_headers, document and log the include_offset_headers default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-08-29
+
+### Added
+- `restore.strip_offset_headers` (default `false`): remove the headers
+  kafka-backup adds at backup time (`x-original-offset`,
+  `x-original-timestamp`, `x-source-cluster`, and `x-source-partition` from
+  chained restores) before producing, so a restore of an archive taken with
+  the default `include_offset_headers: true` is header-for-header identical
+  to the source ([#154](https://github.com/osodevops/kafka-backup/issues/154)).
+  Offset mapping is unaffected — the source offset is stored natively in the
+  segment. Combined with `header-based` / `include_original_offset_header`,
+  the archived headers are stripped first and one fresh set injected.
+- `kafka_backup_core::offset_headers`: the header names kafka-backup adds,
+  in one place, plus `is_offset_header()`.
+- The backup engine logs at startup which headers it will add to every
+  archived record (`include_offset_headers=true (default): ...`) and how to
+  turn that off.
+
+### Changed
+- **Breaking (library API):** `RestoreOptions` gains the public field
+  `strip_offset_headers` (struct-literal construction must set it).
+- `backup.include_offset_headers` keeps its default of **`true`** — the
+  three-phase restore and the operator CRD rely on it — but the default is
+  now documented, and `docs/configuration.md` gained an "Offset-tracking
+  headers" section explaining exactly which side adds which header and
+  the two ways to get a verbatim copy.
+
+### Fixed
+- `docs/configuration.md` backup options table: it listed 9 of 18 options,
+  a `segment_max_age_secs` option that does not exist (it is
+  `segment_max_interval_ms`), `gzip` / `snappy` segment compression that is
+  not offered (`none` / `zstd` / `lz4`), and wrong defaults for
+  `checkpoint_interval_secs` (5, not 60), `segment_max_bytes` (128MB, not
+  100MB), `segment_max_records` (unset, not 100000) and `fetch_max_bytes`
+  (unset → `min(segment_max_bytes, 16MB)`, not 1MB). Restore tables gained
+  `produce_acks`, `produce_timeout_ms`, `rate_limit_bytes_per_sec`,
+  `purge_topics` and `repartitioning`, and the Validation section now says
+  that unknown keys are warned about, not rejected.
+
 ## [0.18.0] - 2026-08-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -15,6 +15,7 @@ use crate::health::HealthCheck;
 use crate::kafka::{PartitionLeaderRouter, TopicMetadata};
 use crate::manifest::{BackupManifest, BackupRecord, OffsetGap, OffsetGapReason, SegmentMetadata};
 use crate::metrics::{ErrorType, PerformanceMetrics, PrometheusMetrics};
+use crate::offset_headers;
 use crate::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
 use crate::segment::format::BinaryRecord;
 use crate::segment::writer::{SegmentWriter, SegmentWriterConfig};
@@ -349,6 +350,7 @@ impl BackupEngine {
             "Backup engine starting with max_concurrent_partitions={}, poll_interval_ms={}",
             backup_opts.max_concurrent_partitions, backup_opts.poll_interval_ms
         );
+        info!("{}", describe_offset_headers(&backup_opts));
 
         // Run backup loop
         loop {
@@ -1521,6 +1523,28 @@ fn should_create_offset_store(continuous: bool, offset_storage_configured: bool)
     continuous || offset_storage_configured
 }
 
+/// One-line startup summary of the headers this backup will add to every
+/// archived record, so the (default-on) behaviour is visible in the logs
+/// (issue #154).
+fn describe_offset_headers(options: &BackupOptions) -> String {
+    if !options.include_offset_headers {
+        return "include_offset_headers=false: records are archived with their original headers only"
+            .to_string();
+    }
+    let cluster = match &options.source_cluster_id {
+        Some(id) => format!(" and {}={id}", offset_headers::X_SOURCE_CLUSTER),
+        None => String::new(),
+    };
+    format!(
+        "include_offset_headers=true (default): every archived record gets {} and {}{cluster} \
+         headers for header-based consumer offset recovery; set backup.include_offset_headers: \
+         false for a header-for-header identical archive, or restore.strip_offset_headers: true \
+         to drop them at restore time",
+        offset_headers::X_ORIGINAL_OFFSET,
+        offset_headers::X_ORIGINAL_TIMESTAMP,
+    )
+}
+
 /// Convert a fetched record into the on-disk segment representation.
 ///
 /// Header values are copied as-is: a null header value stays `None` and is
@@ -1538,16 +1562,16 @@ fn to_binary_record(record: &BackupRecord, options: &BackupOptions) -> BinaryRec
 
     if options.include_offset_headers {
         headers.push((
-            "x-original-offset".to_string(),
+            offset_headers::X_ORIGINAL_OFFSET.to_string(),
             Some(Bytes::from(record.offset.to_le_bytes().to_vec())),
         ));
         headers.push((
-            "x-original-timestamp".to_string(),
+            offset_headers::X_ORIGINAL_TIMESTAMP.to_string(),
             Some(Bytes::from(record.timestamp.to_le_bytes().to_vec())),
         ));
         if let Some(cluster_id) = &options.source_cluster_id {
             headers.push((
-                "x-source-cluster".to_string(),
+                offset_headers::X_SOURCE_CLUSTER.to_string(),
                 Some(Bytes::from(cluster_id.as_bytes().to_vec())),
             ));
         }
@@ -1645,6 +1669,40 @@ mod tests {
             Some(&1_700_000_000_000i64.to_le_bytes()[..])
         );
         assert_eq!(binary.headers[3].1.as_deref(), Some(&b"src-eu"[..]));
+    }
+
+    #[test]
+    fn describe_offset_headers_names_the_headers_and_the_opt_outs() {
+        let on = describe_offset_headers(&BackupOptions::default());
+        assert!(
+            on.starts_with("include_offset_headers=true (default)"),
+            "{on}"
+        );
+        for needle in [
+            "x-original-offset",
+            "x-original-timestamp",
+            "backup.include_offset_headers: false",
+            "restore.strip_offset_headers: true",
+        ] {
+            assert!(on.contains(needle), "missing {needle:?} in {on}");
+        }
+        assert!(!on.contains("x-source-cluster"));
+
+        let with_cluster = describe_offset_headers(&BackupOptions {
+            source_cluster_id: Some("eu-prod".to_string()),
+            ..BackupOptions::default()
+        });
+        assert!(
+            with_cluster.contains("x-source-cluster=eu-prod"),
+            "{with_cluster}"
+        );
+
+        let off = describe_offset_headers(&BackupOptions {
+            include_offset_headers: false,
+            ..BackupOptions::default()
+        });
+        assert!(off.starts_with("include_offset_headers=false"), "{off}");
+        assert!(!off.contains("x-original-offset"));
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -442,9 +442,18 @@ pub struct BackupOptions {
     #[serde(default = "default_sync_interval_secs")]
     pub sync_interval_secs: u64,
 
-    /// Include original offset headers in backup (Phase 1 of three-phase restore)
-    /// Headers: x-original-offset, x-original-timestamp, x-source-cluster (if set)
-    /// Default: true for DR scenarios
+    /// Add offset-tracking headers to every record as it is archived
+    /// (Phase 1 of the three-phase restore).
+    ///
+    /// Adds `x-original-offset` and `x-original-timestamp` (little-endian
+    /// `i64`), plus `x-source-cluster` when `source_cluster_id` is set. They
+    /// are what makes `consumer_group_strategy: header-based` recovery
+    /// possible after a restore, but they also mean an archived record is
+    /// not header-for-header identical to the source record.
+    ///
+    /// **Default: `true`.** Set to `false` for a verbatim archive, or leave
+    /// it on and use `restore.strip_offset_headers: true` to drop the
+    /// headers at restore time.
     #[serde(default = "default_include_offset_headers")]
     pub include_offset_headers: bool,
 
@@ -671,9 +680,28 @@ pub struct RestoreOptions {
     #[serde(default)]
     pub dry_run: bool,
 
-    /// Include original offset as a header
+    /// Add `x-original-offset`, `x-original-timestamp` and
+    /// `x-source-partition` headers to every record as it is produced to
+    /// the target cluster. Also implied by `consumer_group_strategy:
+    /// header-based`. Default: `false`.
     #[serde(default)]
     pub include_original_offset_header: bool,
+
+    /// Remove the headers kafka-backup adds (`x-original-offset`,
+    /// `x-original-timestamp`, `x-source-cluster`, `x-source-partition`)
+    /// from archived records before producing them, so a restored record
+    /// carries exactly the headers the source record had.
+    ///
+    /// Use this to restore an archive taken with the default
+    /// `backup.include_offset_headers: true` header-for-header identical to
+    /// the source. Offset mapping is unaffected: the source offset is stored
+    /// natively in the segment, not only in the header. If
+    /// `include_original_offset_header` / `header-based` is also on, the
+    /// headers are stripped first and fresh ones injected.
+    ///
+    /// Default: `false`.
+    #[serde(default)]
+    pub strip_offset_headers: bool,
 
     /// Rate limit in records per second
     #[serde(default)]
@@ -790,6 +818,7 @@ impl Default for RestoreOptions {
             consumer_group_strategy: OffsetStrategy::default(),
             dry_run: false,
             include_original_offset_header: false,
+            strip_offset_headers: false,
             rate_limit_records_per_sec: None,
             rate_limit_bytes_per_sec: None,
             max_concurrent_partitions: default_max_concurrent_partitions(),
@@ -1136,6 +1165,49 @@ logging:
             warnings.is_empty(),
             "expected no warnings, got {warnings:?}"
         );
+    }
+
+    /// Issue #154: the backup-side default is `true` and was undocumented.
+    /// This pins the contract so a change to it is a deliberate one.
+    #[test]
+    fn backup_include_offset_headers_defaults_to_true() {
+        assert!(BackupOptions::default().include_offset_headers);
+        let yaml = r#"
+mode: backup
+backup_id: defaults
+source:
+  bootstrap_servers: [localhost:9092]
+storage:
+  backend: filesystem
+  path: /tmp/defaults
+backup:
+  compression: zstd
+"#;
+        let (config, _) = Config::from_yaml_with_warnings(yaml).unwrap();
+        assert!(config.backup.unwrap().include_offset_headers);
+    }
+
+    #[test]
+    fn restore_strip_offset_headers_defaults_to_false_and_parses() {
+        assert!(!RestoreOptions::default().strip_offset_headers);
+        let yaml = r#"
+mode: restore
+backup_id: strip
+target:
+  bootstrap_servers: [localhost:9092]
+storage:
+  backend: filesystem
+  path: /tmp/strip
+restore:
+  strip_offset_headers: true
+  consumer_group_strategy: skip
+"#;
+        let (config, warnings) = Config::from_yaml_with_warnings(yaml).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+        let restore = config.restore.unwrap();
+        assert!(restore.strip_offset_headers);
+        assert!(!restore.include_original_offset_header);
+        assert_eq!(restore.consumer_group_strategy, OffsetStrategy::Skip);
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/lib.rs
+++ b/crates/kafka-backup-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod kafka;
 pub mod manifest;
 pub mod metrics;
 pub mod notification;
+pub mod offset_headers;
 pub mod offset_store;
 pub mod restore;
 pub mod segment;

--- a/crates/kafka-backup-core/src/offset_headers.rs
+++ b/crates/kafka-backup-core/src/offset_headers.rs
@@ -1,0 +1,55 @@
+//! Names of the record headers kafka-backup itself adds to records.
+//!
+//! Two places inject headers:
+//!
+//! * **Backup** (`backup.include_offset_headers`, default `true`) appends
+//!   [`X_ORIGINAL_OFFSET`] and [`X_ORIGINAL_TIMESTAMP`] — and
+//!   [`X_SOURCE_CLUSTER`] when `backup.source_cluster_id` is set — to every
+//!   record *as it is archived*. These are Phase 1 of the three-phase restore
+//!   and make header-based consumer offset recovery possible.
+//! * **Restore** (`restore.include_original_offset_header`, or
+//!   `consumer_group_strategy: header-based`) appends [`X_ORIGINAL_OFFSET`],
+//!   [`X_ORIGINAL_TIMESTAMP`] and [`X_SOURCE_PARTITION`] to every record *as
+//!   it is produced* to the target cluster.
+//!
+//! `restore.strip_offset_headers` removes all of [`ALL`] from archived
+//! records before they are produced, for restores that must be
+//! header-for-header identical to the source.
+
+/// Source offset of the record, as a little-endian `i64`.
+pub const X_ORIGINAL_OFFSET: &str = "x-original-offset";
+/// Source timestamp of the record (epoch millis), as a little-endian `i64`.
+pub const X_ORIGINAL_TIMESTAMP: &str = "x-original-timestamp";
+/// `backup.source_cluster_id`, as UTF-8 (backup side only).
+pub const X_SOURCE_CLUSTER: &str = "x-source-cluster";
+/// Source partition of the record, as a little-endian `i32` (restore side only).
+pub const X_SOURCE_PARTITION: &str = "x-source-partition";
+
+/// Every header name kafka-backup may add to a record.
+pub const ALL: [&str; 4] = [
+    X_ORIGINAL_OFFSET,
+    X_ORIGINAL_TIMESTAMP,
+    X_SOURCE_CLUSTER,
+    X_SOURCE_PARTITION,
+];
+
+/// Whether `key` is one of the headers kafka-backup adds.
+pub fn is_offset_header(key: &str) -> bool {
+    ALL.contains(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_only_kafka_backup_headers() {
+        for key in ALL {
+            assert!(is_offset_header(key), "{key}");
+        }
+        assert!(!is_offset_header("x-original-offset-v2"));
+        assert!(!is_offset_header("X-Original-Offset"));
+        assert!(!is_offset_header("trace-id"));
+        assert!(!is_offset_header(""));
+    }
+}

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -691,6 +691,22 @@ impl RestoreEngine {
         }
 
         info!("Restoring {} topics", topics_to_restore.len());
+        if restore_options.strip_offset_headers {
+            info!(
+                "strip_offset_headers=true: removing {} headers from archived records before producing",
+                crate::offset_headers::ALL.join(", ")
+            );
+        }
+        if restore_options.include_original_offset_header
+            || restore_options.consumer_group_strategy == OffsetStrategy::HeaderBased
+        {
+            info!(
+                "Adding {}, {} and {} headers to every produced record (include_original_offset_header / header-based strategy)",
+                crate::offset_headers::X_ORIGINAL_OFFSET,
+                crate::offset_headers::X_ORIGINAL_TIMESTAMP,
+                crate::offset_headers::X_SOURCE_PARTITION
+            );
+        }
 
         let mut shutdown_rx = self.shutdown_receiver();
         let mut topic_reports = Vec::new();
@@ -1379,9 +1395,12 @@ impl RestorePartitionContext {
                 );
             }
 
-            // Add original offset headers if configured (header-based strategy)
+            // Drop the archive's kafka-backup headers if asked to, then add
+            // fresh original-offset headers if configured (header-based strategy)
+            let stripped_records =
+                super::helpers::strip_offset_headers(filtered_records, &self.options);
             let records_to_produce = super::helpers::inject_offset_headers(
-                filtered_records,
+                stripped_records,
                 self.source_partition,
                 &self.options,
             );
@@ -1536,7 +1555,7 @@ impl RestorePartitionContext {
         record
             .headers
             .iter()
-            .filter(|h| h.key == "x-original-offset")
+            .filter(|h| h.key == crate::offset_headers::X_ORIGINAL_OFFSET)
             .find_map(|h| decode_i64_header(h.value.as_deref()))
             .unwrap_or(record.offset)
     }
@@ -1547,7 +1566,7 @@ impl RestorePartitionContext {
         record
             .headers
             .iter()
-            .filter(|h| h.key == "x-original-timestamp")
+            .filter(|h| h.key == crate::offset_headers::X_ORIGINAL_TIMESTAMP)
             .find_map(|h| decode_i64_header(h.value.as_deref()))
             .unwrap_or(record.timestamp)
     }

--- a/crates/kafka-backup-core/src/restore/helpers.rs
+++ b/crates/kafka-backup-core/src/restore/helpers.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 use crate::compression::{decompress, detect_from_extension};
 use crate::config::{OffsetStrategy, RestoreOptions};
 use crate::manifest::{BackupRecord, RecordHeader, RestoreCheckpoint, SegmentMetadata};
+use crate::offset_headers;
 use crate::segment::format::{BinaryRecord, MAGIC_BYTES};
 use crate::segment::SegmentReader;
 use crate::storage::StorageBackend;
@@ -81,6 +82,32 @@ pub fn filter_records_by_time(
         .collect()
 }
 
+/// Remove the headers kafka-backup itself adds to records
+/// (`x-original-offset`, `x-original-timestamp`, `x-source-cluster`,
+/// `x-source-partition`) when `restore.strip_offset_headers` is set, so a
+/// restored record carries exactly the headers its source record had
+/// (issue #154). Every other header — including the same names with a
+/// different case — is kept, in order. A no-op when the option is off.
+///
+/// Called before [`inject_offset_headers`], so a restore that both strips
+/// and injects ends up with exactly one fresh set of restore-side headers.
+pub(crate) fn strip_offset_headers(
+    records: Vec<BackupRecord>,
+    options: &RestoreOptions,
+) -> Vec<BackupRecord> {
+    if !options.strip_offset_headers {
+        return records;
+    }
+    records
+        .into_iter()
+        .map(|mut r| {
+            r.headers
+                .retain(|h| !offset_headers::is_offset_header(&h.key));
+            r
+        })
+        .collect()
+}
+
 /// Inject original-offset tracking headers into records.
 ///
 /// Adds `x-original-offset`, `x-original-timestamp`, and `x-source-partition`
@@ -97,15 +124,15 @@ pub fn inject_offset_headers(
             .into_iter()
             .map(|mut r| {
                 r.headers.push(RecordHeader {
-                    key: "x-original-offset".to_string(),
+                    key: offset_headers::X_ORIGINAL_OFFSET.to_string(),
                     value: Some(r.offset.to_le_bytes().to_vec()),
                 });
                 r.headers.push(RecordHeader {
-                    key: "x-original-timestamp".to_string(),
+                    key: offset_headers::X_ORIGINAL_TIMESTAMP.to_string(),
                     value: Some(r.timestamp.to_le_bytes().to_vec()),
                 });
                 r.headers.push(RecordHeader {
-                    key: "x-source-partition".to_string(),
+                    key: offset_headers::X_SOURCE_PARTITION.to_string(),
                     value: Some(source_partition.to_le_bytes().to_vec()),
                 });
                 r
@@ -260,6 +287,132 @@ mod tests {
             Some(&1_700_000_000_000i64.to_le_bytes()[..])
         );
         assert_eq!(headers[3].value.as_deref(), Some(&3i32.to_le_bytes()[..]));
+    }
+
+    /// A record as it comes out of an archive taken with the default
+    /// `include_offset_headers: true`: user headers first, then the two
+    /// backup-side headers.
+    fn archived_record() -> BackupRecord {
+        BackupRecord {
+            key: Some(b"k".to_vec()),
+            value: Some(b"v".to_vec()),
+            headers: vec![
+                header("event-type", Some(b"created")),
+                header("trace-id", None),
+                header("X-Original-Offset", Some(b"user header, different case")),
+                header("x-original-offset", Some(&9i64.to_le_bytes())),
+                header(
+                    "x-original-timestamp",
+                    Some(&1_700_000_000_000i64.to_le_bytes()),
+                ),
+                header("x-source-cluster", Some(b"eu-prod")),
+            ],
+            timestamp: 1_700_000_000_000,
+            offset: 9,
+        }
+    }
+
+    /// Issue #154: `strip_offset_headers` drops exactly the headers
+    /// kafka-backup adds and nothing else, preserving order.
+    #[test]
+    fn strip_offset_headers_removes_only_kafka_backup_headers() {
+        let options = RestoreOptions {
+            strip_offset_headers: true,
+            ..RestoreOptions::default()
+        };
+
+        let out = strip_offset_headers(vec![archived_record()], &options);
+
+        assert_eq!(
+            out[0].headers,
+            vec![
+                header("event-type", Some(b"created")),
+                header("trace-id", None),
+                header("X-Original-Offset", Some(b"user header, different case")),
+            ]
+        );
+        // Everything else about the record is untouched.
+        assert_eq!(out[0].offset, 9);
+        assert_eq!(out[0].key.as_deref(), Some(&b"k"[..]));
+    }
+
+    #[test]
+    fn strip_offset_headers_also_drops_restore_side_headers_from_chained_restores() {
+        let options = RestoreOptions {
+            strip_offset_headers: true,
+            ..RestoreOptions::default()
+        };
+        let mut record = archived_record();
+        record
+            .headers
+            .push(header("x-source-partition", Some(&3i32.to_le_bytes())));
+
+        let out = strip_offset_headers(vec![record], &options);
+
+        assert!(out[0]
+            .headers
+            .iter()
+            .all(|h| !offset_headers::is_offset_header(&h.key)));
+        assert_eq!(out[0].headers.len(), 3);
+    }
+
+    #[test]
+    fn strip_offset_headers_is_a_no_op_by_default() {
+        let before = archived_record();
+        let out = strip_offset_headers(vec![before.clone()], &RestoreOptions::default());
+        assert_eq!(out[0].headers, before.headers);
+    }
+
+    #[test]
+    fn strip_offset_headers_leaves_records_without_such_headers_alone() {
+        let options = RestoreOptions {
+            strip_offset_headers: true,
+            ..RestoreOptions::default()
+        };
+        let record = BackupRecord {
+            key: None,
+            value: None,
+            headers: vec![header("trace-id", None), header("tenant", Some(b"42"))],
+            timestamp: 0,
+            offset: 0,
+        };
+        let out = strip_offset_headers(vec![record.clone()], &options);
+        assert_eq!(out[0].headers, record.headers);
+    }
+
+    /// Strip + inject (header-based strategy) yields exactly one fresh set of
+    /// restore-side headers rather than archived ones plus injected ones.
+    #[test]
+    fn strip_then_inject_yields_a_single_fresh_set_of_headers() {
+        let options = RestoreOptions {
+            strip_offset_headers: true,
+            consumer_group_strategy: OffsetStrategy::HeaderBased,
+            ..RestoreOptions::default()
+        };
+
+        let stripped = strip_offset_headers(vec![archived_record()], &options);
+        let out = inject_offset_headers(stripped, 4, &options);
+
+        let keys: Vec<&str> = out[0].headers.iter().map(|h| h.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            [
+                "event-type",
+                "trace-id",
+                "X-Original-Offset",
+                "x-original-offset",
+                "x-original-timestamp",
+                "x-source-partition",
+            ]
+        );
+        assert_eq!(
+            out[0].headers[3].value.as_deref(),
+            Some(&9i64.to_le_bytes()[..])
+        );
+        assert_eq!(
+            out[0].headers[5].value.as_deref(),
+            Some(&4i32.to_le_bytes()[..])
+        );
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/restore/repartition.rs
+++ b/crates/kafka-backup-core/src/restore/repartition.rs
@@ -326,7 +326,8 @@ async fn run_reader(
             continue;
         }
 
-        let records_to_send = helpers::inject_offset_headers(filtered, source_partition, options);
+        let stripped = helpers::strip_offset_headers(filtered, options);
+        let records_to_send = helpers::inject_offset_headers(stripped, source_partition, options);
 
         // Route each record through the partitioner
         for record in records_to_send {

--- a/crates/kafka-backup-core/tests/integration_suite/issue_154_offset_headers.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_154_offset_headers.rs
@@ -1,0 +1,293 @@
+//! Issue #154 — `backup.include_offset_headers` defaults to `true`, so every
+//! archived record gains `x-original-offset` / `x-original-timestamp` and a
+//! restore is never header-for-header identical to the source unless the
+//! backup was taken with the option off. `restore.strip_offset_headers`
+//! removes those headers from an archive that already carries them.
+//!
+//! Requires Docker.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, OffsetStrategy, RestoreOptions,
+    SecurityConfig, TopicSelection,
+};
+use kafka_backup_core::kafka::{KafkaClient, TopicToCreate};
+use kafka_backup_core::manifest::{BackupRecord, RecordHeader};
+use kafka_backup_core::offset_headers;
+use kafka_backup_core::restore::RestoreEngine;
+use kafka_backup_core::storage::StorageBackendConfig;
+
+use super::common::{create_temp_storage, KafkaTestCluster};
+
+const SOURCE_TOPIC: &str = "issue-154-src";
+const BACKUP_ID: &str = "issue-154-backup";
+const RECORDS: usize = 30;
+
+fn header(key: &str, value: Option<&[u8]>) -> RecordHeader {
+    RecordHeader {
+        key: key.to_string(),
+        value: value.map(|v| v.to_vec()),
+    }
+}
+
+/// The reporter's records: `event-type:created, tenant:42`, plus a null one.
+fn source_records() -> Vec<BackupRecord> {
+    (0..RECORDS)
+        .map(|i| BackupRecord {
+            key: Some(format!("k-{i}").into_bytes()),
+            value: Some(format!("v-{i}").into_bytes()),
+            headers: vec![
+                header("event-type", Some(b"created")),
+                header("tenant", Some(b"42")),
+                header("trace-id", None),
+            ],
+            timestamp: 1_700_000_000_000 + i as i64,
+            offset: i as i64,
+        })
+        .collect()
+}
+
+/// Backup config that leaves `include_offset_headers` at its default.
+fn backup_config(bs: &str, storage: PathBuf) -> Config {
+    let backup = BackupOptions {
+        segment_max_bytes: 1024 * 1024,
+        segment_max_interval_ms: 5000,
+        compression: CompressionType::Zstd,
+        stop_at_current_offsets: true,
+        continuous: false,
+        ..Default::default()
+    };
+    assert!(
+        backup.include_offset_headers,
+        "the default under test is `true`"
+    );
+    Config {
+        mode: Mode::Backup,
+        backup_id: BACKUP_ID.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![SOURCE_TOPIC.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: Some(backup),
+        restore: None,
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+fn restore_config(bs: &str, storage: PathBuf, target: &str, restore: RestoreOptions) -> Config {
+    let mut topic_mapping = HashMap::new();
+    topic_mapping.insert(SOURCE_TOPIC.to_string(), target.to_string());
+    Config {
+        mode: Mode::Restore,
+        backup_id: BACKUP_ID.to_string(),
+        source: None,
+        target: Some(KafkaConfig {
+            bootstrap_servers: vec![bs.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection::default(),
+            connection: Default::default(),
+        }),
+        storage: StorageBackendConfig::Filesystem { path: storage },
+        backup: None,
+        restore: Some(RestoreOptions {
+            topic_mapping,
+            create_topics: true,
+            ..restore
+        }),
+        offset_storage: None,
+        metrics: None,
+    }
+}
+
+async fn create_single_partition_topic(client: &KafkaClient, name: &str) {
+    let results = client
+        .create_topics(
+            vec![TopicToCreate {
+                name: name.to_string(),
+                num_partitions: 1,
+                replication_factor: 1,
+            }],
+            30_000,
+        )
+        .await
+        .expect("create topic");
+    assert!(
+        results.iter().all(|r| r.is_success_or_exists()),
+        "create {name}: {results:?}"
+    );
+    tokio::time::sleep(Duration::from_secs(2)).await;
+}
+
+async fn fetch_all(client: &KafkaClient, topic: &str, expected: usize) -> Vec<BackupRecord> {
+    let mut out = Vec::new();
+    let mut offset = 0;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    while out.len() < expected && tokio::time::Instant::now() < deadline {
+        let resp = client
+            .fetch(topic, 0, offset, 8 * 1024 * 1024)
+            .await
+            .expect("fetch");
+        if resp.records.is_empty() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        }
+        offset = resp.next_offset;
+        out.extend(resp.records);
+    }
+    out
+}
+
+fn header_keys(r: &BackupRecord) -> Vec<&str> {
+    r.headers.iter().map(|h| h.key.as_str()).collect()
+}
+
+async fn restore_to(bs: &str, storage: PathBuf, target: &str, restore: RestoreOptions) {
+    let report = tokio::time::timeout(
+        Duration::from_secs(60),
+        RestoreEngine::new(restore_config(bs, storage, target, restore))
+            .expect("restore engine")
+            .run(),
+    )
+    .await
+    .expect("restore timed out")
+    .expect("restore");
+    assert_eq!(report.records_restored as usize, RECORDS);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn test_default_backup_adds_offset_headers_and_strip_restores_them_verbatim() {
+    let cluster = KafkaTestCluster::start().await.expect("start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka ready");
+    let bs = cluster.bootstrap_servers.clone();
+    let client = cluster.create_client();
+    client.connect().await.expect("connect");
+
+    create_single_partition_topic(&client, SOURCE_TOPIC).await;
+    let expected = source_records();
+    client
+        .produce(SOURCE_TOPIC, 0, expected.clone(), -1, 30_000)
+        .await
+        .expect("produce");
+
+    // Backup with defaults.
+    let storage = create_temp_storage();
+    let engine = BackupEngine::new(backup_config(&bs, storage.path().to_path_buf()))
+        .await
+        .expect("backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup");
+
+    // 1. Plain restore: the reporter's observation — exactly two extra
+    //    headers, appended after the record's own, and no x-source-partition
+    //    (that one is restore-side only and off by default).
+    restore_to(
+        &bs,
+        storage.path().to_path_buf(),
+        "issue-154-plain",
+        RestoreOptions::default(),
+    )
+    .await;
+    let plain = fetch_all(&client, "issue-154-plain", RECORDS).await;
+    assert_eq!(plain.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&plain) {
+        assert_eq!(
+            header_keys(got),
+            [
+                "event-type",
+                "tenant",
+                "trace-id",
+                offset_headers::X_ORIGINAL_OFFSET,
+                offset_headers::X_ORIGINAL_TIMESTAMP,
+            ],
+            "plain restore, offset {}",
+            got.offset
+        );
+        assert_eq!(&got.headers[..3], &want.headers[..]);
+        assert_eq!(
+            got.headers[3].value.as_deref(),
+            Some(&want.offset.to_le_bytes()[..]),
+            "x-original-offset carries the source offset"
+        );
+    }
+
+    // 2. strip_offset_headers: header-for-header identical to the source.
+    restore_to(
+        &bs,
+        storage.path().to_path_buf(),
+        "issue-154-stripped",
+        RestoreOptions {
+            strip_offset_headers: true,
+            ..RestoreOptions::default()
+        },
+    )
+    .await;
+    let stripped = fetch_all(&client, "issue-154-stripped", RECORDS).await;
+    assert_eq!(stripped.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&stripped) {
+        assert_eq!(want.key, got.key);
+        assert_eq!(want.value, got.value);
+        assert_eq!(
+            want.headers, got.headers,
+            "stripped restore must match the source exactly (offset {})",
+            got.offset
+        );
+    }
+
+    // 3. strip + header-based strategy: the archived headers are replaced by
+    //    exactly one fresh set of restore-side headers, and the offset
+    //    mapping still points at the right source offsets.
+    restore_to(
+        &bs,
+        storage.path().to_path_buf(),
+        "issue-154-rebased",
+        RestoreOptions {
+            strip_offset_headers: true,
+            consumer_group_strategy: OffsetStrategy::HeaderBased,
+            ..RestoreOptions::default()
+        },
+    )
+    .await;
+    let rebased = fetch_all(&client, "issue-154-rebased", RECORDS).await;
+    assert_eq!(rebased.len(), RECORDS);
+    for (want, got) in expected.iter().zip(&rebased) {
+        assert_eq!(
+            header_keys(got),
+            [
+                "event-type",
+                "tenant",
+                "trace-id",
+                offset_headers::X_ORIGINAL_OFFSET,
+                offset_headers::X_ORIGINAL_TIMESTAMP,
+                offset_headers::X_SOURCE_PARTITION,
+            ],
+            "strip + inject, offset {}",
+            got.offset
+        );
+        assert_eq!(
+            got.headers[3].value.as_deref(),
+            Some(&want.offset.to_le_bytes()[..])
+        );
+        assert_eq!(
+            got.headers[5].value.as_deref(),
+            Some(&0i32.to_le_bytes()[..])
+        );
+    }
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -12,12 +12,14 @@
 //! - Issue #144: OFFSET_OUT_OF_RANGE recovery and data-gap recording
 //! - Issue #146: connection-error classification and reconnect (no Docker)
 //! - Issue #148: consumer group offsets applied in Phase 3 after restore
+//! - Issue #154: default offset headers are documented, logged, and strippable on restore
 //! - Issue #155: null header values survive backup and restore
 
 pub mod common;
 pub mod issue_144_offset_out_of_range;
 pub mod issue_146_connection_errors;
 pub mod issue_148_offset_reset_after_restore;
+pub mod issue_154_offset_headers;
 pub mod issue_155_null_header_value;
 pub mod issue_56_missing_topic;
 pub mod issue_67_fixes;

--- a/docs/Three_Phase_Restore_Guide.md
+++ b/docs/Three_Phase_Restore_Guide.md
@@ -328,7 +328,7 @@ The offset mapping report contains:
 
 ## Best Practices
 
-1. **Always enable offset headers** during backup (`include_offset_headers: true`)
+1. **Keep offset headers enabled** during backup (`include_offset_headers: true`, the default — see [Offset-tracking headers](configuration.md#offset-tracking-headers))
 2. **Review offset reset plans** before applying in production
 3. **Use dry-run mode** first to validate the plan
 4. **Save offset mapping reports** for audit trails

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -375,20 +375,65 @@ storage:
 
 ## Backup Configuration
 
-Options specific to backup operations.
+Options specific to backup operations (the `backup:` section). Defaults are
+the values in `kafka-backup-core`'s `BackupOptions::default()`.
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `compression` | string | No | `zstd` | Compression algorithm |
+| `compression` | string | No | `zstd` | Segment compression: `none`, `zstd` or `lz4` |
+| `compression_level` | int | No | `3` | Compression level (1–22; only meaningful for `zstd`) |
+| `start_offset` | string / map | No | `earliest` | Where a partition starts when there is no checkpoint: `earliest`, `latest`, or `specific: {topic: {partition: offset}}` |
 | `continuous` | bool | No | `false` | Run continuously (streaming replication) |
 | `stop_at_current_offsets` | bool | No | `false` | Snapshot mode: capture HWMs at start, exit when caught up |
-| `checkpoint_interval_secs` | int | No | `60` | Checkpoint interval |
-| `segment_max_records` | int | No | `100000` | Max records per segment |
-| `segment_max_bytes` | int | No | `104857600` | Max bytes per segment (100MB) |
-| `segment_max_age_secs` | int | No | `3600` | Max segment age |
-| `max_concurrent_partitions` | int | No | `8` | Maximum concurrent partition backups (limits parallelism) |
 | `poll_interval_ms` | int | No | `100` | Delay between backup passes in continuous mode (milliseconds) |
-| `fetch_max_bytes` | int | No | `1048576` | Max bytes per fetch |
+| `max_concurrent_partitions` | int | No | `8` | Maximum concurrent partition backups (limits parallelism) |
+| `segment_max_bytes` | int | No | `134217728` | Rotate a segment once it holds this many uncompressed bytes (128MB) |
+| `segment_max_interval_ms` | int | No | `60000` | Rotate a segment after this many milliseconds even if it is not full |
+| `segment_max_records` | int | No | unset | Rotate a segment after this many records (no record limit when unset) |
+| `fetch_max_bytes` | int | No | unset | Max bytes per Kafka Fetch request; when unset, `min(segment_max_bytes, 16MB)` |
+| `checkpoint_interval_secs` | int | No | `5` | How often partition progress is checkpointed to the offset store |
+| `sync_interval_secs` | int | No | `30` | How often the offset store is synced to remote storage |
+| `include_offset_headers` | bool | No | **`true`** | Add `x-original-offset` / `x-original-timestamp` headers to every archived record — see [Offset-tracking headers](#offset-tracking-headers) |
+| `source_cluster_id` | string | No | unset | Recorded in the `x-source-cluster` header (only with `include_offset_headers`) |
+| `include_internal_topics` | bool | No | `false` | Also back up internal topics listed in `internal_topics` |
+| `internal_topics` | list[string] | No | `[]` | Internal topics to include (e.g. `__consumer_offsets`) when `include_internal_topics` is set |
+| `consumer_group_snapshot` | bool | No | `false` | Write `consumer-groups-snapshot.json` after each cycle for `auto_consumer_groups` restores |
+
+### Offset-tracking headers
+
+`include_offset_headers` is **on by default**. With it, every record is
+archived with two extra headers appended after the record's own headers:
+
+| Header | Value | Added when |
+|--------|-------|------------|
+| `x-original-offset` | source offset, little-endian `i64` | always |
+| `x-original-timestamp` | source timestamp (epoch ms), little-endian `i64` | always |
+| `x-source-cluster` | `source_cluster_id`, UTF-8 | `source_cluster_id` is set |
+
+They are Phase 1 of the [three-phase restore](Three_Phase_Restore_Guide.md)
+and make `consumer_group_strategy: header-based` recovery possible. The
+trade-off is that an archived — and therefore a restored — record is not
+header-for-header identical to its source. The backup logs which headers it
+is adding at startup (`include_offset_headers=true (default): ...`).
+
+To get a verbatim copy, either:
+
+```yaml
+# at backup time — archive the record's own headers only
+backup:
+  include_offset_headers: false
+```
+
+```yaml
+# at restore time — works for archives that already carry the headers
+restore:
+  strip_offset_headers: true
+```
+
+`strip_offset_headers` removes `x-original-offset`, `x-original-timestamp`,
+`x-source-cluster` and `x-source-partition` from archived records before
+they are produced. Offset mapping is unaffected: the source offset is stored
+natively in the segment, not only in the header.
 
 ### Performance Tuning
 
@@ -449,10 +494,12 @@ the topic's retention so a full run fits inside the retention window.
 | Algorithm | Description |
 |-----------|-------------|
 | `none` | No compression |
-| `zstd` | Zstandard (default, best ratio) |
+| `zstd` | Zstandard (default, best ratio; `compression_level` 1–22, default 3) |
 | `lz4` | LZ4 (faster, lower ratio) |
-| `gzip` | Gzip (widely compatible) |
-| `snappy` | Snappy (balanced) |
+
+This is the compression of the segment files written to storage. It is
+independent of the compression the source topic uses on the broker — every
+broker-side codec (including gzip and snappy) is decoded on fetch.
 
 ### Examples
 
@@ -463,11 +510,11 @@ backup:
   continuous: true
   checkpoint_interval_secs: 30
   segment_max_records: 50000
-  segment_max_bytes: 52428800  # 50MB
-  segment_max_age_secs: 1800   # 30 minutes
-  max_concurrent_partitions: 8 # Limit concurrent partition tasks
-  poll_interval_ms: 100        # Delay between backup passes (lower = less lag)
-  fetch_max_bytes: 5242880     # 5MB
+  segment_max_bytes: 52428800     # 50MB
+  segment_max_interval_ms: 1800000 # 30 minutes
+  max_concurrent_partitions: 8    # Limit concurrent partition tasks
+  poll_interval_ms: 100           # Delay between backup passes (lower = less lag)
+  fetch_max_bytes: 5242880        # 5MB
 ```
 
 **Snapshot Backup (DR/Scheduled):**
@@ -475,9 +522,18 @@ backup:
 backup:
   compression: zstd
   stop_at_current_offsets: true  # Exit when caught up
-  include_offset_headers: true    # For offset remapping on restore
+  include_offset_headers: true    # Default; x-original-* headers for offset recovery on restore
+  source_cluster_id: prod-eu      # Optional; recorded as x-source-cluster
   checkpoint_interval_secs: 30
   segment_max_bytes: 134217728    # 128MB
+```
+
+**Verbatim Archive (no headers added):**
+```yaml
+backup:
+  compression: zstd
+  stop_at_current_offsets: true
+  include_offset_headers: false   # Records are archived with their own headers only
 ```
 
 ---
@@ -624,7 +680,15 @@ Options specific to restore operations.
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `dry_run` | bool | No | `false` | Simulate restore without writing |
-| `include_original_offset_header` | bool | No | `false` | Add original offset to headers |
+| `include_original_offset_header` | bool | No | `false` | Add `x-original-offset`, `x-original-timestamp` and `x-source-partition` headers to every record as it is produced (also implied by `consumer_group_strategy: header-based`) |
+| `strip_offset_headers` | bool | No | `false` | Remove the headers kafka-backup added at backup time (`x-original-*`, `x-source-*`) before producing, for a header-for-header identical restore — see [Offset-tracking headers](#offset-tracking-headers) |
+| `purge_topics` | bool | No | `false` | **Irreversible.** Advance every target partition's log-start-offset to its end-offset (`DeleteRecords`) before restoring, so the topic appears empty without being deleted (Strimzi-managed topics) |
+
+Note the two header options govern different sides of the pipeline:
+`backup.include_offset_headers` decides what goes *into* the archive,
+`restore.include_original_offset_header` what is added *on the way out*.
+Neither removes headers that are already in the archive — that is what
+`strip_offset_headers` is for.
 
 ### Time Window Filtering
 
@@ -661,6 +725,7 @@ restore:
 |--------|------|----------|---------|-------------|
 | `topic_mapping` | map[string, string] | No | `{}` | Rename topics during restore |
 | `partition_mapping` | map[int, int] | No | `{}` | Remap partitions during restore |
+| `repartitioning` | map[string, object] | No | `{}` | Per *target* topic: `{strategy: murmur2 \| automatic, target_partitions: N}` — re-partition records on the fly to a different partition count; mutually exclusive with `partition_mapping`. See [restore_guide.md](restore_guide.md#partition-remapping) |
 
 ```yaml
 restore:
@@ -719,7 +784,10 @@ restore:
 |--------|------|----------|---------|-------------|
 | `max_concurrent_partitions` | int | No | `4` | Concurrent partition restores |
 | `produce_batch_size` | int | No | `1000` | Records per produce batch |
+| `produce_acks` | int | No | `-1` | Producer acks: `-1` all in-sync replicas (safest), `1` leader only, `0` fire-and-forget |
+| `produce_timeout_ms` | int | No | `30000` | Broker-side produce timeout in milliseconds |
 | `rate_limit_records_per_sec` | int | No | - | Rate limit (records/sec) |
+| `rate_limit_bytes_per_sec` | int | No | - | Rate limit (bytes/sec) |
 
 ```yaml
 restore:
@@ -1062,6 +1130,17 @@ The system validates configuration on load:
 - Time windows must have start < end
 - Partition mappings must be valid
 - Consumer group strategy must be recognized
+
+Unknown keys are **not** an error — a misspelled or mis-nested key (for
+example `fetch_max_bytez`, or `include_offset_headers` placed under
+`restore:` instead of `backup:`) is ignored. The CLI logs a warning for each
+one at startup:
+
+```
+WARN Ignoring unknown config key `restore.include_offset_headers` — check for typos
+```
+
+so check the first lines of output when an option seems to have no effect.
 
 ### Example Validation Error
 

--- a/docs/restore_guide.md
+++ b/docs/restore_guide.md
@@ -60,10 +60,13 @@ Things that can make a restored record differ from its source:
 
 - **Injected headers.** `backup.include_offset_headers` (default `true`) adds
   `x-original-offset` and `x-original-timestamp` to every *archived* record;
-  set it to `false` on the backup for a header-for-header identical archive.
-  On the restore side, `include_original_offset_header: true` or
+  set it to `false` on the backup for a header-for-header identical archive,
+  or set `restore.strip_offset_headers: true` to drop them from an archive
+  that already has them. On the restore side,
+  `include_original_offset_header: true` or
   `consumer_group_strategy: header-based` add `x-original-offset`,
   `x-original-timestamp` and `x-source-partition` to every produced record.
+  See [Offset-tracking headers](configuration.md#offset-tracking-headers).
 - **Duplicate header keys** (two headers with the same key on one record) are
   currently collapsed to the last one at backup time
   ([#156](https://github.com/osodevops/kafka-backup/issues/156)).
@@ -211,6 +214,7 @@ restore:
   # Offset handling
   consumer_group_strategy: header-based
   include_original_offset_header: true
+  strip_offset_headers: false      # true = drop the x-original-*/x-source-* headers the backup added
 
   # Safety
   dry_run: false
@@ -243,7 +247,8 @@ restore:
 | `topic_mapping` | {str: str} | {} | Source to target topic mapping |
 | `consumer_group_strategy` | enum | skip | Offset handling strategy |
 | `dry_run` | bool | false | Validate without writing |
-| `include_original_offset_header` | bool | false | Add offset headers to records |
+| `include_original_offset_header` | bool | false | Add `x-original-offset` / `x-original-timestamp` / `x-source-partition` to produced records |
+| `strip_offset_headers` | bool | false | Remove the headers the backup added (`backup.include_offset_headers`, default on) so restored records match the source header-for-header |
 | `max_concurrent_partitions` | usize | 4 | Parallel partition restores |
 | `produce_batch_size` | usize | 1000 | Records per produce batch |
 | `rate_limit_records_per_sec` | u64 | None | Rate limit (records/sec) |


### PR DESCRIPTION
Closes #154

Stacked on #157 (same version-bump / CHANGELOG files); rebases cleanly once that merges.

## What is actually wrong

@izmal's follow-up is right: `include_original_offset_header: false` works. The two headers come from the **backup** side — `backup.include_offset_headers` defaults to `true`, appends `x-original-offset` / `x-original-timestamp` to every archived record, and the default was documented nowhere (the backup options table in `docs/configuration.md` didn't list the option at all). Once the headers are in the archive, no restore option could remove them, so a restore was never header-for-header identical to its source.

Reproduced against a real broker with a default-config backup: every restored record carries exactly the reporter's two extra headers (no `x-source-partition` — that one is restore-side only and off by default).

## Decision: keep the default, make it visible and reversible

Flipping the default to `false` would silently change what every existing config archives, and both the three-phase restore and the operator CRD (`includeOffsetHeaders`, default `true`) rely on it. So instead:

- **`restore.strip_offset_headers`** (new, default `false`) removes `x-original-offset`, `x-original-timestamp`, `x-source-cluster` and `x-source-partition` (chained restores) from archived records before producing. Runs *before* `inject_offset_headers`, so `strip` + `header-based` yields exactly one fresh set of restore-side headers. Offset mapping is unaffected — the source offset is stored natively in the segment, not only in the header. Works in both the 1:1 and the repartitioning fan-out paths.
- **`kafka_backup_core::offset_headers`** — the header names in one place (they were string literals in four files) plus `is_offset_header()`.
- **Startup logging.** The backup engine now logs `include_offset_headers=true (default): every archived record gets x-original-offset and x-original-timestamp ... set backup.include_offset_headers: false ..., or restore.strip_offset_headers: true ...`; the restore engine logs when it strips and when it injects.
- **Docs.** `docs/configuration.md` gains an "Offset-tracking headers" section (which side adds which header, and the two ways to get a verbatim copy), and the backup options table was rewritten — it listed 9 of 18 options, a `segment_max_age_secs` that doesn't exist (`segment_max_interval_ms`), `gzip`/`snappy` segment compression that isn't offered, and wrong defaults for `checkpoint_interval_secs` (5, not 60), `segment_max_bytes` (128MB), `segment_max_records` (unset) and `fetch_max_bytes` (unset → `min(segment_max_bytes, 16MB)`). Restore tables gained `strip_offset_headers`, `produce_acks`, `produce_timeout_ms`, `rate_limit_bytes_per_sec`, `purge_topics`, `repartitioning`. `restore_guide.md` / `Three_Phase_Restore_Guide.md` updated to match.
- **Unknown keys.** The "possibly related" note in the issue is already addressed: since #140 (in 0.17.4) `kafka-backup backup|restore|...` go through `parse_config`, which logs `WARN Ignoring unknown config key ...` for every unrecognised key. The Validation section of the docs now says so (unknown keys are warned about, not rejected).

**Breaking library API change** (new public field on `RestoreOptions`) → **0.19.0**. The operator sets `RestoreOptions` by struct literal and needs `strip_offset_headers` added when it bumps.

## Tests (TDD)

- `config.rs`: pins `include_offset_headers` default `true`; `strip_offset_headers` default `false` and parses from YAML with no unknown-key warning.
- `offset_headers.rs`: exact-match recognition only.
- `restore/helpers.rs`: strip removes only kafka-backup headers, preserves order and a same-name-different-case user header; drops restore-side headers from chained restores; no-op by default; leaves records without such headers alone; strip → inject yields a single fresh set.
- `backup/engine.rs`: startup message names the headers and both opt-outs; changes with `source_cluster_id`; off-message when disabled.
- New Docker-backed E2E `issue_154_offset_headers.rs`: default backup → plain restore has exactly the two extra headers after the user's; `strip_offset_headers` restore equals the source header-for-header (including a null-valued header, per #155); strip + `header-based` gives one fresh set with the right source offset.

## Verification

Independent of the test suite (confluent-kafka producer/consumer, fixed CLI, real broker, default backup config):

```
plain restore     : 40 records differ — extra header keys on restored side: {x-original-offset: 40, x-original-timestamp: 40}
strip restore     : IDENTICAL (40/40 identical)
typo in key       : WARN Ignoring unknown config key `restore.strip_offset_headerz` — check for typos
backup log        : include_offset_headers=true (default): every archived record gets x-original-offset and x-original-timestamp headers ...
```

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`, Docker E2E: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya4R9LzZbzFG79JV4FUGxK
