### PR TITLE
fix(metrics): size snapshot progress gauges from this run's planned records (strimzi-backup-operator#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-08-29
+
+### Fixed
+- `kafka_backup_snapshot_records_target` and
+  `kafka_backup_snapshot_records_remaining` now describe the work of the
+  current run. Snapshot mode (`stop_at_current_offsets`) sized both gauges
+  from the whole captured offset range (`latest - earliest` summed over
+  partitions) and only subtracted a partition's checkpointed prefix once that
+  partition's task started, so an incremental run over a large archive began
+  with "remaining" at the size of the entire archive even when only a few
+  records were new
+  ([strimzi-backup-operator#57](https://github.com/osodevops/strimzi-backup-operator/issues/57)).
+  The snapshot plan now resolves every partition's resume position (the
+  checkpoint's successor, else the configured `start_offset`) in one bulk read
+  of the offset store at capture time: `target` is the number of records this
+  run will fetch, `remaining` counts down from it to zero, and a run with
+  nothing new reports `0` / `0`. The `snapshot_capture_complete` log line
+  reports the planned records, the captured range and how many partitions
+  resume from a checkpoint. Dashboards using
+  `1 - remaining / clamp_min(target, 1)` keep working and now show per-run
+  progress.
+
 ## [0.19.0] - 2026-08-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ the pod exits. Keep the value within the pod termination grace period.
 **Key metrics:**
 - `kafka_backup_lag_records` — Consumer lag per partition
 - `kafka_backup_lag_records_sum` — Current lag across all partitions
-- `kafka_backup_snapshot_records_target` — Captured snapshot offset span
-- `kafka_backup_snapshot_records_remaining` — Snapshot offset span still to process
+- `kafka_backup_snapshot_records_target` — Records this run will fetch (captured snapshot range minus what earlier runs already archived)
+- `kafka_backup_snapshot_records_remaining` — Records this run has still to fetch
 - `kafka_backup_records_total` — Total records backed up
 - `kafka_backup_compression_ratio` — Compression efficiency
 - `kafka_backup_storage_write_latency_seconds` — Storage I/O latency

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -380,9 +380,12 @@ impl BackupEngine {
             // Capture snapshot offsets if stop_at_current_offsets is enabled
             // This provides a consistent "point-in-time" snapshot for DR backups
             // Returns (earliest, latest) pairs to avoid redundant offset fetches later
-            let snapshot_offsets: Option<HashMap<(String, i32), (i64, i64)>> =
+            let snapshot_ranges: Option<HashMap<(String, i32), SnapshotRange>> =
                 if backup_opts.stop_at_current_offsets {
-                    Some(self.capture_snapshot_offsets(&topics_metadata).await?)
+                    Some(
+                        self.capture_snapshot_offsets(&topics_metadata, &backup_opts.start_offset)
+                            .await?,
+                    )
                 } else {
                     None
                 };
@@ -427,12 +430,10 @@ impl BackupEngine {
                 // acquiring the semaphore before spawning serialized the loop and caused
                 // severe slowdowns on high-latency connections (Issue #29).
                 for partition in partitions {
-                    // Get cached offsets for snapshot mode (if enabled)
-                    let (earliest_offset, target_offset) = snapshot_offsets
+                    // Planned offset range for snapshot mode (if enabled)
+                    let snapshot = snapshot_ranges
                         .as_ref()
-                        .and_then(|m| m.get(&(topic.clone(), partition)))
-                        .map(|(earliest, latest)| (Some(*earliest), Some(*latest)))
-                        .unwrap_or((None, None));
+                        .and_then(|m| m.get(&(topic.clone(), partition)).copied());
 
                     let sem = semaphore.clone();
 
@@ -452,8 +453,7 @@ impl BackupEngine {
                         offset_persistence: self.offset_persistence.clone(),
                         kafka_cb: Arc::clone(&self.kafka_circuit_breaker),
                         storage_cb: Arc::clone(&self.storage_circuit_breaker),
-                        earliest_offset,
-                        target_offset,
+                        snapshot,
                     };
 
                     all_handles.push(tokio::spawn(async move {
@@ -799,17 +799,24 @@ impl BackupEngine {
 
     /// Capture current offsets for all partitions (snapshot mode).
     ///
-    /// Returns both earliest and latest offsets for each partition.
-    /// The latest offsets provide a consistent snapshot point - all partitions
+    /// Returns the planned offset range for each partition: the log start and
+    /// high watermark at capture time plus the offset this run resumes from.
+    /// The high watermarks provide a consistent snapshot point - all partitions
     /// will backup to the same logical point in time.
     ///
     /// Uses batched ListOffsets requests (one per broker per timestamp) instead
     /// of per-partition requests. For 8,660 partitions across 3 brokers, this
     /// sends ~6 requests instead of ~17,320 (Issue #29).
+    ///
+    /// The progress gauges are sized from the records this run will actually
+    /// fetch, not the whole captured range: an incremental run that resumes
+    /// from checkpoints reports only its new records
+    /// (strimzi-backup-operator#57).
     async fn capture_snapshot_offsets(
         &self,
         topics_metadata: &[TopicMetadata],
-    ) -> Result<HashMap<(String, i32), (i64, i64)>> {
+        start_offset: &StartOffset,
+    ) -> Result<HashMap<(String, i32), SnapshotRange>> {
         info!(
             "Snapshot mode: capturing offsets for {} topics",
             topics_metadata.len()
@@ -830,25 +837,128 @@ impl BackupEngine {
         // Batch fetch all offsets (grouped by leader broker)
         let offsets = self.router.batch_get_all_offsets(&all_partitions).await?;
 
-        let total_records: i64 = offsets
-            .values()
-            .map(|(earliest, latest)| latest - earliest)
-            .sum();
+        let checkpoints = self.load_checkpoints().await?;
+        let ranges = plan_snapshot_ranges(offsets, &checkpoints, start_offset);
+
+        let planned_records: i64 = ranges.values().map(SnapshotRange::planned_records).sum();
+        let captured_records: i64 = ranges.values().map(SnapshotRange::captured_records).sum();
+        let resumed_partitions = ranges
+            .keys()
+            .filter(|key| checkpoints.contains_key(*key))
+            .count();
 
         let snapshot_elapsed_ms = snapshot_start.elapsed().as_millis();
         info!(
-            "snapshot_capture_complete: {} partitions in {}ms ({} total records to backup)",
-            offsets.len(),
+            "snapshot_capture_complete: {} partitions in {}ms ({} records to back up this run, \
+             {} in the captured offset range, {} partitions resuming from a checkpoint)",
+            ranges.len(),
             snapshot_elapsed_ms,
-            total_records
+            planned_records,
+            captured_records,
+            resumed_partitions
         );
 
         if let Some(ref prom) = self.prometheus_metrics {
-            prom.initialize_snapshot_progress(&self.config.backup_id, total_records);
+            prom.initialize_snapshot_progress(&self.config.backup_id, planned_records);
         }
 
-        Ok(offsets)
+        Ok(ranges)
     }
+
+    /// Last checkpointed offset per partition for this backup id (empty without
+    /// an offset store). Read once, in bulk, at snapshot capture time: the store
+    /// has just been loaded and nothing has been written yet, so one query is
+    /// the complete picture — no per-partition lookups for large clusters.
+    async fn load_checkpoints(&self) -> Result<HashMap<(String, i32), i64>> {
+        let Some(ref offset_store) = self.offset_store else {
+            return Ok(HashMap::new());
+        };
+        let checkpoints = offset_store
+            .get_all_offsets(&self.config.backup_id)
+            .await?
+            .into_iter()
+            .map(|info| ((info.topic, info.partition), info.last_offset))
+            .collect();
+        Ok(checkpoints)
+    }
+}
+
+/// Offsets captured for one partition of a snapshot (`stop_at_current_offsets`) run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SnapshotRange {
+    /// Log start offset at capture time.
+    earliest: i64,
+    /// First offset this run fetches: the successor of the checkpointed offset
+    /// when one exists, otherwise the configured start position.
+    start: i64,
+    /// High watermark at capture time; the run stops here.
+    latest: i64,
+}
+
+impl SnapshotRange {
+    /// Offsets this run has to fetch. Zero when the checkpoint already covers
+    /// the captured range (nothing new since the previous run) and never
+    /// negative, even if a checkpoint outlives a recreated topic.
+    fn planned_records(&self) -> i64 {
+        (self.latest - self.start).max(0)
+    }
+
+    /// The whole captured range, whether or not earlier runs archived part of it.
+    fn captured_records(&self) -> i64 {
+        (self.latest - self.earliest).max(0)
+    }
+}
+
+/// Start offset for a partition from the configured `start_offset`, when no
+/// checkpoint exists. For backups `latest` has always meant "start fresh".
+fn configured_start_offset(
+    start_offset: &StartOffset,
+    topic: &str,
+    partition: i32,
+    earliest: i64,
+) -> i64 {
+    match start_offset {
+        StartOffset::Earliest => earliest,
+        StartOffset::Latest => earliest,
+        StartOffset::Specific(map) => map
+            .get(topic)
+            .and_then(|partitions| partitions.get(&partition))
+            .copied()
+            .unwrap_or(earliest),
+    }
+}
+
+/// Turn captured `(earliest, latest)` offsets into the range each partition
+/// will actually fetch this run. A checkpoint takes precedence over the
+/// configured start offset, exactly as `backup_partition` resumes.
+///
+/// A checkpoint below `earliest` (retention moved the log start since the
+/// previous run) is kept as the start: the fetch loop resumes there, hits
+/// OFFSET_OUT_OF_RANGE, records the gap and advances the progress gauge by the
+/// gap span, so counting from the checkpoint keeps target and remaining
+/// consistent.
+fn plan_snapshot_ranges(
+    offsets: HashMap<(String, i32), (i64, i64)>,
+    checkpoints: &HashMap<(String, i32), i64>,
+    start_offset: &StartOffset,
+) -> HashMap<(String, i32), SnapshotRange> {
+    offsets
+        .into_iter()
+        .map(|((topic, partition), (earliest, latest))| {
+            let start = match checkpoints.get(&(topic.clone(), partition)) {
+                Some(last_offset) => last_offset + 1,
+                None => configured_start_offset(start_offset, &topic, partition, earliest),
+            };
+            (
+                (topic, partition),
+                SnapshotRange {
+                    earliest,
+                    start,
+                    latest,
+                },
+            )
+        })
+        .collect()
 }
 
 /// Context for backing up a single partition
@@ -869,64 +979,38 @@ struct BackupPartitionContext {
     kafka_cb: Arc<CircuitBreaker>,
     #[allow(dead_code)] // Reserved for future storage circuit breaker integration
     storage_cb: Arc<CircuitBreaker>,
-    /// Cached earliest offset from snapshot capture.
-    /// When set, avoids a redundant get_offsets() call in backup_partition().
-    earliest_offset: Option<i64>,
-    /// Target offset for snapshot mode (stop_at_current_offsets)
-    /// When set, backup stops when this offset is reached instead of latest
-    target_offset: Option<i64>,
+    /// Planned offset range from snapshot capture (stop_at_current_offsets).
+    /// When set, backup resumes at `start`, stops at `latest` instead of the
+    /// live high watermark, and skips the redundant get_offsets() call.
+    snapshot: Option<SnapshotRange>,
 }
 
 impl BackupPartitionContext {
     async fn backup_partition(self) -> Result<()> {
         debug!("Starting backup of {}:{}", self.topic, self.partition);
 
-        // Use cached offsets from snapshot capture if available (avoids redundant
-        // network calls that serialize through the broker mutex - Issue #29).
-        // In snapshot mode, capture_snapshot_offsets() already fetched both earliest
-        // and latest offsets for all partitions in batched requests.
-        let (earliest, latest) =
-            if let (Some(e), Some(l)) = (self.earliest_offset, self.target_offset) {
-                (e, l)
-            } else {
-                self.router.get_offsets(&self.topic, self.partition).await?
-            };
-
-        // Determine end offset: use snapshot target if set, otherwise current latest
-        // This enables "stop_at_current_offsets" mode for consistent DR snapshots
-        let end_offset = self.target_offset.unwrap_or(latest);
-
-        if self.target_offset.is_some() {
-            debug!(
-                "{}:{}: snapshot mode - target offset {} (current latest: {})",
-                self.topic, self.partition, end_offset, latest
-            );
-        }
-
-        // Determine starting offset
-        let start_offset = if let Some(ref offset_store) = self.offset_store {
-            // Check for saved offset first
-            if let Some(saved) = offset_store
-                .get_offset(&self.backup_id, &self.topic, self.partition)
-                .await?
-            {
-                saved + 1 // Start from next offset
-            } else {
-                self.get_configured_start_offset(earliest)
+        // Snapshot mode: capture_snapshot_offsets() already resolved this
+        // partition's earliest/start/latest in batched requests (avoids
+        // redundant network calls that serialize through the broker mutex -
+        // Issue #29) and sized the progress gauges from the planned start, so
+        // the end offset is the captured high watermark ("stop_at_current_offsets"
+        // for consistent DR snapshots). Otherwise resolve the offsets and the
+        // resume position here.
+        let (earliest, start_offset, end_offset) = match self.snapshot {
+            Some(range) => {
+                debug!(
+                    "{}:{}: snapshot mode - target offset {} (earliest {}, resuming at {})",
+                    self.topic, self.partition, range.latest, range.earliest, range.start
+                );
+                (range.earliest, range.start, range.latest)
             }
-        } else {
-            self.get_configured_start_offset(earliest)
+            None => {
+                let (earliest, latest) =
+                    self.router.get_offsets(&self.topic, self.partition).await?;
+                let start_offset = self.resolve_start_offset(earliest).await?;
+                (earliest, start_offset, latest)
+            }
         };
-
-        // The snapshot target spans earliest..latest. Account immediately for
-        // offsets skipped by the configured start position or an existing
-        // checkpoint, then decrement the remainder as fetches advance.
-        if self.target_offset.is_some() {
-            if let Some(ref prom) = self.prometheus_metrics {
-                let skipped_offsets = start_offset.min(end_offset) - earliest;
-                prom.advance_snapshot_progress(&self.backup_id, skipped_offsets.max(0));
-            }
-        }
 
         // Record consumer lag (how many records we need to catch up)
         let lag = end_offset - start_offset;
@@ -1111,7 +1195,7 @@ impl BackupPartitionContext {
                 prom.inc_records(&self.backup_id, record_count);
                 prom.inc_bytes(&self.backup_id, bytes_processed);
 
-                if self.target_offset.is_some() {
+                if self.snapshot.is_some() {
                     prom.advance_snapshot_progress(
                         &self.backup_id,
                         (next_offset - current_offset).max(0),
@@ -1151,7 +1235,7 @@ impl BackupPartitionContext {
             }
         }
 
-        if self.target_offset.is_some() {
+        if self.snapshot.is_some() {
             info!(
                 "Completed snapshot backup of {}:{} - {} segments (reached target offset {})",
                 self.topic, self.partition, segments_written, end_offset
@@ -1166,16 +1250,23 @@ impl BackupPartitionContext {
         Ok(())
     }
 
-    fn get_configured_start_offset(&self, earliest: i64) -> i64 {
-        match &self.options.start_offset {
-            StartOffset::Earliest => earliest,
-            StartOffset::Latest => earliest, // For backup, latest at start means start fresh
-            StartOffset::Specific(map) => map
-                .get(&self.topic)
-                .and_then(|partitions| partitions.get(&self.partition))
-                .copied()
-                .unwrap_or(earliest),
+    /// Resume position outside snapshot mode: the successor of the checkpointed
+    /// offset when one exists, otherwise the configured start position.
+    async fn resolve_start_offset(&self, earliest: i64) -> Result<i64> {
+        if let Some(ref offset_store) = self.offset_store {
+            if let Some(saved) = offset_store
+                .get_offset(&self.backup_id, &self.topic, self.partition)
+                .await?
+            {
+                return Ok(saved + 1);
+            }
         }
+        Ok(configured_start_offset(
+            &self.options.start_offset,
+            &self.topic,
+            self.partition,
+            earliest,
+        ))
     }
 
     fn segment_key(&self, start_offset: i64) -> String {
@@ -1228,7 +1319,7 @@ impl BackupPartitionContext {
             // The skipped span still counts towards the captured snapshot's
             // remaining offsets, otherwise the progress gauge never reaches
             // zero for a partition that recovered from a gap.
-            if self.target_offset.is_some() {
+            if self.snapshot.is_some() {
                 prom.advance_snapshot_progress(&self.backup_id, span);
             }
         }
@@ -1590,6 +1681,202 @@ fn to_binary_record(record: &BackupRecord, options: &BackupOptions) -> BinaryRec
 mod tests {
     use super::*;
     use crate::manifest::{PartitionBackup, RecordHeader, TopicBackup};
+
+    // ------------------------------------------------------------------
+    // Snapshot planning (strimzi-backup-operator#57)
+    //
+    // `kafka_backup_snapshot_records_target` / `_remaining` must describe the
+    // work of *this* run. An incremental run that resumes from checkpoints
+    // must not start its gauges at the size of the whole archive.
+    // ------------------------------------------------------------------
+
+    fn tp(topic: &str, partition: i32) -> (String, i32) {
+        (topic.to_string(), partition)
+    }
+
+    fn offsets(entries: &[(&str, i32, i64, i64)]) -> HashMap<(String, i32), (i64, i64)> {
+        entries
+            .iter()
+            .map(|(t, p, earliest, latest)| (tp(t, *p), (*earliest, *latest)))
+            .collect()
+    }
+
+    fn checkpoints(entries: &[(&str, i32, i64)]) -> HashMap<(String, i32), i64> {
+        entries
+            .iter()
+            .map(|(t, p, last)| (tp(t, *p), *last))
+            .collect()
+    }
+
+    fn planned_total(ranges: &HashMap<(String, i32), SnapshotRange>) -> i64 {
+        ranges.values().map(SnapshotRange::planned_records).sum()
+    }
+
+    #[test]
+    fn first_run_without_checkpoints_plans_the_full_captured_range() {
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 1_000), ("orders", 1, 250, 1_250)]),
+            &checkpoints(&[]),
+            &StartOffset::Earliest,
+        );
+
+        assert_eq!(
+            ranges[&tp("orders", 0)],
+            SnapshotRange {
+                earliest: 0,
+                start: 0,
+                latest: 1_000
+            }
+        );
+        assert_eq!(
+            ranges[&tp("orders", 1)],
+            SnapshotRange {
+                earliest: 250,
+                start: 250,
+                latest: 1_250
+            }
+        );
+        assert_eq!(planned_total(&ranges), 2_000);
+    }
+
+    #[test]
+    fn incremental_run_plans_only_offsets_after_the_checkpoint() {
+        // Previous run checkpointed offset 899 of 1_000 -> 100 new records.
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 1_000)]),
+            &checkpoints(&[("orders", 0, 899)]),
+            &StartOffset::Earliest,
+        );
+
+        let range = ranges[&tp("orders", 0)];
+        assert_eq!(range.start, 900);
+        assert_eq!(range.planned_records(), 100);
+        assert_eq!(range.captured_records(), 1_000);
+    }
+
+    #[test]
+    fn caught_up_partition_plans_zero_records() {
+        // Checkpoint is the last offset in the log: nothing new since last run.
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 1_000)]),
+            &checkpoints(&[("orders", 0, 999)]),
+            &StartOffset::Earliest,
+        );
+
+        assert_eq!(ranges[&tp("orders", 0)].planned_records(), 0);
+    }
+
+    #[test]
+    fn checkpoint_beyond_the_captured_watermark_never_goes_negative() {
+        // A recreated/truncated topic can leave a checkpoint past the new
+        // high watermark; the plan must clamp instead of counting backwards.
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 100)]),
+            &checkpoints(&[("orders", 0, 5_000)]),
+            &StartOffset::Earliest,
+        );
+
+        assert_eq!(ranges[&tp("orders", 0)].planned_records(), 0);
+        assert_eq!(planned_total(&ranges), 0);
+    }
+
+    #[test]
+    fn retention_gap_since_last_run_counts_from_the_checkpoint() {
+        // Log start moved past the checkpoint: the fetch loop resumes at
+        // checkpoint+1, hits OFFSET_OUT_OF_RANGE, records the gap and advances
+        // the progress gauge by the gap span — so the plan counts from the
+        // checkpoint too, keeping target and remaining consistent.
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 500, 1_000)]),
+            &checkpoints(&[("orders", 0, 99)]),
+            &StartOffset::Earliest,
+        );
+
+        let range = ranges[&tp("orders", 0)];
+        assert_eq!(range.start, 100);
+        assert_eq!(range.planned_records(), 900);
+        assert_eq!(range.captured_records(), 500);
+    }
+
+    #[test]
+    fn checkpoint_wins_over_configured_start_offset() {
+        let mut specific = HashMap::new();
+        specific.insert("orders".to_string(), HashMap::from([(0, 300_i64)]));
+
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 1_000)]),
+            &checkpoints(&[("orders", 0, 599)]),
+            &StartOffset::Specific(specific),
+        );
+
+        assert_eq!(ranges[&tp("orders", 0)].start, 600);
+    }
+
+    #[test]
+    fn configured_specific_offset_applies_without_a_checkpoint() {
+        let mut specific = HashMap::new();
+        specific.insert("orders".to_string(), HashMap::from([(0, 300_i64)]));
+
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 1_000), ("orders", 1, 0, 1_000)]),
+            &checkpoints(&[]),
+            &StartOffset::Specific(specific),
+        );
+
+        // Partition 0 has an explicit start; partition 1 falls back to earliest.
+        assert_eq!(ranges[&tp("orders", 0)].planned_records(), 700);
+        assert_eq!(ranges[&tp("orders", 1)].planned_records(), 1_000);
+        assert_eq!(planned_total(&ranges), 1_700);
+    }
+
+    #[test]
+    fn configured_latest_start_keeps_backup_semantics_of_earliest() {
+        // For backups `latest` has always meant "start fresh from earliest";
+        // planning must match what backup_partition() actually fetches.
+        assert_eq!(
+            configured_start_offset(&StartOffset::Latest, "orders", 0, 42),
+            42
+        );
+        assert_eq!(
+            configured_start_offset(&StartOffset::Earliest, "orders", 0, 42),
+            42
+        );
+    }
+
+    #[test]
+    fn checkpoints_for_other_partitions_do_not_leak() {
+        let ranges = plan_snapshot_ranges(
+            offsets(&[("orders", 0, 0, 100), ("orders", 1, 0, 100)]),
+            &checkpoints(&[("orders", 1, 49), ("payments", 0, 99)]),
+            &StartOffset::Earliest,
+        );
+
+        assert_eq!(ranges[&tp("orders", 0)].planned_records(), 100);
+        assert_eq!(ranges[&tp("orders", 1)].planned_records(), 50);
+        assert_eq!(ranges.len(), 2, "plan covers captured partitions only");
+    }
+
+    #[test]
+    fn mixed_partitions_sum_to_this_runs_work_not_the_archive_size() {
+        // The reporter's shape: a huge archive, a few new records per run.
+        let ranges = plan_snapshot_ranges(
+            offsets(&[
+                ("big", 0, 0, 8_000_000_000),
+                ("big", 1, 0, 8_000_000_000),
+                ("busy", 0, 0, 3_000_000),
+            ]),
+            &checkpoints(&[
+                ("big", 0, 7_999_999_999),
+                ("big", 1, 7_999_999_999),
+                ("busy", 0, 1_999_999),
+            ]),
+            &StartOffset::Earliest,
+        );
+
+        assert_eq!(planned_total(&ranges), 1_000_000);
+        let captured: i64 = ranges.values().map(SnapshotRange::captured_records).sum();
+        assert_eq!(captured, 16_003_000_000);
+    }
 
     fn record_with_headers(headers: Vec<RecordHeader>) -> BackupRecord {
         BackupRecord {

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -284,12 +284,12 @@ impl PrometheusMetrics {
         );
         registry.register(
             "kafka_backup_snapshot_records_target",
-            "Total records in the captured snapshot offset range",
+            "Records this backup run will fetch: the captured snapshot range minus offsets already archived by earlier runs (checkpoints), summed over partitions",
             snapshot_records_target.clone(),
         );
         registry.register(
             "kafka_backup_snapshot_records_remaining",
-            "Records remaining before the captured snapshot target is reached",
+            "Records this backup run has still to fetch before the captured snapshot target is reached",
             snapshot_records_remaining.clone(),
         );
 

--- a/crates/kafka-backup-core/tests/integration_suite/issue_57_incremental_snapshot_target.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_57_incremental_snapshot_target.rs
@@ -1,0 +1,175 @@
+//! strimzi-backup-operator#57 — `kafka_backup_snapshot_records_target` and
+//! `kafka_backup_snapshot_records_remaining` were sized from the whole
+//! captured offset range on every run, so an incremental snapshot backup
+//! (offset store + `stop_at_current_offsets`) with only a handful of new
+//! records still started its gauges at the size of the entire archive. Both
+//! gauges must describe the work of the current run.
+//!
+//! Requires Docker.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, OffsetStorageConfig, SecurityConfig,
+    TopicSelection,
+};
+use kafka_backup_core::metrics::PrometheusMetrics;
+use kafka_backup_core::storage::StorageBackendConfig;
+
+use super::common::{generate_test_records, KafkaTestCluster};
+
+const TOPIC: &str = "issue-57-incremental";
+const BACKUP_ID: &str = "issue-57-backup";
+const PARTITIONS: usize = 3; // KafkaTestCluster::create_topic creates 3 partitions
+
+fn snapshot_config(bootstrap: &str, storage: &TempDir, offset_db: &Path) -> Config {
+    Config {
+        mode: Mode::Backup,
+        backup_id: BACKUP_ID.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bootstrap.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![TOPIC.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem {
+            path: storage.path().to_path_buf(),
+        },
+        backup: Some(BackupOptions {
+            segment_max_bytes: 1024 * 1024,
+            segment_max_interval_ms: 10_000,
+            compression: CompressionType::Zstd,
+            stop_at_current_offsets: true,
+            continuous: false,
+            ..Default::default()
+        }),
+        restore: None,
+        offset_storage: Some(OffsetStorageConfig {
+            db_path: offset_db.to_path_buf(),
+            ..Default::default()
+        }),
+        metrics: None,
+    }
+}
+
+/// Value of the `backup_id`-labelled series for `name` in the rendered
+/// exposition, or `None` when the series was never created.
+fn metric(metrics: &PrometheusMetrics, name: &str) -> Option<i64> {
+    let prefix = format!("{name}{{backup_id=\"{BACKUP_ID}\"}} ");
+    metrics
+        .encode()
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix(&prefix)
+                .map(str::trim)
+                .map(str::to_string)
+        })
+        .map(|value| value.parse().expect("integer metric value"))
+}
+
+fn gauge(metrics: &PrometheusMetrics, name: &str) -> i64 {
+    metric(metrics, name)
+        .unwrap_or_else(|| panic!("{name} was not exported:\n{}", metrics.encode()))
+}
+
+/// One snapshot run with a fresh registry, exactly like a new job pod.
+async fn run_snapshot_backup(config: Config) -> Arc<PrometheusMetrics> {
+    let metrics = Arc::new(PrometheusMetrics::new());
+    let engine = BackupEngine::new_with_metrics(config, Some(Arc::clone(&metrics)))
+        .await
+        .expect("failed to create backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup run failed");
+    metrics
+}
+
+async fn produce(cluster: &KafkaTestCluster, count: usize) {
+    let client = cluster.create_client();
+    client.connect().await.expect("failed to connect");
+    for (i, record) in generate_test_records(count, TOPIC).iter().enumerate() {
+        let partition = (i % PARTITIONS) as i32;
+        client
+            .produce(TOPIC, partition, vec![record.clone()], -1, 30_000)
+            .await
+            .expect("failed to produce");
+    }
+    sleep(Duration::from_secs(2)).await;
+}
+
+/// Three runs against one archive: the first plans the whole topic, the
+/// second only the records produced in between, the third nothing at all.
+/// Before the fix run 2 reported a target of 75 and run 3 of 75 as well.
+#[tokio::test]
+#[ignore] // Requires Docker
+async fn incremental_snapshot_runs_report_only_their_own_records() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let initial_records = 60;
+    cluster
+        .create_topic(TOPIC, initial_records)
+        .await
+        .expect("failed to create topic");
+    sleep(Duration::from_secs(2)).await;
+
+    let storage = TempDir::new().expect("storage dir");
+    let offsets = TempDir::new().expect("offset dir");
+    let offset_db = offsets.path().join("offsets.db");
+    let config = || snapshot_config(&cluster.bootstrap_servers, &storage, &offset_db);
+
+    // Run 1: nothing archived yet, so the whole topic is this run's work.
+    let run1 = run_snapshot_backup(config()).await;
+    assert_eq!(
+        gauge(&run1, "kafka_backup_snapshot_records_target"),
+        initial_records as i64
+    );
+    assert_eq!(gauge(&run1, "kafka_backup_snapshot_records_remaining"), 0);
+    assert_eq!(
+        metric(&run1, "kafka_backup_records_total"),
+        Some(initial_records as i64)
+    );
+
+    // Run 2: only the records produced since run 1 are planned.
+    let new_records = 15;
+    produce(&cluster, new_records).await;
+
+    let run2 = run_snapshot_backup(config()).await;
+    assert_eq!(
+        gauge(&run2, "kafka_backup_snapshot_records_target"),
+        new_records as i64,
+        "target must be this run's records, not the whole archive"
+    );
+    assert_eq!(gauge(&run2, "kafka_backup_snapshot_records_remaining"), 0);
+    assert_eq!(
+        metric(&run2, "kafka_backup_records_total"),
+        Some(new_records as i64),
+        "the run fetched exactly what it planned"
+    );
+
+    // Run 3: nothing new since run 2 — a zero-work run reports 0 / 0.
+    let run3 = run_snapshot_backup(config()).await;
+    assert_eq!(gauge(&run3, "kafka_backup_snapshot_records_target"), 0);
+    assert_eq!(gauge(&run3, "kafka_backup_snapshot_records_remaining"), 0);
+    assert_eq!(
+        metric(&run3, "kafka_backup_records_total"),
+        None,
+        "no records were fetched, so the counter is never created"
+    );
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -14,6 +14,7 @@
 //! - Issue #148: consumer group offsets applied in Phase 3 after restore
 //! - Issue #154: default offset headers are documented, logged, and strippable on restore
 //! - Issue #155: null header values survive backup and restore
+//! - strimzi-backup-operator#57: snapshot progress gauges describe the current run
 
 pub mod common;
 pub mod issue_144_offset_out_of_range;
@@ -22,6 +23,7 @@ pub mod issue_148_offset_reset_after_restore;
 pub mod issue_154_offset_headers;
 pub mod issue_155_null_header_value;
 pub mod issue_56_missing_topic;
+pub mod issue_57_incremental_snapshot_target;
 pub mod issue_67_fixes;
 pub mod offset_semantics;
 pub mod performance_issues;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -658,8 +658,8 @@ metrics:
 |--------|------|-------------|
 | `kafka_backup_lag_records` | Gauge | Consumer lag per topic/partition |
 | `kafka_backup_lag_records_sum` | Gauge | Current lag summed across all partitions |
-| `kafka_backup_snapshot_records_target` | Gauge | Total captured snapshot offset span |
-| `kafka_backup_snapshot_records_remaining` | Gauge | Captured snapshot offset span still to process |
+| `kafka_backup_snapshot_records_target` | Gauge | Records this run will fetch: the captured snapshot range minus offsets already archived by earlier runs (checkpoints) |
+| `kafka_backup_snapshot_records_remaining` | Gauge | Records this run has still to fetch; reaches 0 when the run completes |
 | `kafka_backup_records_total` | Counter | Total records backed up |
 | `kafka_backup_bytes_total` | Counter | Total bytes backed up |
 | `kafka_backup_offset_gaps_total` | Counter | Offset ranges skipped because the source no longer had the records (see [retention gaps](#retention-deleting-data-before-it-is-fetched)) |


### PR DESCRIPTION
Fixes [strimzi-backup-operator#57](https://github.com/osodevops/strimzi-backup-operator/issues/57).

## Problem

`kafka_backup_snapshot_records_target` and `kafka_backup_snapshot_records_remaining` are meant to answer "how far is this finite backup from done?" (`1 - remaining / clamp_min(target, 1)` in the docs). In snapshot mode (`stop_at_current_offsets`) `capture_snapshot_offsets` sized both gauges from the **whole captured offset range** — `Σ (latest − earliest)` — and only subtracted a partition's checkpointed prefix once that partition's task acquired a semaphore permit (`skipped_offsets` in `backup_partition`). For an incremental one-shot (offset store + snapshot mode, the operator's scheduled-backup shape) that means every run starts "remaining" at the size of the **entire archive** and it only creeps down as partitions get around to starting, no matter how little is new. The reporter sees 16.4 B "remaining" on hourly runs that back up 3 M records.

## Reproduction (before the fix)

Operator-driven, in kind, `osodevops/kafka-backup:v0.19.0`, one `KafkaBackup` with `offsetStorage: sqlite` + `stopAtCurrentOffsets: true`, runs triggered from its CronJob, `/metrics` scraped from each run's own pod:

| run | new records | log `snapshot_capture_complete` | `snapshot_records_target` | `records_total` |
|---|---|---|---|---|
| 1 | 10 000 | `10000 total records to backup` | 10 000 | 10 000 |
| 4 | 300 | `10800 total records to backup` | **10 800** | 300 |
| 5 | 0 | `10800 total records to backup` | **10 800** | — |

## Fix

- `plan_snapshot_ranges()` turns the captured `(earliest, latest)` pairs into a `SnapshotRange { earliest, start, latest }` per partition, where `start` is the checkpoint's successor when one exists, else the configured `start_offset` — exactly the resume rule `backup_partition` uses. Checkpoints come from **one** `offset_store.get_all_offsets(backup_id)` at capture time (the store was just loaded and nothing has been written yet), so there are no per-partition lookups for large clusters.
- `target` is initialised from `Σ planned_records()` = `Σ max(latest − start, 0)`; `remaining` counts down from it to `0`. A run with nothing new reports `0` / `0`. Metric names are unchanged, so the documented progress expression keeps working and now shows per-run progress.
- `SnapshotRange` replaces the separate `earliest_offset` / `target_offset` context fields, so the plan and the fetch loop cannot disagree; the per-partition "skipped offsets" adjustment is gone. Non-snapshot mode keeps resolving its resume position per partition (`resolve_start_offset`).
- A checkpoint *below* `earliest` (retention moved the log start since the previous run) is kept as `start`: the fetch loop resumes there, hits OFFSET_OUT_OF_RANGE, records the gap and advances the gauge by the gap span (#144), so counting from the checkpoint keeps target and remaining consistent. A checkpoint *past* the watermark clamps to `0`.
- The `snapshot_capture_complete` log line now reports planned records, the captured range and how many partitions resume from a checkpoint.

Run-scoped semantics match what other backup exporters do (pgBackRest's `backup_delta_bytes` / `backup_total_bytes` for the backup in progress, restic per-run counters).

## Tests

- `backup::engine::tests` (pure, no broker): first run without checkpoints, incremental run, caught-up partition, checkpoint beyond the watermark never negative, retention gap counts from the checkpoint, checkpoint wins over `start_offset: specific`, specific offsets without a checkpoint, `latest` keeps its backup meaning, checkpoints of other partitions don't leak, and the reporter's shape (16 B archive, 1 M new → target 1 M).
- `integration_suite::issue_57_incremental_snapshot_target` (Docker): three runs against one archive with a fresh registry each — 60 → target 60; +15 → target **15** (main: 75) and `records_total` 15; nothing new → `0` / `0`. Passes in 18 s locally.

Local CI checklist: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (310 lib tests) — clean.

Version 0.19.1 (patch: no public API change — `SnapshotRange` and the planning helpers are private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018N17QRtHGqE4EWkqQ2CVyc
