### PR TITLE
docs: reflect 0.18/0.19 header changes, real storage layout and config defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,15 +273,17 @@ kafka-backup three-phase-restore --config restore.yaml
 s3://kafka-backups/
 └── {prefix}/
     └── {backup_id}/
-        ├── manifest.json
-        ├── state/
-        │   └── offsets.db           # SQLite checkpoint
+        ├── manifest.json                    # merged on every save
+        ├── offsets.db                       # SQLite offset store; only with continuous: true or offset_storage:
+        ├── consumer-groups-snapshot.json    # only with backup.consumer_group_snapshot: true
         └── topics/
             └── {topic}/
                 └── partition={id}/
-                    ├── segment-0001.zst
-                    └── segment-0002.zst
+                    ├── segment-00000000000000000000.bin.zst   # named by first offset; .lz4 / no ext for other codecs
+                    └── segment-00000000000000125000.bin.zst
 ```
+
+Header names kafka-backup adds live in `crates/kafka-backup-core/src/offset_headers.rs`.
 
 ## Configuration Format
 
@@ -310,10 +312,11 @@ storage:
   prefix: backups/
 
 backup:
-  compression: zstd | lz4 | gzip | snappy | none
+  compression: zstd | lz4 | none
   segment_max_bytes: 134217728  # 128MB
   checkpoint_interval_secs: 5
-  max_concurrent_partitions: 4
+  max_concurrent_partitions: 8
+  include_offset_headers: true  # default; adds x-original-offset / x-original-timestamp to every archived record
 
 restore:
   time_window_start: 1736899200000  # epoch millis (PITR)
@@ -321,6 +324,7 @@ restore:
   topic_mapping:
     orders: orders-recovered
   consumer_group_strategy: skip | header-based | timestamp-based | cluster-scan | manual
+  strip_offset_headers: false  # true = drop the x-original-*/x-source-* headers the backup added (v0.19.0+)
   dry_run: false
 ```
 
@@ -344,7 +348,7 @@ The project solves the **offset space discontinuity problem** (source cluster of
 ## Three-Phase Restore
 
 For exact consumer offset recovery:
-1. **Phase 1 (Backup):** Store original offset in message headers
+1. **Phase 1 (Backup):** Store original offset in message headers (`include_offset_headers`, default `true`; `restore.strip_offset_headers` is the opt-out on the way back)
 2. **Phase 2 (Restore):** Produce records, track source→target offset mapping
 3. **Phase 3 (Reset):** Apply offset resets using generated mapping
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ storage:
 backup:
   compression: zstd
   segment_max_bytes: 134217728  # 128MB
+  include_offset_headers: true   # default — adds x-original-offset / x-original-timestamp to every archived record
 ```
 
 Run the backup:
@@ -171,7 +172,15 @@ restore:
   # Remap topics (optional)
   topic_mapping:
     orders-prod: orders-recovered
+
+  # Drop the x-original-*/x-source-* headers the backup added, so restored
+  # records are header-for-header identical to the source (v0.19.0+)
+  strip_offset_headers: false
 ```
+
+Records are restored verbatim — keys, values, timestamps and headers, including the
+difference between null and empty values; see
+[Record Fidelity](docs/restore_guide.md#record-fidelity) for details and known limits.
 
 Run the restore:
 ```bash

--- a/config/example-backup-azure.yaml
+++ b/config/example-backup-azure.yaml
@@ -71,7 +71,8 @@ backup:
   checkpoint_interval_secs: 5
   sync_interval_secs: 30
 
-  # Include original offsets for DR scenarios
+  # Offset-tracking headers (default: true) — adds x-original-offset /
+  # x-original-timestamp to every archived record; set false for a verbatim archive
   include_offset_headers: true
   source_cluster_id: "prod-cluster-east"
 

--- a/config/example-backup.yaml
+++ b/config/example-backup.yaml
@@ -51,6 +51,12 @@ backup:
   # Continuous mode (keep running and backing up new data)
   continuous: false  # true for continuous, false for one-shot
 
+  # Offset-tracking headers (default: true). Adds x-original-offset and
+  # x-original-timestamp to every archived record for header-based consumer
+  # offset recovery. Set false for an archive whose records carry only their
+  # original headers (or use restore.strip_offset_headers at restore time).
+  include_offset_headers: true
+
 # Offset storage — enables resumable incremental backups.
 # Used automatically with continuous: true. For one-shot or snapshot mode,
 # add this section explicitly to resume from where the last run stopped.

--- a/config/example-restore-azure.yaml
+++ b/config/example-restore-azure.yaml
@@ -42,7 +42,8 @@ restore:
   #   1: 1
 
   # Consumer group offset handling
-  consumer_group_strategy: skip  # skip | header-based | timestamp-based
+  consumer_group_strategy: skip  # skip | header-based | timestamp-based | cluster-scan | manual
+  # strip_offset_headers: true   # v0.19.0+: drop the x-original-*/x-source-* headers the backup added
 
   # Performance settings
   max_concurrent_partitions: 4

--- a/config/example-restore.yaml
+++ b/config/example-restore.yaml
@@ -85,11 +85,16 @@ restore:
   dry_run: false
 
   # ==========================================
-  # Original Offset Headers
+  # Offset-tracking headers
   # ==========================================
-  # Include original offset as a header in restored records
-  # Headers added: x-original-offset, x-original-timestamp
+  # Add x-original-offset, x-original-timestamp and x-source-partition headers
+  # to every restored record (default: false; implied by header-based strategy).
   include_original_offset_header: true
+
+  # Remove the headers the backup added (x-original-*, x-source-*; the backup
+  # default include_offset_headers: true adds them) before producing, for a
+  # header-for-header identical restore. Default: false. (v0.19.0+)
+  strip_offset_headers: false
 
   # ==========================================
   # Rate Limiting

--- a/config/gssapi-restore.yaml
+++ b/config/gssapi-restore.yaml
@@ -37,6 +37,6 @@ restore:
     smoke-topic: smoke-topic-restored
   consumer_group_strategy: skip
   dry_run: false
-  include_original_offset_header: true
+  include_original_offset_header: true  # default: false; adds x-original-* / x-source-partition headers
   max_concurrent_partitions: 1
   produce_batch_size: 100

--- a/config/test-snapshot-backup.yaml
+++ b/config/test-snapshot-backup.yaml
@@ -20,7 +20,7 @@ backup:
   compression: zstd
   compression_level: 3
   stop_at_current_offsets: true  # Snapshot mode - exit when caught up
-  include_offset_headers: true
+  include_offset_headers: true  # default; adds x-original-* headers to archived records
 
 logging:
   level: info

--- a/crates/kafka-backup-core/README.md
+++ b/crates/kafka-backup-core/README.md
@@ -13,6 +13,7 @@ Core engine for high-performance Kafka backup and restore operations with point-
 - **Consumer offset recovery** - Automatically reset consumer group offsets after restore
 - **High performance** - 100+ MB/s throughput with zstd/lz4 compression
 - **Fault tolerance** - Circuit breaker pattern for resilient operations
+- **Faithful records** - Null vs empty keys, values and header values are preserved (0.18.0+); `restore.strip_offset_headers` gives header-for-header identical restores (0.19.0+)
 
 ## Installation
 
@@ -20,7 +21,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kafka-backup-core = "0.1"
+kafka-backup-core = "0.19"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/Offset_Remapping_Deep_Dive.md
+++ b/docs/Offset_Remapping_Deep_Dive.md
@@ -561,10 +561,11 @@ This is what **Kannika does** and what you should implement:
 
 ```
 PHASE 1: BACKUP
-├─ For each record, store in header:
-│  ├─ x-original-offset: i64
-│  ├─ x-original-timestamp: i64
-│  └─ x-original-partition: i32
+├─ For each record, store in header (on by default: include_offset_headers):
+│  ├─ x-original-offset: i64 (little-endian)
+│  ├─ x-original-timestamp: i64 (little-endian)
+│  └─ x-source-cluster: UTF-8 (only when source_cluster_id is set)
+│  (x-source-partition: i32 is added on the RESTORE side, not here)
 └─ Also backup __consumer_offsets topic (if readable)
 
 PHASE 2: RESTORE
@@ -719,8 +720,9 @@ Update your Restore PRD with this **Consumer Offset Handling** section:
 ### 8.1 Always Use Three-Phase Restore
 
 Phase 1: Backup
-  ✅ Store x-original-offset header on all records
+  ✅ Store x-original-offset header on all records (default: include_offset_headers: true)
   ✅ Store x-original-timestamp header
+  ℹ️  restore.strip_offset_headers: true removes them again for a verbatim restore
   ✅ (Optional) Backup __consumer_offsets topic if readable
 
 Phase 2: Restore
@@ -746,7 +748,11 @@ Phase 3: Offset Reset
 
 ### 8.3 Safety Guarantees
 
-✅ Records are restored with 100% fidelity (no loss/duplication)
+✅ Records are restored with full fidelity (no loss/duplication) — keys, values,
+   timestamps and headers verbatim, including null vs empty (null header values
+   from v0.18.0, see #155). Known limitation: duplicate header keys on one record
+   collapse to the last one (#156). The x-original-* headers are the one
+   deliberate addition; see restore_guide.md → Record Fidelity.
 ✅ Original offsets NEVER conflict with target data
 ✅ Offset reset is reversible (can revert if needed)
 ✅ Consumer groups start from correct position

--- a/docs/Three_Phase_Restore_Guide.md
+++ b/docs/Three_Phase_Restore_Guide.md
@@ -320,7 +320,7 @@ The offset mapping report contains:
 
 ## Safety Guarantees
 
-- **No data loss**: Records are restored with 100% fidelity
+- **No data loss**: Records are restored with full fidelity — see [Record Fidelity](restore_guide.md#record-fidelity) for exactly what is preserved (null vs empty header values from v0.18.0) and the one known limitation (duplicate header keys, [#156](https://github.com/osodevops/kafka-backup/issues/156))
 - **No duplicates**: Each record is produced exactly once
 - **Exact positioning**: Consumer groups resume at the exact logical position
 - **Reversible**: Offset resets can be reverted if needed

--- a/docs/restore_guide.md
+++ b/docs/restore_guide.md
@@ -538,22 +538,27 @@ restore:
   include_original_offset_header: true
 ```
 
-- **Behavior**: Stores original offset in message header `x-original-offset`
+- **Behavior**: Adds the source offset to every restored record as the `x-original-offset` header. The backup itself already archives that header by default (`backup.include_offset_headers: true`), so `header-based` works without any restore-side flag; `include_original_offset_header: true` merely forces the restore-side set on.
 - **Result**: Applications can read the original offset from headers
 - **Use Case**: Exact offset recovery when applications support header-based seeking
 
-**Headers Added:**
+**Headers Added** (values are **binary little-endian**, not strings):
 ```
-x-original-offset: 12345
-x-original-timestamp: 1705312800000
+x-original-offset:    i64 LE, 8 bytes   (e.g. 12345)
+x-original-timestamp: i64 LE, 8 bytes   (epoch ms, e.g. 1705312800000)
+x-source-partition:   i32 LE, 4 bytes   (source partition number)
 ```
 
 **Application-Side Usage (Java):**
 ```java
 ConsumerRecord<String, String> record = ...;
 Header offsetHeader = record.headers().lastHeader("x-original-offset");
-long originalOffset = Long.parseLong(new String(offsetHeader.value()));
+long originalOffset = ByteBuffer.wrap(offsetHeader.value())
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .getLong();
 ```
+
+To restore records *without* any of these headers (header-for-header identical to the source) set `strip_offset_headers: true` — see [Record Fidelity](#record-fidelity).
 
 ### Strategy: Timestamp-Based
 

--- a/docs/storage_api_reference.md
+++ b/docs/storage_api_reference.md
@@ -761,7 +761,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let backend: Arc<dyn StorageBackend> = create_backend_from_config(&config)?;
 
     // 2. Write data
-    let manifest = r#"{"backup_id": "backup-001", "version": 1}"#;
+    let manifest = r#"{"backup_id": "backup-001", "created_at": 1733220000000, "topics": []}"#;
     backend.put("backup-001/manifest.json", Bytes::from(manifest)).await?;
 
     // 3. Check existence


### PR DESCRIPTION
Docs-only sweep after v0.18.0 / v0.19.0 (#157, #158). No files under `crates/` change, so no version bump.

- **`docs/restore_guide.md`** — the header-based strategy's Java sample decoded the binary little-endian `x-original-offset` with `Long.parseLong(new String(v))`, which throws; replaced with `ByteBuffer…LITTLE_ENDIAN.getLong()`. Header list gains `x-source-partition`; notes that the backup already archives the header by default and that `strip_offset_headers` is the opt-out.
- **`docs/Offset_Remapping_Deep_Dive.md`** — `x-original-partition` never existed (backup adds `x-source-cluster`; restore adds `x-source-partition`); the "100% fidelity" guarantee is qualified with the 0.18.0 null-header fix and the #156 duplicate-key limitation. Same qualification in `Three_Phase_Restore_Guide.md`.
- **`CLAUDE.md`** — Storage Data Layout showed a `state/offsets.db` that doesn't exist (the key is `{backup_id}/offsets.db`) and `segment-0001.zst` names (real: `segment-<20-digit start offset>.bin.zst`); compression list dropped `gzip`/`snappy`; backup `max_concurrent_partitions` default is 8; header options added to the config sketch.
- **`README.md`, `crates/kafka-backup-core/README.md`** — examples show `include_offset_headers` (default) and `strip_offset_headers`; core README pinned `kafka-backup-core = "0.1"` → `"0.19"`.
- **`config/*.yaml`** — defaults annotated, `strip_offset_headers` added, strategy lists completed (`cluster-scan`, `manual`).
- **`docs/storage_api_reference.md`** — the sample manifest had a `"version"` field the manifest doesn't have.

Companion PRs: kafka-backup-docs (site) and strimzi-backup-operator#64 (README); operator 1.3.0 exposes the restore header options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya4R9LzZbzFG79JV4FUGxK