### PR TITLE
feat(backup): kafka-backup prune and backup.retention — safe retention for backup sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the filter's name; `restore` and `three-phase-restore` print the counts
   when non-zero. ([#170](https://github.com/osodevops/kafka-backup/issues/170))
 
+- `kafka-backup prune` and `backup.retention` — safe retention for backup
+  sets ([#169](https://github.com/osodevops/kafka-backup/issues/169)).
+  `prune` plans (default) or executes (`--execute`) the deletion of aged
+  (`--older-than 30d` / `--before <ts>`) or oversized (`--max-total-bytes`)
+  segments: only a contiguous oldest-first prefix per partition, never the
+  resume position or the newest `--keep-segments`, manifest rewritten
+  *before* objects are deleted, and every removal recorded as a
+  `pruned` range (`PartitionBackup.pruned`) that `describe`, `validate` and
+  `validate-restore` report without failing. `backup.retention`
+  (`max_age`, `max_total_bytes`, `keep_segments`) runs the same prune at the
+  end of each backup cycle. `prune` refuses while a backup run looks live
+  (offset checkpoint younger than 2 minutes) unless `--force`. New metrics
+  `kafka_backup_segments_pruned_total` and `kafka_backup_bytes_pruned_total`.
+  **Do not use bucket lifecycle rules on incremental backup sets** — they
+  delete segments the manifest still references; the storage guide now
+  explains the failure mode.
+- `SegmentMetadata` gains `sha256` (digest of the stored segment bytes,
+  verified by `validate --deep`) and `uploaded_at` (retention prefers upload
+  time over record time); both empty/zero for segments written by earlier
+  releases.
+- `validate-restore` now HEADs the oldest segment of every selected
+  partition (a canary that catches lifecycle-rule expiry at one request per
+  partition; `restore.dry_run_check_segments: true` sweeps every segment)
+  and fails the dry-run when a referenced segment is missing from storage.
+
 ### Fixed
 - Resumable restores work from a fresh run: with `restore.checkpoint_state`
   set, the engine now seeds the checkpoint file (previously it was only ever
@@ -31,12 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking (library API):** `RestoreOptions` gains the public fields
-  `record_filter` and `record_filter_fingerprint` (both `#[serde(skip)]`;
-  struct-literal construction must set them — the Kubernetes operators
-  construct `RestoreOptions` by struct literal and need a rebuild).
+  `record_filter`, `record_filter_fingerprint` (both `#[serde(skip)]`) and
+  `dry_run_check_segments`; `BackupOptions` gains `retention`;
+  `PartitionBackup` gains `pruned`; `SegmentMetadata` gains `sha256` and
+  `uploaded_at` (struct-literal construction must set them — the Kubernetes
+  operators construct these types by struct literal and need a rebuild).
   `RestoreReport`, `TopicRestoreReport` and `PartitionRestoreReport` gain
-  filter-count fields with serde defaults; existing report JSON stays
-  readable.
+  filter-count fields. All new fields carry serde defaults; existing
+  manifest and report JSON stays readable, and manifests written by 0.21
+  load in older releases minus the new fields.
 
 ## [0.20.0] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -318,15 +318,20 @@ Backups are stored in a structured format:
 s3://kafka-backups/
 └── {prefix}/
     └── {backup_id}/
-        ├── manifest.json           # Backup metadata
-        ├── state/
-        │   └── offsets.db          # Checkpoint state (synced from local)
+        ├── manifest.json                    # topics, partitions, segments, gaps, pruned ranges
+        ├── offsets.db                       # resume state (synced from the local SQLite db)
+        ├── consumer-groups-snapshot.json    # committed offsets captured at backup time
         └── topics/
             └── {topic}/
                 └── partition={id}/
-                    ├── segment-0001.zst
-                    └── segment-0002.zst
+                    ├── segment-00000000000000000000.bin.zst
+                    └── segment-00000000000000012345.bin.zst
 ```
+
+Segment files are `segment-{start_offset:020}.bin` plus the compression
+extension (`.zst`, `.lz4`, or none). Everything above shares the backup
+prefix — see the storage guide before attaching lifecycle rules to it
+(retention belongs to `kafka-backup prune`, not bucket rules).
 
 A local SQLite offset database is maintained at `$TMPDIR/{backup_id}-offsets.db` (configurable via `offset_storage.db_path`) and periodically synced to remote storage for durability. To enable incremental one-shot backups (resume from where the last run stopped), add the `offset_storage` section to your config.
 

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -87,6 +87,17 @@ fn print_manifest_text(manifest: &BackupManifest) {
             )
         );
     }
+    let total_pruned = manifest.total_pruned();
+    if total_pruned > 0 {
+        let pruned_bytes: u64 = manifest.pruned().map(|(_, _, r)| r.bytes).sum();
+        println!(
+            "║ Pruned Ranges:  {:55} ║",
+            format!(
+                "{} ({} bytes deleted by retention)",
+                total_pruned, pruned_bytes
+            )
+        );
+    }
 
     // Calculate total size
     let total_compressed: u64 = manifest
@@ -194,6 +205,17 @@ fn print_manifest_text(manifest: &BackupManifest) {
                     gap.end_offset,
                     gap.offset_span(),
                     gap.reason
+                );
+            }
+            for range in &partition.pruned {
+                println!(
+                    "║     P{}: PRUNED offsets {}..{} ({} segments, {} bytes: {}) ║",
+                    partition.partition_id,
+                    range.start_offset,
+                    range.end_offset,
+                    range.segments,
+                    range.bytes,
+                    range.reason
                 );
             }
         }

--- a/crates/kafka-backup-cli/src/commands/mod.rs
+++ b/crates/kafka-backup-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod offset_mapping;
 pub mod offset_reset;
 pub mod offset_reset_bulk;
 pub mod offset_rollback;
+pub mod prune;
 pub mod restore;
 pub mod sasl_plugin;
 pub mod security_args;

--- a/crates/kafka-backup-cli/src/commands/prune.rs
+++ b/crates/kafka-backup-cli/src/commands/prune.rs
@@ -1,0 +1,188 @@
+//! `kafka-backup prune` — delete aged/oversized segments from a backup set,
+//! safely (issue #169). Plan-only by default; `--execute` performs it.
+
+use anyhow::{bail, Context, Result};
+use kafka_backup_core::backup::prune::{self, PruneCriteria, PrunePlan};
+use kafka_backup_core::manifest::{BackupManifest, PruneReason};
+use kafka_backup_core::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
+use kafka_backup_core::storage::{create_backend, StorageBackend};
+use kafka_backup_core::util::parse_duration;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::storage_path::backend_from_path;
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    older_than: Option<&str>,
+    before: Option<&str>,
+    keep_segments: usize,
+    max_total_bytes: Option<u64>,
+    execute: bool,
+    force: bool,
+    format: &str,
+) -> Result<()> {
+    let (storage, backup_id): (Arc<dyn StorageBackend>, String) = match (config, path, backup_id) {
+        (Some(config_path), None, None) => {
+            let content = tokio::fs::read_to_string(config_path).await?;
+            let content = super::config::expand_env_vars(&content);
+            let cfg = super::config::parse_config(&content)?;
+            (create_backend(&cfg.storage)?, cfg.backup_id)
+        }
+        (None, Some(path), Some(id)) => (backend_from_path(path)?, id.to_string()),
+        _ => bail!("pass either --config, or --path together with --backup-id"),
+    };
+
+    let cutoff = match (older_than, before) {
+        (Some(raw), None) => {
+            let d = parse_duration(raw).context("--older-than")?;
+            Some(chrono::Utc::now().timestamp_millis() - d.as_millis() as i64)
+        }
+        (None, Some(raw)) => Some(parse_rfc3339_or_epoch_ms(raw).context("--before")?),
+        (None, None) => None,
+        (Some(_), Some(_)) => bail!("--older-than and --before are mutually exclusive"),
+    };
+    if cutoff.is_none() && max_total_bytes.is_none() {
+        bail!("nothing to prune: pass --older-than/--before and/or --max-total-bytes");
+    }
+
+    // Load manifest.
+    let manifest_key = format!("{}/manifest.json", backup_id);
+    let manifest_bytes = storage
+        .get(&manifest_key)
+        .await
+        .with_context(|| format!("loading {}", manifest_key))?;
+    let manifest: BackupManifest = serde_json::from_slice(&manifest_bytes)
+        .with_context(|| format!("parsing {}", manifest_key))?;
+
+    // Resume positions + liveness from the remote offsets.db, if present.
+    let offsets_key = format!("{}/offsets.db", backup_id);
+    let mut resume: HashMap<(String, i32), i64> = HashMap::new();
+    let mut newest_checkpoint_ms: Option<i64> = None;
+    if storage.exists(&offsets_key).await.unwrap_or(false) {
+        let tmp = std::env::temp_dir().join(format!(
+            "kafka-backup-prune-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_millis()
+        ));
+        tokio::fs::create_dir_all(&tmp).await?;
+        let store = SqliteOffsetStore::new(OffsetStoreConfig {
+            db_path: tmp.join("offsets.db"),
+            s3_key: Some(offsets_key.clone()),
+            checkpoint_interval_secs: 5,
+            sync_interval_secs: 30,
+        })
+        .await?;
+        store
+            .try_load_from_storage(storage.as_ref(), &offsets_key)
+            .await?;
+        let offsets = store.get_all_offsets(&backup_id).await?;
+        newest_checkpoint_ms = offsets.iter().map(|o| o.checkpoint_ts).max();
+        resume = offsets
+            .into_iter()
+            .map(|o| ((o.topic, o.partition), o.last_offset + 1))
+            .collect();
+        let _ = tokio::fs::remove_dir_all(&tmp).await;
+    }
+
+    // Refuse when a run looks live: a checkpoint younger than 2 minutes
+    // means an active writer could resurrect the manifest we rewrite.
+    if let Some(ts) = newest_checkpoint_ms {
+        let age_ms = chrono::Utc::now().timestamp_millis() - ts;
+        if age_ms < 120_000 && !force {
+            bail!(
+                "a backup run for '{}' looks live (offset checkpoint {}s old); \
+                 re-run when it finishes, or pass --force",
+                backup_id,
+                age_ms / 1000
+            );
+        }
+    }
+
+    let criteria = PruneCriteria {
+        older_than: cutoff,
+        max_total_bytes,
+        keep_segments: keep_segments.max(1),
+    };
+    let plan = prune::plan_prune(
+        &manifest,
+        &resume,
+        &criteria,
+        chrono::Utc::now().timestamp_millis(),
+        PruneReason::Manual,
+    );
+
+    print_plan(&plan, execute, format)?;
+    if plan.segments == 0 {
+        return Ok(());
+    }
+    if !execute {
+        println!("\nDry run — nothing deleted. Re-run with --execute to prune.");
+        return Ok(());
+    }
+
+    prune::execute_prune(storage.as_ref(), manifest, &plan).await?;
+    println!(
+        "\nPruned {} segment(s), {} bytes. Manifest rewritten first; pruned ranges recorded.",
+        plan.segments, plan.bytes
+    );
+    Ok(())
+}
+
+fn parse_rfc3339_or_epoch_ms(raw: &str) -> Result<i64> {
+    if let Ok(ms) = raw.parse::<i64>() {
+        return Ok(ms);
+    }
+    let dt = chrono::DateTime::parse_from_rfc3339(raw)
+        .with_context(|| format!("expected epoch milliseconds or RFC 3339, got '{raw}'"))?;
+    Ok(dt.timestamp_millis())
+}
+
+fn print_plan(plan: &PrunePlan, execute: bool, format: &str) -> Result<()> {
+    if format == "json" {
+        let value = serde_json::json!({
+            "backup_id": plan.backup_id,
+            "execute": execute,
+            "segments": plan.segments,
+            "bytes": plan.bytes,
+            "partitions": plan.partitions.iter().map(|p| serde_json::json!({
+                "topic": p.topic,
+                "partition": p.partition,
+                "segments": p.segments.len(),
+                "bytes": p.range.bytes,
+                "start_offset": p.range.start_offset,
+                "end_offset": p.range.end_offset,
+            })).collect::<Vec<_>>(),
+            "protected_partitions": plan.protected_partitions,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    println!("Prune plan for '{}':", plan.backup_id);
+    if plan.partitions.is_empty() {
+        println!("  nothing to prune");
+    }
+    for p in &plan.partitions {
+        println!(
+            "  {}:{} — {} segment(s), {} bytes, offsets {}..{}",
+            p.topic,
+            p.partition,
+            p.segments.len(),
+            p.range.bytes,
+            p.range.start_offset,
+            p.range.end_offset
+        );
+    }
+    for (topic, partition) in &plan.protected_partitions {
+        println!(
+            "  {}:{} — pruning stopped early to protect the resume position",
+            topic, partition
+        );
+    }
+    println!("Total: {} segment(s), {} bytes", plan.segments, plan.bytes);
+    Ok(())
+}

--- a/crates/kafka-backup-cli/src/commands/prune.rs
+++ b/crates/kafka-backup-cli/src/commands/prune.rs
@@ -62,6 +62,7 @@ pub async fn run(
     let offsets_key = format!("{}/offsets.db", backup_id);
     let mut resume: HashMap<(String, i32), i64> = HashMap::new();
     let mut newest_checkpoint_ms: Option<i64> = None;
+    let mut job_status: Option<String> = None;
     if storage.exists(&offsets_key).await.unwrap_or(false) {
         let tmp = std::env::temp_dir().join(format!(
             "kafka-backup-prune-{}-{}",
@@ -81,6 +82,7 @@ pub async fn run(
             .await?;
         let offsets = store.get_all_offsets(&backup_id).await?;
         newest_checkpoint_ms = offsets.iter().map(|o| o.checkpoint_ts).max();
+        job_status = store.job_status(&backup_id).await?;
         resume = offsets
             .into_iter()
             .map(|o| ((o.topic, o.partition), o.last_offset + 1))
@@ -88,17 +90,22 @@ pub async fn run(
         let _ = tokio::fs::remove_dir_all(&tmp).await;
     }
 
-    // Refuse when a run looks live: a checkpoint younger than 2 minutes
-    // means an active writer could resurrect the manifest we rewrite.
-    if let Some(ts) = newest_checkpoint_ms {
-        let age_ms = chrono::Utc::now().timestamp_millis() - ts;
-        if age_ms < 120_000 && !force {
-            bail!(
-                "a backup run for '{}' looks live (offset checkpoint {}s old); \
-                 re-run when it finishes, or pass --force",
-                backup_id,
-                age_ms / 1000
-            );
+    // Refuse when a run looks live: the job row says "running" (a clean
+    // finish flips it to "completed" before the final sync) AND the offset
+    // checkpoint is younger than 2 minutes — an active writer could
+    // resurrect the manifest we rewrite. A crashed run leaves "running"
+    // with an aging checkpoint, so it stops blocking after 2 minutes.
+    if job_status.as_deref() == Some("running") {
+        if let Some(ts) = newest_checkpoint_ms {
+            let age_ms = chrono::Utc::now().timestamp_millis() - ts;
+            if age_ms < 120_000 && !force {
+                bail!(
+                    "a backup run for '{}' looks live (job status 'running', offset \
+                     checkpoint {}s old); re-run when it finishes, or pass --force",
+                    backup_id,
+                    age_ms / 1000
+                );
+            }
         }
     }
 

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -20,6 +20,9 @@ struct ValidationReport {
     /// knowingly incomplete for these ranges.
     data_gaps: Vec<String>,
     offsets_missing: i64,
+    /// Ranges deliberately deleted by retention (`prune` /
+    /// `backup.retention`). Informational, never an integrity failure.
+    pruned_ranges: Vec<String>,
 }
 
 impl ValidationReport {
@@ -35,6 +38,7 @@ impl ValidationReport {
         println!("Segments Corrupted: {}", self.segments_corrupted);
         println!("Records Validated:  {}", self.records_validated);
         println!("Data Gaps:          {}", self.data_gaps.len());
+        println!("Pruned Ranges:      {}", self.pruned_ranges.len());
 
         if !self.issues.is_empty() {
             println!("\nIssues Found:");
@@ -51,6 +55,13 @@ impl ValidationReport {
             );
             for gap in &self.data_gaps {
                 println!("  - {}", gap);
+            }
+        }
+
+        if !self.pruned_ranges.is_empty() {
+            println!("\nPruned Ranges (deliberately deleted by retention — not data loss):");
+            for range in &self.pruned_ranges {
+                println!("  - {}", range);
             }
         }
 
@@ -122,6 +133,24 @@ pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
             detected
         ));
         report.offsets_missing += gap.offset_span();
+    }
+
+    // Ranges deliberately removed by retention (issue #169).
+    for (topic, partition, range) in manifest.pruned() {
+        let when = chrono::DateTime::from_timestamp_millis(range.pruned_at)
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_else(|| range.pruned_at.to_string());
+        report.pruned_ranges.push(format!(
+            "{}:{} offsets {}..{} ({} segments, {} bytes, {}, pruned {})",
+            topic,
+            partition,
+            range.start_offset,
+            range.end_offset,
+            range.segments,
+            range.bytes,
+            range.reason,
+            when
+        ));
     }
 
     // Validate each segment

--- a/crates/kafka-backup-cli/src/main.rs
+++ b/crates/kafka-backup-cli/src/main.rs
@@ -110,6 +110,54 @@ enum Commands {
         deep: bool,
     },
 
+    /// Delete aged/oversized segments from a backup set, recording the
+    /// pruned ranges in the manifest. Plan-only unless --execute is passed.
+    /// Do NOT use bucket lifecycle rules on incremental backup sets.
+    #[command(
+        after_help = "Examples:\n  kafka-backup prune --config backup.yaml --older-than 30d\n  kafka-backup prune --path s3://bucket/prefix --backup-id daily --before 2026-08-01T00:00:00Z --execute"
+    )]
+    Prune {
+        /// Path to the backup configuration file
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
+        /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
+
+        /// Backup ID to prune
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
+
+        /// Prune segments older than this duration (30d, 12h, 1d12h, ...)
+        #[arg(long, conflicts_with = "before")]
+        older_than: Option<String>,
+
+        /// Prune segments older than this instant (RFC 3339 or epoch ms)
+        #[arg(long)]
+        before: Option<String>,
+
+        /// Never prune a partition below this many newest segments
+        #[arg(long, default_value = "1")]
+        keep_segments: usize,
+
+        /// Keep pruning oldest-first until the set fits under this many compressed bytes
+        #[arg(long)]
+        max_total_bytes: Option<u64>,
+
+        /// Actually delete (default is a dry-run plan)
+        #[arg(long)]
+        execute: bool,
+
+        /// Proceed even when a backup run looks live
+        #[arg(long)]
+        force: bool,
+
+        /// Output format (text, json)
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
+
     /// Show detailed backup manifest (topics, partitions, time ranges, record counts)
     Describe {
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
@@ -541,6 +589,32 @@ async fn main() -> Result<()> {
             deep,
         } => {
             commands::validate::run(&path, &backup_id, deep).await?;
+        }
+        Commands::Prune {
+            config,
+            path,
+            backup_id,
+            older_than,
+            before,
+            keep_segments,
+            max_total_bytes,
+            execute,
+            force,
+            format,
+        } => {
+            commands::prune::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                older_than.as_deref(),
+                before.as_deref(),
+                keep_segments,
+                max_total_bytes,
+                execute,
+                force,
+                &format,
+            )
+            .await?;
         }
         Commands::Describe {
             path,

--- a/crates/kafka-backup-cli/tests/issue_169_prune.rs
+++ b/crates/kafka-backup-cli/tests/issue_169_prune.rs
@@ -1,0 +1,183 @@
+//! End-to-end CLI tests for `kafka-backup prune` (issue #169) against a
+//! fabricated backup set on the filesystem backend.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Three segments per the manifest, with real files on disk. Segment ages
+/// (uploaded_at) are 90, 60 and 1 day(s) old; offsets 0-9, 10-19, 20-29.
+fn create_backup_set(root: &Path, backup_id: &str) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let day = 86_400_000i64;
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+
+    let mut segments = Vec::new();
+    for (idx, (start, end, age_days)) in [(0i64, 9i64, 90i64), (10, 19, 60), (20, 29, 1)]
+        .iter()
+        .enumerate()
+    {
+        let name = format!("segment-{:020}.bin.zst", start);
+        let payload = format!("fake-segment-{idx}");
+        fs::write(seg_dir.join(&name), &payload).unwrap();
+        segments.push(serde_json::json!({
+            "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+            "start_offset": start,
+            "end_offset": end,
+            "start_timestamp": now - age_days * day,
+            "end_timestamp": now - age_days * day,
+            "record_count": end - start + 1,
+            "uncompressed_size": payload.len() * 4,
+            "compressed_size": payload.len(),
+            "uploaded_at": now - age_days * day,
+        }));
+    }
+
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 90 * day,
+        "compression": "zstd",
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": segments}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn run_kafka_backup(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn segment_files(root: &Path, backup_id: &str) -> Vec<String> {
+    let mut names: Vec<String> =
+        fs::read_dir(root.join(backup_id).join("topics/orders/partition=0"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn prune_is_a_plan_only_dry_run_by_default() {
+    let temp = tempfile::tempdir().unwrap();
+    create_backup_set(temp.path(), "daily");
+    let path = temp.path().to_str().unwrap().to_string();
+
+    let output = run_kafka_backup(&[
+        "prune",
+        "--path",
+        &path,
+        "--backup-id",
+        "daily",
+        "--older-than",
+        "30d",
+    ]);
+    let text = output_text(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("Dry run — nothing deleted"), "{text}");
+    assert!(text.contains("2 segment(s)"), "{text}");
+    assert_eq!(segment_files(temp.path(), "daily").len(), 3, "{text}");
+}
+
+#[test]
+fn prune_execute_deletes_segments_and_records_the_range() {
+    let temp = tempfile::tempdir().unwrap();
+    create_backup_set(temp.path(), "daily");
+    let path = temp.path().to_str().unwrap().to_string();
+
+    let output = run_kafka_backup(&[
+        "prune",
+        "--path",
+        &path,
+        "--backup-id",
+        "daily",
+        "--older-than",
+        "30d",
+        "--execute",
+    ]);
+    let text = output_text(&output);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("Pruned 2 segment(s)"), "{text}");
+
+    // The two old segment files are gone; the newest remains.
+    let remaining = segment_files(temp.path(), "daily");
+    assert_eq!(
+        remaining,
+        vec!["segment-00000000000000000020.bin.zst"],
+        "{text}"
+    );
+
+    // Manifest: one segment left, pruned range 0..19 recorded.
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(temp.path().join("daily/manifest.json")).unwrap())
+            .unwrap();
+    let partition = &manifest["topics"][0]["partitions"][0];
+    assert_eq!(partition["segments"].as_array().unwrap().len(), 1);
+    let pruned = &partition["pruned"][0];
+    assert_eq!(pruned["start_offset"], 0);
+    assert_eq!(pruned["end_offset"], 19);
+    assert_eq!(pruned["reason"], "manual");
+
+    // A second run is a no-op.
+    let output2 = run_kafka_backup(&[
+        "prune",
+        "--path",
+        &path,
+        "--backup-id",
+        "daily",
+        "--older-than",
+        "30d",
+        "--execute",
+    ]);
+    let text2 = output_text(&output2);
+    assert!(output2.status.success(), "{text2}");
+    assert!(text2.contains("nothing to prune"), "{text2}");
+
+    // validate still passes (pruned is informational) and mentions the range.
+    let validate = run_kafka_backup(&["validate", "--path", &path, "--backup-id", "daily"]);
+    let vtext = output_text(&validate);
+    assert!(validate.status.success(), "{vtext}");
+    assert!(
+        vtext.contains("Pruned Ranges (deliberately deleted"),
+        "{vtext}"
+    );
+
+    // describe shows it too.
+    let describe = run_kafka_backup(&["describe", "--path", &path, "--backup-id", "daily"]);
+    let dtext = output_text(&describe);
+    assert!(describe.status.success(), "{dtext}");
+    assert!(dtext.contains("PRUNED offsets 0..19"), "{dtext}");
+}
+
+#[test]
+fn prune_requires_a_criterion_and_exclusive_arguments() {
+    let temp = tempfile::tempdir().unwrap();
+    create_backup_set(temp.path(), "daily");
+    let path = temp.path().to_str().unwrap().to_string();
+
+    let output = run_kafka_backup(&["prune", "--path", &path, "--backup-id", "daily"]);
+    let text = output_text(&output);
+    assert!(!output.status.success(), "{text}");
+    assert!(text.contains("nothing to prune"), "{text}");
+}

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -13,7 +13,9 @@ use crate::config::{BackupOptions, CompressionType, Config, Mode, StartOffset, T
 use crate::error::KafkaError;
 use crate::health::HealthCheck;
 use crate::kafka::{ConfigResourceType, PartitionLeaderRouter, TopicMetadata};
-use crate::manifest::{BackupManifest, BackupRecord, OffsetGap, OffsetGapReason, SegmentMetadata};
+use crate::manifest::{
+    BackupManifest, BackupRecord, OffsetGap, OffsetGapReason, PartitionBackup, SegmentMetadata,
+};
 use crate::metrics::{ErrorType, PerformanceMetrics, PrometheusMetrics};
 use crate::offset_headers;
 use crate::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
@@ -569,6 +571,16 @@ impl BackupEngine {
             // Save manifest periodically
             self.save_manifest().await?;
 
+            // Apply backup.retention (issue #169): prune aged/oversized
+            // segments from this backup set. Runs each cycle in continuous
+            // mode, once for one-shot/snapshot runs. Non-fatal: a failed
+            // prune must not fail the backup that just succeeded.
+            if let Some(retention) = &backup_opts.retention {
+                if let Err(e) = self.apply_retention(retention).await {
+                    warn!("Retention prune failed (non-fatal): {}", e);
+                }
+            }
+
             // Optionally snapshot consumer group offsets (Issue #67 bug 5/6)
             if backup_opts.consumer_group_snapshot {
                 if let Err(e) = self.snapshot_consumer_groups().await {
@@ -601,6 +613,54 @@ impl BackupEngine {
             info!("Backup completed successfully");
         }
 
+        Ok(())
+    }
+
+    /// Apply `backup.retention` to this backup set: plan against the
+    /// in-memory manifest, remove the planned segments from it, persist the
+    /// manifest (manifest first, so a crash leaves orphan objects rather
+    /// than a manifest referencing deleted segments), then delete the
+    /// objects.
+    async fn apply_retention(&self, retention: &crate::config::RetentionOptions) -> Result<()> {
+        let criteria = retention.to_criteria()?;
+        let resume = match &self.offset_store {
+            Some(store) => {
+                super::prune::resume_positions(store.as_ref(), &self.config.backup_id).await?
+            }
+            None => std::collections::HashMap::new(),
+        };
+
+        let plan = {
+            let manifest = self.manifest.lock().await;
+            super::prune::plan_prune(
+                &manifest,
+                &resume,
+                &criteria,
+                chrono::Utc::now().timestamp_millis(),
+                crate::manifest::PruneReason::Retention,
+            )
+        };
+        if plan.segments == 0 {
+            return Ok(());
+        }
+
+        info!(
+            "Retention: pruning {} segment(s), {} bytes across {} partition(s)",
+            plan.segments,
+            plan.bytes,
+            plan.partitions.len()
+        );
+
+        {
+            let mut manifest = self.manifest.lock().await;
+            super::prune::apply_plan_to_manifest(&mut manifest, &plan);
+        }
+        self.manifest_persistence.save_now().await?;
+        super::prune::delete_planned_segments(self.storage.as_ref(), &plan).await;
+
+        if let Some(ref prom) = self.prometheus_metrics {
+            prom.record_segments_pruned(&self.config.backup_id, plan.segments, plan.bytes);
+        }
         Ok(())
     }
 
@@ -1566,6 +1626,27 @@ fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> Bac
                     .iter_mut()
                     .find(|p| p.partition_id == cur_part.partition_id)
                 {
+                    // Pruned ranges are unioned FIRST: a segment either side
+                    // recorded as deliberately deleted must never come back,
+                    // even when the other side's in-memory manifest still
+                    // lists it (e.g. a run that pruned mid-flight, or a prune
+                    // that raced this run's save).
+                    for range in cur_part.pruned.clone() {
+                        ex_part.add_pruned(range);
+                    }
+                    let inside_pruned = |seg: &SegmentMetadata, part: &PartitionBackup| {
+                        part.pruned.iter().any(|r| {
+                            seg.start_offset >= r.start_offset && seg.end_offset <= r.end_offset
+                        })
+                    };
+                    ex_part.segments = {
+                        let pruned_view = ex_part.clone();
+                        ex_part
+                            .segments
+                            .drain(..)
+                            .filter(|seg| !inside_pruned(seg, &pruned_view))
+                            .collect()
+                    };
                     // Merge segments: deduplicate by key and start_offset; existing wins
                     let mut seen_keys: HM<String, ()> = ex_part
                         .segments
@@ -1578,6 +1659,9 @@ fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> Bac
                         .map(|s| (s.start_offset, ()))
                         .collect();
                     for seg in cur_part.segments {
+                        if inside_pruned(&seg, ex_part) {
+                            continue;
+                        }
                         if !seen_keys.contains_key(&seg.key)
                             && !seen_offsets.contains_key(&seg.start_offset)
                         {
@@ -2219,6 +2303,8 @@ mod tests {
             record_count: end_offset - start_offset + 1,
             uncompressed_size: 0,
             compressed_size: 0,
+            sha256: String::new(),
+            uploaded_at: 0,
         }
     }
 
@@ -2227,6 +2313,7 @@ mod tests {
             partition_id: id,
             segments,
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }
     }
 
@@ -2570,6 +2657,105 @@ mod tests {
             reason: OffsetGapReason::OffsetOutOfRange,
             detected_at: 1_700_000_000_000,
         }
+    }
+
+    #[test]
+    fn merge_keeps_pruned_ranges_and_does_not_resurrect_pruned_segments() {
+        use crate::manifest::{PruneReason, PrunedRange};
+        let range = PrunedRange {
+            start_offset: 0,
+            end_offset: 9,
+            segments: 1,
+            bytes: 100,
+            pruned_at: 5,
+            cutoff_timestamp: 4,
+            reason: PruneReason::Retention,
+        };
+
+        // Existing (stored) manifest: segment pruned away, range recorded.
+        let mut existing_part = make_partition(0, vec![make_segment("k2", 10, 19)]);
+        existing_part.add_pruned(range.clone());
+        let existing = {
+            let mut m = BackupManifest::new("b".to_string());
+            m.topics.push(make_topic("t", Some(1), vec![existing_part]));
+            m
+        };
+
+        // Current (in-memory) manifest of a still-running process: it wrote
+        // the pruned segment this run and still lists it.
+        let current = {
+            let mut m = BackupManifest::new("b".to_string());
+            m.topics.push(make_topic(
+                "t",
+                Some(1),
+                vec![make_partition(
+                    0,
+                    vec![make_segment("k1", 0, 9), make_segment("k2", 10, 19)],
+                )],
+            ));
+            m
+        };
+
+        let merged = merge_manifests(existing, current);
+        let partition = &merged.topics[0].partitions[0];
+        assert_eq!(partition.pruned, vec![range]);
+        assert_eq!(
+            partition
+                .segments
+                .iter()
+                .map(|s| s.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["k2"],
+            "the pruned segment must not be resurrected by the merge"
+        );
+    }
+
+    #[test]
+    fn merge_drops_existing_segments_inside_a_newly_pruned_range() {
+        use crate::manifest::{PruneReason, PrunedRange};
+        let range = PrunedRange {
+            start_offset: 0,
+            end_offset: 9,
+            segments: 1,
+            bytes: 100,
+            pruned_at: 5,
+            cutoff_timestamp: 4,
+            reason: PruneReason::Manual,
+        };
+
+        // Existing (stored) manifest still lists the segment; the current
+        // side (an engine that pruned in memory) carries the range.
+        let existing = {
+            let mut m = BackupManifest::new("b".to_string());
+            m.topics.push(make_topic(
+                "t",
+                Some(1),
+                vec![make_partition(
+                    0,
+                    vec![make_segment("k1", 0, 9), make_segment("k2", 10, 19)],
+                )],
+            ));
+            m
+        };
+        let current = {
+            let mut part = make_partition(0, vec![make_segment("k2", 10, 19)]);
+            part.add_pruned(range);
+            let mut m = BackupManifest::new("b".to_string());
+            m.topics.push(make_topic("t", Some(1), vec![part]));
+            m
+        };
+
+        let merged = merge_manifests(existing, current);
+        let partition = &merged.topics[0].partitions[0];
+        assert_eq!(
+            partition
+                .segments
+                .iter()
+                .map(|s| s.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["k2"]
+        );
+        assert_eq!(partition.pruned.len(), 1);
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -616,11 +616,16 @@ impl BackupEngine {
         Ok(())
     }
 
-    /// Apply `backup.retention` to this backup set: plan against the
-    /// in-memory manifest, remove the planned segments from it, persist the
-    /// manifest (manifest first, so a crash leaves orphan objects rather
-    /// than a manifest referencing deleted segments), then delete the
-    /// objects.
+    /// Apply `backup.retention` to this backup set.
+    ///
+    /// Plans against the STORED (merged) manifest — the in-memory manifest of
+    /// a fresh process only holds segments this run wrote, while the aged
+    /// segments retention exists for live in the merged manifest that
+    /// `save_manifest()` just persisted. The stored manifest is rewritten
+    /// first (a crash leaves orphan objects, never a manifest referencing
+    /// deleted segments), the pruned ranges are mirrored into the in-memory
+    /// manifest so later saves cannot resurrect the segments, and only then
+    /// are the objects deleted.
     async fn apply_retention(&self, retention: &crate::config::RetentionOptions) -> Result<()> {
         let criteria = retention.to_criteria()?;
         let resume = match &self.offset_store {
@@ -630,16 +635,21 @@ impl BackupEngine {
             None => std::collections::HashMap::new(),
         };
 
-        let plan = {
-            let manifest = self.manifest.lock().await;
-            super::prune::plan_prune(
-                &manifest,
-                &resume,
-                &criteria,
-                chrono::Utc::now().timestamp_millis(),
-                crate::manifest::PruneReason::Retention,
-            )
+        // Load the merged manifest that save_manifest() just wrote.
+        let key = format!("{}/manifest.json", self.config.backup_id);
+        let stored: BackupManifest = match self.storage.get(&key).await {
+            Ok(data) => serde_json::from_slice(&data)
+                .map_err(|e| Error::Config(format!("retention: manifest unparseable: {e}")))?,
+            Err(_) => return Ok(()), // nothing persisted yet
         };
+
+        let plan = super::prune::plan_prune(
+            &stored,
+            &resume,
+            &criteria,
+            chrono::Utc::now().timestamp_millis(),
+            crate::manifest::PruneReason::Retention,
+        );
         if plan.segments == 0 {
             return Ok(());
         }
@@ -651,12 +661,21 @@ impl BackupEngine {
             plan.partitions.len()
         );
 
+        // Mirror the pruned ranges (and drop any affected segments) into the
+        // in-memory manifest FIRST, so a concurrent/subsequent save merges
+        // consistently instead of resurrecting.
         {
             let mut manifest = self.manifest.lock().await;
             super::prune::apply_plan_to_manifest(&mut manifest, &plan);
+            for part_plan in &plan.partitions {
+                let topic = manifest.get_or_create_topic(&part_plan.topic);
+                let partition = topic.get_or_create_partition(part_plan.partition);
+                partition.add_pruned(part_plan.range.clone());
+            }
         }
-        self.manifest_persistence.save_now().await?;
-        super::prune::delete_planned_segments(self.storage.as_ref(), &plan).await;
+
+        // Rewrite the stored manifest directly, then delete the objects.
+        super::prune::execute_prune(self.storage.as_ref(), stored, &plan).await?;
 
         if let Some(ref prom) = self.prometheus_metrics {
             prom.record_segments_pruned(&self.config.backup_id, plan.segments, plan.bytes);

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -721,15 +721,18 @@ impl BackupEngine {
     }
 
     async fn finalize(&self) -> Result<()> {
-        // Final checkpoint
+        // Final checkpoint. The job status flips to "completed" BEFORE the
+        // remote sync, so the copy of offsets.db in storage records that the
+        // run finished — tools like `kafka-backup prune` read it to decide
+        // whether a run is still live.
         if let Some(ref offset_store) = self.offset_store {
             offset_store.checkpoint().await?;
-            if let Some(ref offset_persistence) = self.offset_persistence {
-                offset_persistence.sync_now().await?;
-            }
             offset_store
                 .update_job_status(&self.config.backup_id, "completed")
                 .await?;
+            if let Some(ref offset_persistence) = self.offset_persistence {
+                offset_persistence.sync_now().await?;
+            }
         }
 
         // Save final manifest

--- a/crates/kafka-backup-core/src/backup/mod.rs
+++ b/crates/kafka-backup-core/src/backup/mod.rs
@@ -1,5 +1,6 @@
 //! Backup engine module.
 
 mod engine;
+pub mod prune;
 
 pub use engine::BackupEngine;

--- a/crates/kafka-backup-core/src/backup/prune.rs
+++ b/crates/kafka-backup-core/src/backup/prune.rs
@@ -1,0 +1,490 @@
+//! Retention for backup sets: plan and execute the deletion of aged or
+//! oversized segments from an incremental backup, recording every removed
+//! range in the manifest (issue #169).
+//!
+//! Bucket lifecycle rules must NOT be used on an incremental backup set —
+//! they delete segments the manifest still references and never expire the
+//! manifest itself. This module is the safe replacement: manifest first,
+//! object deletion second, and a [`PrunedRange`] left behind so
+//! `describe`/`validate`/`restore` can explain the hole.
+
+use std::collections::HashMap;
+
+use tracing::{debug, warn};
+
+use crate::manifest::{BackupManifest, PruneReason, PrunedRange, SegmentMetadata};
+use crate::offset_store::OffsetStore;
+use crate::storage::StorageBackend;
+use crate::{Error, Result};
+
+/// What to prune.
+#[derive(Debug, Clone, Default)]
+pub struct PruneCriteria {
+    /// Prune segments whose newest record (or upload time, when recorded) is
+    /// older than this (epoch milliseconds).
+    pub older_than: Option<i64>,
+    /// After the age pass, keep pruning oldest-first until the set's total
+    /// compressed size fits under this many bytes.
+    pub max_total_bytes: Option<u64>,
+    /// Never prune a partition below this many newest segments (minimum 1).
+    pub keep_segments: usize,
+}
+
+/// One partition's slice of a [`PrunePlan`].
+#[derive(Debug, Clone)]
+pub struct PartitionPrunePlan {
+    pub topic: String,
+    pub partition: i32,
+    /// Segments to delete, oldest first (a prefix of the partition's list).
+    pub segments: Vec<SegmentMetadata>,
+    /// The manifest entry recording the removal.
+    pub range: PrunedRange,
+}
+
+/// A concrete, explainable prune decision.
+#[derive(Debug, Clone, Default)]
+pub struct PrunePlan {
+    pub backup_id: String,
+    pub partitions: Vec<PartitionPrunePlan>,
+    /// Total segments to delete.
+    pub segments: u64,
+    /// Total compressed bytes to delete.
+    pub bytes: u64,
+    /// Partitions where pruning stopped early to protect the resume position.
+    pub protected_partitions: Vec<(String, i32)>,
+}
+
+/// The effective age of a segment for retention purposes: upload time when
+/// recorded (0.21+), else the newest record timestamp.
+fn segment_age_basis(segment: &SegmentMetadata) -> i64 {
+    if segment.uploaded_at > 0 {
+        segment.uploaded_at
+    } else {
+        segment.end_timestamp
+    }
+}
+
+/// Resume positions (`last_offset + 1`) per (topic, partition) from the
+/// backup's offset store; a segment containing or after the resume position
+/// is never pruned.
+pub async fn resume_positions(
+    store: &dyn OffsetStore,
+    backup_id: &str,
+) -> Result<HashMap<(String, i32), i64>> {
+    let offsets = store.get_all_offsets(backup_id).await?;
+    Ok(offsets
+        .into_iter()
+        .map(|o| ((o.topic, o.partition), o.last_offset + 1))
+        .collect())
+}
+
+/// Plan a prune of `manifest` under `criteria`.
+///
+/// Per partition (segments sorted by `start_offset`), only a *prefix* of the
+/// segment list is ever pruned — no holes mid-partition. A segment is
+/// prunable when:
+/// - it is older than `older_than` (when set),
+/// - it is not among the newest `keep_segments` segments,
+/// - its `end_offset` is below the partition's resume position (when known;
+///   with no offset store the newest segment is always protected).
+///
+/// `max_total_bytes` then continues pruning oldest-first across the whole
+/// set until the total fits, under the same protections.
+pub fn plan_prune(
+    manifest: &BackupManifest,
+    resume: &HashMap<(String, i32), i64>,
+    criteria: &PruneCriteria,
+    now_ms: i64,
+    reason: PruneReason,
+) -> PrunePlan {
+    let keep_segments = criteria.keep_segments.max(1);
+    let mut plan = PrunePlan {
+        backup_id: manifest.backup_id.clone(),
+        ..Default::default()
+    };
+
+    // Per partition: the age-pruned prefix, plus the contiguous tail of
+    // further prunable segments the size pass may extend into.
+    let mut prefixes: Vec<(String, i32, Vec<SegmentMetadata>)> = Vec::new();
+    let mut size_candidates: Vec<(String, i32, SegmentMetadata)> = Vec::new();
+    let mut total_compressed: u64 = 0;
+
+    for topic in &manifest.topics {
+        for partition in &topic.partitions {
+            let mut segments = partition.segments.clone();
+            segments.sort_by_key(|s| s.start_offset);
+            total_compressed += segments.iter().map(|s| s.compressed_size).sum::<u64>();
+            let resume_offset = resume
+                .get(&(topic.name.clone(), partition.partition_id))
+                .copied();
+            let max_prunable = segments.len().saturating_sub(keep_segments);
+
+            let safe = |segment: &SegmentMetadata| match resume_offset {
+                Some(resume) => segment.end_offset < resume,
+                // Without an offset store there is no resume position to
+                // protect; keep_segments >= 1 already protects the newest.
+                None => true,
+            };
+
+            let mut prefix: Vec<SegmentMetadata> = Vec::new();
+            let mut still_prunable = true;
+            for (idx, segment) in segments.iter().enumerate() {
+                if idx >= max_prunable || !safe(segment) {
+                    if idx < max_prunable && !safe(segment) {
+                        plan.protected_partitions
+                            .push((topic.name.clone(), partition.partition_id));
+                    }
+                    still_prunable = false;
+                    break;
+                }
+                let old_enough = matches!(criteria.older_than, Some(cutoff) if segment_age_basis(segment) < cutoff);
+                if old_enough {
+                    prefix.push(segment.clone());
+                } else {
+                    // Age prefix ends here; anything further is only
+                    // reachable by the size pass, contiguously.
+                    break;
+                }
+            }
+            if still_prunable {
+                for (idx, segment) in segments.iter().enumerate().skip(prefix.len()) {
+                    if idx >= max_prunable || !safe(segment) {
+                        break;
+                    }
+                    size_candidates.push((
+                        topic.name.clone(),
+                        partition.partition_id,
+                        segment.clone(),
+                    ));
+                }
+            }
+            prefixes.push((topic.name.clone(), partition.partition_id, prefix));
+        }
+    }
+
+    // Size cap: keep pruning globally oldest-first, extending each
+    // partition's prefix contiguously, until the total fits.
+    if let Some(cap) = criteria.max_total_bytes {
+        let age_pruned: u64 = prefixes
+            .iter()
+            .flat_map(|(_, _, p)| p)
+            .map(|s| s.compressed_size)
+            .sum();
+        let mut remaining_total = total_compressed.saturating_sub(age_pruned);
+        size_candidates.sort_by_key(|(_, _, s)| segment_age_basis(s));
+        for (topic, partition, segment) in size_candidates {
+            if remaining_total <= cap {
+                break;
+            }
+            let Some((_, _, prefix)) = prefixes
+                .iter_mut()
+                .find(|(t, p, _)| *t == topic && *p == partition)
+            else {
+                continue;
+            };
+            // Contiguity: only extend with the segment directly after the
+            // current prefix (candidates were collected in offset order).
+            let expected_next = prefix.last().map(|s| s.end_offset);
+            let contiguous = match expected_next {
+                Some(prev_end) => segment.start_offset > prev_end,
+                None => true,
+            };
+            // Candidates for a partition arrive in order, so the first
+            // unconsumed one is always the contiguous next; later ones only
+            // apply once the earlier ones were taken.
+            if !contiguous {
+                continue;
+            }
+            remaining_total = remaining_total.saturating_sub(segment.compressed_size);
+            prefix.push(segment);
+        }
+    }
+
+    // Materialise partition plans.
+    for (topic, partition, segments) in prefixes {
+        if segments.is_empty() {
+            continue;
+        }
+        let bytes: u64 = segments.iter().map(|s| s.compressed_size).sum();
+        let range = PrunedRange {
+            start_offset: segments.first().map(|s| s.start_offset).unwrap_or(0),
+            end_offset: segments.last().map(|s| s.end_offset).unwrap_or(0),
+            segments: segments.len() as u32,
+            bytes,
+            pruned_at: now_ms,
+            cutoff_timestamp: criteria.older_than.unwrap_or(0),
+            reason,
+        };
+        plan.segments += segments.len() as u64;
+        plan.bytes += bytes;
+        plan.partitions.push(PartitionPrunePlan {
+            topic,
+            partition,
+            segments,
+            range,
+        });
+    }
+    plan
+}
+
+/// Remove the planned segments from `manifest` and record the pruned ranges.
+pub fn apply_plan_to_manifest(manifest: &mut BackupManifest, plan: &PrunePlan) {
+    for part_plan in &plan.partitions {
+        let Some(topic) = manifest
+            .topics
+            .iter_mut()
+            .find(|t| t.name == part_plan.topic)
+        else {
+            continue;
+        };
+        let Some(partition) = topic
+            .partitions
+            .iter_mut()
+            .find(|p| p.partition_id == part_plan.partition)
+        else {
+            continue;
+        };
+        let doomed: std::collections::HashSet<&str> =
+            part_plan.segments.iter().map(|s| s.key.as_str()).collect();
+        partition
+            .segments
+            .retain(|s| !doomed.contains(s.key.as_str()));
+        partition.add_pruned(part_plan.range.clone());
+    }
+}
+
+/// Delete the planned segment objects, tolerating already-missing keys —
+/// the manifest was rewritten first, so a partial failure leaves harmless
+/// orphans that a retry or `--sweep-orphans` removes.
+pub async fn delete_planned_segments(storage: &dyn StorageBackend, plan: &PrunePlan) {
+    for part_plan in &plan.partitions {
+        for segment in &part_plan.segments {
+            match storage.delete(&segment.key).await {
+                Ok(()) => debug!("Pruned segment {}", segment.key),
+                Err(e) => warn!(
+                    "Could not delete pruned segment {} (continuing; the manifest no longer \
+                     references it): {}",
+                    segment.key, e
+                ),
+            }
+        }
+    }
+}
+
+/// Execute `plan` against a stored manifest: rewrite `{backup_id}/manifest.json`
+/// directly (never via the merge path — a union merge would resurrect the
+/// removed entries), then delete the objects.
+pub async fn execute_prune(
+    storage: &dyn StorageBackend,
+    mut manifest: BackupManifest,
+    plan: &PrunePlan,
+) -> Result<BackupManifest> {
+    if plan.segments == 0 {
+        return Ok(manifest);
+    }
+    apply_plan_to_manifest(&mut manifest, plan);
+    let key = format!("{}/manifest.json", manifest.backup_id);
+    let json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| Error::Config(format!("serialize manifest: {e}")))?;
+    storage.put(&key, bytes::Bytes::from(json)).await?;
+    delete_planned_segments(storage, plan).await;
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::PartitionBackup;
+
+    fn seg(start: i64, end: i64, uploaded_at: i64, bytes: u64) -> SegmentMetadata {
+        SegmentMetadata {
+            key: format!("b/topics/t/partition=0/segment-{:020}.bin.zst", start),
+            start_offset: start,
+            end_offset: end,
+            start_timestamp: start * 1000,
+            end_timestamp: end * 1000,
+            record_count: end - start + 1,
+            uncompressed_size: bytes * 4,
+            compressed_size: bytes,
+            sha256: String::new(),
+            uploaded_at,
+        }
+    }
+
+    fn manifest(segments: Vec<SegmentMetadata>) -> BackupManifest {
+        let mut m = BackupManifest::new("b".to_string());
+        let topic = m.get_or_create_topic("t");
+        topic.original_partition_count = Some(1);
+        topic.partitions = vec![PartitionBackup {
+            partition_id: 0,
+            segments,
+            gaps: Vec::new(),
+            pruned: Vec::new(),
+        }];
+        m
+    }
+
+    fn resume(offset: i64) -> HashMap<(String, i32), i64> {
+        HashMap::from([(("t".to_string(), 0), offset)])
+    }
+
+    const DAY_MS: i64 = 86_400_000;
+
+    #[test]
+    fn plan_prunes_only_an_aged_prefix_and_respects_keep_segments() {
+        let now = 100 * DAY_MS;
+        let m = manifest(vec![
+            seg(0, 9, 10 * DAY_MS, 100),
+            seg(10, 19, 20 * DAY_MS, 100),
+            seg(20, 29, 95 * DAY_MS, 100), // too new
+            seg(30, 39, 96 * DAY_MS, 100),
+        ]);
+        let plan = plan_prune(
+            &m,
+            &resume(1_000),
+            &PruneCriteria {
+                older_than: Some(now - 30 * DAY_MS),
+                max_total_bytes: None,
+                keep_segments: 1,
+            },
+            now,
+            PruneReason::Manual,
+        );
+        assert_eq!(plan.segments, 2);
+        assert_eq!(plan.bytes, 200);
+        let range = &plan.partitions[0].range;
+        assert_eq!((range.start_offset, range.end_offset), (0, 19));
+    }
+
+    #[test]
+    fn plan_never_prunes_at_or_past_the_resume_position() {
+        let now = 100 * DAY_MS;
+        let m = manifest(vec![
+            seg(0, 9, 10 * DAY_MS, 100),
+            seg(10, 19, 11 * DAY_MS, 100),
+            seg(20, 29, 12 * DAY_MS, 100),
+        ]);
+        // Resume inside the second segment: only the first is safe.
+        let plan = plan_prune(
+            &m,
+            &resume(15),
+            &PruneCriteria {
+                older_than: Some(now),
+                max_total_bytes: None,
+                keep_segments: 1,
+            },
+            now,
+            PruneReason::Retention,
+        );
+        assert_eq!(plan.segments, 1);
+        assert_eq!(plan.partitions[0].range.end_offset, 9);
+        assert_eq!(plan.protected_partitions, vec![("t".to_string(), 0)]);
+    }
+
+    #[test]
+    fn plan_without_offsets_db_still_keeps_the_newest_segment() {
+        let now = 100 * DAY_MS;
+        let m = manifest(vec![seg(0, 9, DAY_MS, 100), seg(10, 19, DAY_MS, 100)]);
+        let plan = plan_prune(
+            &m,
+            &HashMap::new(),
+            &PruneCriteria {
+                older_than: Some(now),
+                max_total_bytes: None,
+                keep_segments: 1,
+            },
+            now,
+            PruneReason::Manual,
+        );
+        assert_eq!(plan.segments, 1);
+    }
+
+    #[test]
+    fn size_cap_extends_the_prefix_oldest_first() {
+        let now = 100 * DAY_MS;
+        let m = manifest(vec![
+            seg(0, 9, 10 * DAY_MS, 100),
+            seg(10, 19, 20 * DAY_MS, 100),
+            seg(20, 29, 30 * DAY_MS, 100),
+            seg(30, 39, 90 * DAY_MS, 100),
+        ]);
+        // No age cutoff; cap forces two oldest out (400 total, cap 200,
+        // newest protected by keep_segments).
+        let plan = plan_prune(
+            &m,
+            &resume(1_000),
+            &PruneCriteria {
+                older_than: None,
+                max_total_bytes: Some(200),
+                keep_segments: 1,
+            },
+            now,
+            PruneReason::Retention,
+        );
+        assert_eq!(plan.segments, 2);
+        assert_eq!(plan.partitions[0].range.end_offset, 19);
+    }
+
+    #[test]
+    fn old_segments_without_uploaded_at_fall_back_to_record_time() {
+        let now = 100 * DAY_MS;
+        let m = manifest(vec![seg(0, 9, 0, 100), seg(10, 19, 0, 100)]);
+        // end_timestamp = end_offset * 1000 — ancient; both eligible, newest kept.
+        let plan = plan_prune(
+            &m,
+            &resume(1_000),
+            &PruneCriteria {
+                older_than: Some(now),
+                max_total_bytes: None,
+                keep_segments: 1,
+            },
+            now,
+            PruneReason::Manual,
+        );
+        assert_eq!(plan.segments, 1);
+    }
+
+    #[tokio::test]
+    async fn execute_writes_manifest_before_deleting_and_tolerates_missing_objects() {
+        use crate::storage::{MemoryBackend, StorageBackend};
+        let storage = MemoryBackend::new();
+        let m = manifest(vec![
+            seg(0, 9, 1, 100),
+            seg(10, 19, 2, 100),
+            seg(20, 29, 3, 100),
+        ]);
+        // Only the first segment's object exists; the second is already gone.
+        storage
+            .put(
+                &m.topics[0].partitions[0].segments[0].key,
+                bytes::Bytes::from("x"),
+            )
+            .await
+            .unwrap();
+        let plan = plan_prune(
+            &m,
+            &resume(1_000),
+            &PruneCriteria {
+                older_than: Some(i64::MAX),
+                max_total_bytes: None,
+                keep_segments: 1,
+            },
+            4,
+            PruneReason::Manual,
+        );
+        assert_eq!(plan.segments, 2);
+        let updated = execute_prune(&storage, m, &plan).await.unwrap();
+        assert_eq!(updated.topics[0].partitions[0].segments.len(), 1);
+        assert_eq!(updated.topics[0].partitions[0].pruned.len(), 1);
+        // Manifest in storage matches.
+        let stored = storage.get("b/manifest.json").await.unwrap();
+        let parsed: BackupManifest = serde_json::from_slice(&stored).unwrap();
+        assert_eq!(parsed.total_pruned(), 1);
+        assert_eq!(parsed.total_segments(), 1);
+        // The deleted object is gone.
+        assert!(!storage
+            .exists(&plan.partitions[0].segments[0].key)
+            .await
+            .unwrap());
+    }
+}

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -531,6 +531,72 @@ pub struct BackupOptions {
     /// recommended for compliance and disaster-recovery jobs.
     #[serde(default)]
     pub require_topic_configs: bool,
+
+    /// Retention for this backup set: prune aged/oversized segments at the
+    /// end of each backup cycle (see `kafka-backup prune` for the on-demand
+    /// form). Off by default. Bucket lifecycle rules must NOT be used on an
+    /// incremental set — see the storage guide.
+    #[serde(default)]
+    pub retention: Option<RetentionOptions>,
+}
+
+/// Retention policy for a backup set (issue #169).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RetentionOptions {
+    /// Prune segments older than this human-readable duration (`30d`, `12h`,
+    /// `1d12h`, …). Deviates from the `_secs` convention deliberately:
+    /// `2592000` is not a number a reviewer can read, and the operator's
+    /// `retention.maxAge` already uses this grammar.
+    #[serde(default)]
+    pub max_age: Option<String>,
+
+    /// After the age pass, keep pruning oldest-first until the set's total
+    /// compressed size fits under this many bytes (compressed sizes).
+    #[serde(default)]
+    pub max_total_bytes: Option<u64>,
+
+    /// Never prune a partition below this many newest segments.
+    #[serde(default = "default_keep_segments")]
+    pub keep_segments: usize,
+}
+
+fn default_keep_segments() -> usize {
+    1
+}
+
+impl RetentionOptions {
+    /// Convert to prune criteria, resolving `max_age` against "now".
+    pub fn to_criteria(&self) -> crate::Result<crate::backup::prune::PruneCriteria> {
+        let older_than = match &self.max_age {
+            Some(raw) => {
+                let d = crate::util::parse_duration(raw)?;
+                Some(chrono::Utc::now().timestamp_millis() - d.as_millis() as i64)
+            }
+            None => None,
+        };
+        Ok(crate::backup::prune::PruneCriteria {
+            older_than,
+            max_total_bytes: self.max_total_bytes,
+            keep_segments: self.keep_segments.max(1),
+        })
+    }
+
+    pub fn validate(&self) -> crate::Result<()> {
+        if let Some(raw) = &self.max_age {
+            crate::util::parse_duration(raw)?;
+        }
+        if self.max_age.is_none() && self.max_total_bytes.is_none() {
+            return Err(crate::Error::Config(
+                "backup.retention requires max_age and/or max_total_bytes".to_string(),
+            ));
+        }
+        if self.keep_segments == 0 {
+            return Err(crate::Error::Config(
+                "backup.retention.keep_segments must be >= 1".to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn default_capture_topic_configs() -> bool {
@@ -572,6 +638,7 @@ impl Default for BackupOptions {
             segment_max_records: None,
             capture_topic_configs: default_capture_topic_configs(),
             require_topic_configs: false,
+            retention: None,
         }
     }
 }
@@ -878,6 +945,14 @@ pub struct RestoreOptions {
     #[serde(skip)]
     pub header_preflight_external: bool,
 
+    /// During `validate-restore` / dry-run, HEAD every segment in the
+    /// selected time window instead of only the oldest per partition (the
+    /// default canary, which catches lifecycle-rule expiry at
+    /// one-request-per-partition cost). Full sweeps can take a long time on
+    /// large archives. Default: `false`.
+    #[serde(default)]
+    pub dry_run_check_segments: bool,
+
     /// Programmatic per-record filter (Keep / Drop / Tombstone), consulted on
     /// every restore path after time-window filtering. Set by code — e.g. an
     /// embedding application or a commercial distribution — never from YAML.
@@ -959,6 +1034,7 @@ impl Default for RestoreOptions {
             schema_id_mapping: Default::default(),
             header_preflight: HeaderPreflightMode::default(),
             header_preflight_external: false,
+            dry_run_check_segments: false,
             record_filter: None,
             record_filter_fingerprint: None,
         }
@@ -1091,6 +1167,10 @@ impl BackupOptions {
             return Err(crate::Error::Config(
                 "max_concurrent_partitions must be > 0".to_string(),
             ));
+        }
+
+        if let Some(retention) = &self.retention {
+            retention.validate()?;
         }
 
         Ok(())

--- a/crates/kafka-backup-core/src/lib.rs
+++ b/crates/kafka-backup-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod offset_store;
 pub mod restore;
 pub mod segment;
 pub mod storage;
+pub mod util;
 pub mod validation;
 
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitState};

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -79,6 +79,26 @@ impl BackupManifest {
     /// Zero means the backup captured every offset it set out to. Non-zero
     /// means the source no longer had some records by the time they were
     /// fetched, and this backup is knowingly incomplete for those ranges.
+    /// Total pruned ranges across all partitions.
+    pub fn total_pruned(&self) -> usize {
+        self.topics
+            .iter()
+            .flat_map(|t| &t.partitions)
+            .map(|p| p.pruned.len())
+            .sum()
+    }
+
+    /// Iterate every pruned range with its topic and partition.
+    pub fn pruned(&self) -> impl Iterator<Item = (&str, i32, &PrunedRange)> {
+        self.topics.iter().flat_map(|t| {
+            t.partitions.iter().flat_map(move |p| {
+                p.pruned
+                    .iter()
+                    .map(move |range| (t.name.as_str(), p.partition_id, range))
+            })
+        })
+    }
+
     pub fn total_gaps(&self) -> usize {
         self.topics
             .iter()
@@ -141,6 +161,7 @@ impl TopicBackup {
                 partition_id,
                 segments: Vec::new(),
                 gaps: Vec::new(),
+                pruned: Vec::new(),
             });
         }
         self.partitions
@@ -166,6 +187,14 @@ pub struct PartitionBackup {
     /// as an empty list. Sorted by `start_offset`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gaps: Vec<OffsetGap>,
+
+    /// Offset ranges deliberately deleted from this backup by retention
+    /// (`kafka-backup prune` / `backup.retention` — see [`PrunedRange`]).
+    /// Unlike [`gaps`](Self::gaps), these were captured and later removed on
+    /// purpose; `validate`/`describe` report them without failing. Sorted by
+    /// `start_offset`; omitted from JSON when empty (absent before 0.21).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pruned: Vec<PrunedRange>,
 }
 
 impl PartitionBackup {
@@ -191,6 +220,72 @@ impl PartitionBackup {
         }
         self.gaps.push(gap);
         self.gaps.sort_by_key(|g| g.start_offset);
+    }
+
+    /// Record a pruned range, keeping `pruned` sorted and free of duplicates
+    /// (same rule as [`add_gap`](Self::add_gap): manifest merges must not
+    /// double-count a range).
+    pub fn add_pruned(&mut self, range: PrunedRange) {
+        if self
+            .pruned
+            .iter()
+            .any(|p| p.start_offset == range.start_offset)
+        {
+            return;
+        }
+        self.pruned.push(range);
+        self.pruned.sort_by_key(|p| p.start_offset);
+    }
+}
+
+/// A contiguous range of offsets deliberately deleted from a backup by
+/// retention (`kafka-backup prune` or `backup.retention`).
+///
+/// The segments covering `[start_offset, end_offset]` were captured and then
+/// removed on purpose; the range is recorded so `describe`/`validate` can
+/// explain the hole and `restore` can distinguish "pruned" from "lost".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrunedRange {
+    /// First pruned offset (inclusive).
+    pub start_offset: i64,
+
+    /// Last pruned offset (inclusive — matches `SegmentMetadata.end_offset`).
+    pub end_offset: i64,
+
+    /// Number of segments deleted for this range.
+    pub segments: u32,
+
+    /// Compressed bytes deleted for this range.
+    pub bytes: u64,
+
+    /// When the prune ran (epoch milliseconds).
+    pub pruned_at: i64,
+
+    /// The age cutoff the prune used (epoch milliseconds; `0` for a purely
+    /// size-based prune).
+    pub cutoff_timestamp: i64,
+
+    /// Why the range was pruned.
+    pub reason: PruneReason,
+}
+
+/// Why a [`PrunedRange`] was recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum PruneReason {
+    /// `backup.retention` applied at the end of a backup run.
+    Retention,
+    /// An operator ran `kafka-backup prune`.
+    Manual,
+}
+
+impl std::fmt::Display for PruneReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PruneReason::Retention => write!(f, "retention"),
+            PruneReason::Manual => write!(f, "manual"),
+        }
     }
 }
 
@@ -277,6 +372,18 @@ pub struct SegmentMetadata {
     /// Compressed size in bytes
     #[serde(default)]
     pub compressed_size: u64,
+
+    /// SHA-256 of the stored segment bytes (header + compressed data + CRC
+    /// footer), hex-encoded. Written since 0.21; empty for older segments.
+    /// `validate --deep` verifies it when present.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub sha256: String,
+
+    /// When the segment was written to storage (epoch milliseconds). `0` for
+    /// segments written before 0.21. Retention prefers this over
+    /// `end_timestamp` (which is producer record time) when present.
+    #[serde(default)]
+    pub uploaded_at: i64,
 }
 
 impl SegmentMetadata {
@@ -1412,6 +1519,86 @@ mod tests {
             !json.contains("gaps"),
             "a backup with no gaps must not advertise a gaps field: {json}"
         );
+    }
+
+    fn pruned_range(start: i64, end: i64) -> PrunedRange {
+        PrunedRange {
+            start_offset: start,
+            end_offset: end,
+            segments: 2,
+            bytes: 2048,
+            pruned_at: 1_700_000_000_000,
+            cutoff_timestamp: 1_699_000_000_000,
+            reason: PruneReason::Retention,
+        }
+    }
+
+    #[test]
+    fn pruned_range_serde_round_trip() {
+        let range = pruned_range(0, 19);
+        let json = serde_json::to_string(&range).unwrap();
+        assert!(json.contains("\"reason\":\"retention\""), "{json}");
+        let back: PrunedRange = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, range);
+    }
+
+    #[test]
+    fn empty_pruned_is_omitted_from_json() {
+        let partition = PartitionBackup {
+            partition_id: 0,
+            segments: Vec::new(),
+            gaps: Vec::new(),
+            pruned: Vec::new(),
+        };
+        let json = serde_json::to_string(&partition).unwrap();
+        assert!(!json.contains("pruned"), "{json}");
+    }
+
+    #[test]
+    fn add_pruned_dedups_by_start_and_sorts() {
+        let mut partition = PartitionBackup {
+            partition_id: 0,
+            segments: Vec::new(),
+            gaps: Vec::new(),
+            pruned: Vec::new(),
+        };
+        partition.add_pruned(pruned_range(20, 29));
+        partition.add_pruned(pruned_range(0, 19));
+        partition.add_pruned(pruned_range(0, 25)); // duplicate start ignored
+        assert_eq!(partition.pruned.len(), 2);
+        assert_eq!(partition.pruned[0].start_offset, 0);
+        assert_eq!(partition.pruned[0].end_offset, 19);
+        assert_eq!(partition.pruned[1].start_offset, 20);
+    }
+
+    #[test]
+    fn manifest_written_before_pruned_and_sha256_existed_still_parses() {
+        // A 0.20-era segment/partition: no pruned, no sha256, no uploaded_at.
+        let legacy = r#"{
+            "backup_id": "legacy",
+            "created_at": 1700000000000,
+            "compression": "zstd",
+            "topics": [{
+                "name": "orders",
+                "partitions": [{
+                    "partition_id": 0,
+                    "segments": [{
+                        "key": "legacy/topics/orders/partition=0/segment-00000000000000000000.bin.zst",
+                        "start_offset": 0,
+                        "end_offset": 9,
+                        "start_timestamp": 1,
+                        "end_timestamp": 2,
+                        "record_count": 10
+                    }]
+                }]
+            }]
+        }"#;
+        let manifest: BackupManifest = serde_json::from_str(legacy).unwrap();
+        let segment = &manifest.topics[0].partitions[0].segments[0];
+        assert_eq!(segment.sha256, "");
+        assert_eq!(segment.uploaded_at, 0);
+        assert!(manifest.topics[0].partitions[0].pruned.is_empty());
+        assert_eq!(manifest.total_pruned(), 0);
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -86,6 +86,13 @@ pub struct PrometheusMetrics {
     /// bound on records permanently missing from the backup.
     pub offsets_skipped_total: Family<BackupLabels, Counter>,
 
+    /// Segments deliberately deleted by retention (`prune` /
+    /// `backup.retention`). Each increment is one segment removed.
+    pub segments_pruned_total: Family<BackupLabels, Counter>,
+
+    /// Cumulative compressed bytes deleted by retention.
+    pub bytes_pruned_total: Family<BackupLabels, Counter>,
+
     // ========================================
     // Operation Duration Metrics
     // ========================================
@@ -212,6 +219,8 @@ impl PrometheusMetrics {
         let bytes_total = Family::<BackupLabels, Counter>::default();
         let offset_gaps_total = Family::<BackupLabels, Counter>::default();
         let offsets_skipped_total = Family::<BackupLabels, Counter>::default();
+        let segments_pruned_total = Family::<BackupLabels, Counter>::default();
+        let bytes_pruned_total = Family::<BackupLabels, Counter>::default();
 
         // Operation Duration Metrics
         let backup_duration_seconds =
@@ -323,6 +332,16 @@ impl PrometheusMetrics {
             "kafka_backup_offsets_skipped",
             "Cumulative source offsets skipped across all recorded gaps",
             offsets_skipped_total.clone(),
+        );
+        registry.register(
+            "kafka_backup_segments_pruned",
+            "Segments deliberately deleted by retention (prune / backup.retention)",
+            segments_pruned_total.clone(),
+        );
+        registry.register(
+            "kafka_backup_bytes_pruned",
+            "Cumulative compressed bytes deleted by retention",
+            bytes_pruned_total.clone(),
         );
 
         // Operation Duration Metrics
@@ -440,6 +459,8 @@ impl PrometheusMetrics {
             bytes_total,
             offset_gaps_total,
             offsets_skipped_total,
+            segments_pruned_total,
+            bytes_pruned_total,
             backup_duration_seconds,
             restore_duration_seconds,
             storage_write_latency_seconds,
@@ -608,6 +629,15 @@ impl PrometheusMetrics {
         self.offsets_skipped_total
             .get_or_create(&labels)
             .inc_by(offsets_skipped.max(0) as u64);
+    }
+
+    /// Record segments deleted by retention.
+    pub fn record_segments_pruned(&self, backup_id: &str, segments: u64, bytes: u64) {
+        let labels = BackupLabels::new(backup_id);
+        self.segments_pruned_total
+            .get_or_create(&labels)
+            .inc_by(segments);
+        self.bytes_pruned_total.get_or_create(&labels).inc_by(bytes);
     }
 
     /// Increment cumulative bytes counter.

--- a/crates/kafka-backup-core/src/offset_store/sqlite.rs
+++ b/crates/kafka-backup-core/src/offset_store/sqlite.rs
@@ -98,6 +98,19 @@ impl SqliteOffsetStore {
         Ok(())
     }
 
+    /// Status of the backup job row for `backup_id` (`running`/`completed`),
+    /// or `None` when no run ever registered. Read by `kafka-backup prune`
+    /// to decide whether a run is still live.
+    pub async fn job_status(&self, backup_id: &str) -> Result<Option<String>> {
+        let pool = self.pool.read().await;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM backup_jobs WHERE backup_id = ?")
+                .bind(backup_id)
+                .fetch_optional(&*pool)
+                .await?;
+        Ok(row.map(|(status,)| status))
+    }
+
     /// Try to load database from storage if local doesn't exist
     pub async fn try_load_from_storage(
         &self,

--- a/crates/kafka-backup-core/src/restore/engine.rs
+++ b/crates/kafka-backup-core/src/restore/engine.rs
@@ -552,7 +552,55 @@ impl RestoreEngine {
                     .collect();
 
                 if segments.is_empty() {
+                    if !partition_backup.pruned.is_empty() {
+                        report.warnings.push(format!(
+                            "{}:{}: all segments in the selected window were pruned by retention",
+                            topic_backup.name, partition_backup.partition_id
+                        ));
+                    }
                     continue;
+                }
+
+                // Storage existence checks: the oldest overlapping segment is
+                // always checked (bucket lifecycle rules expire oldest-first,
+                // so this canary catches a wiped archive at one request per
+                // partition); dry_run_check_segments sweeps every segment.
+                let to_check: Vec<&SegmentMetadata> = if restore_options.dry_run_check_segments {
+                    segments.iter().map(|s| &**s).collect()
+                } else {
+                    segments.first().map(|s| &**s).into_iter().collect()
+                };
+                for segment in to_check {
+                    match self.storage.exists(&segment.key).await {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            report.valid = false;
+                            report.errors.push(format!(
+                                "segment missing from storage: {} (deleted by a bucket \
+                                 lifecycle rule? use `kafka-backup prune` instead — see the \
+                                 storage guide)",
+                                segment.key
+                            ));
+                        }
+                        Err(e) => {
+                            report
+                                .warnings
+                                .push(format!("could not check segment {}: {}", segment.key, e));
+                        }
+                    }
+                }
+
+                for range in &partition_backup.pruned {
+                    report.warnings.push(format!(
+                        "{}:{}: offsets {}..{} were pruned by retention on {}",
+                        topic_backup.name,
+                        partition_backup.partition_id,
+                        range.start_offset,
+                        range.end_offset,
+                        chrono::DateTime::from_timestamp_millis(range.pruned_at)
+                            .map(|dt| dt.to_rfc3339())
+                            .unwrap_or_else(|| range.pruned_at.to_string())
+                    ));
                 }
 
                 let mut partition_records = 0i64;

--- a/crates/kafka-backup-core/src/restore/helpers.rs
+++ b/crates/kafka-backup-core/src/restore/helpers.rs
@@ -302,6 +302,8 @@ mod tests {
                 record_count: 2,
                 uncompressed_size: json.len() as u64,
                 compressed_size: 0,
+                sha256: String::new(),
+                uploaded_at: 0,
             };
 
             let out = read_segment(&storage, &segment)

--- a/crates/kafka-backup-core/src/segment/writer.rs
+++ b/crates/kafka-backup-core/src/segment/writer.rs
@@ -102,6 +102,18 @@ impl SegmentFlusher {
 
         let compressed_size = segment.len();
 
+        // Digest of the exact bytes stored, for manifest-level integrity
+        // (verified by `validate --deep`) and safe retention bookkeeping.
+        let sha256 = {
+            use sha2::{Digest, Sha256};
+            let digest = Sha256::digest(&segment);
+            digest
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        };
+        let uploaded_at = chrono::Utc::now().timestamp_millis();
+
         // Write to storage
         self.storage.put(&sealed.key, Bytes::from(segment)).await?;
 
@@ -140,6 +152,8 @@ impl SegmentFlusher {
             record_count: sealed.record_count as i64,
             uncompressed_size: uncompressed_size as u64,
             compressed_size: compressed_size as u64,
+            sha256,
+            uploaded_at,
         };
 
         info!(

--- a/crates/kafka-backup-core/src/storage/config.rs
+++ b/crates/kafka-backup-core/src/storage/config.rs
@@ -142,6 +142,19 @@ impl StorageBackendConfig {
                     .find(|(k, _)| k == "path_style")
                     .map(|(_, v)| v == "true")
                     .unwrap_or(false);
+                // Plain-HTTP endpoints (in-cluster MinIO/Ceph RGW) need
+                // allow_http or the S3 client refuses to build; an explicit
+                // `allow_http=true` query param works too, and an
+                // `endpoint=http://…` implies it (issue #166).
+                let allow_http = parsed
+                    .query_pairs()
+                    .find(|(k, _)| k == "allow_http")
+                    .map(|(_, v)| v == "true")
+                    .unwrap_or_else(|| {
+                        endpoint
+                            .as_deref()
+                            .is_some_and(|e| e.starts_with("http://"))
+                    });
 
                 Ok(Self::S3 {
                     bucket,
@@ -151,7 +164,7 @@ impl StorageBackendConfig {
                     secret_key: std::env::var("AWS_SECRET_ACCESS_KEY").ok(),
                     prefix,
                     path_style,
-                    allow_http: false,
+                    allow_http,
                 })
             }
             "azure" | "az" => {
@@ -264,6 +277,48 @@ mod tests {
     fn test_memory_url_parsing() {
         let config = StorageBackendConfig::from_url("memory://").unwrap();
         assert!(matches!(config, StorageBackendConfig::Memory));
+    }
+
+    #[test]
+    fn from_url_s3_http_endpoint_implies_allow_http() {
+        let config = StorageBackendConfig::from_url(
+            "s3://bucket/prefix?endpoint=http://minio:9000&path_style=true",
+        )
+        .unwrap();
+        match config {
+            StorageBackendConfig::S3 {
+                allow_http,
+                path_style,
+                endpoint,
+                ..
+            } => {
+                assert!(allow_http, "http:// endpoint must imply allow_http");
+                assert!(path_style);
+                assert_eq!(endpoint.as_deref(), Some("http://minio:9000"));
+            }
+            _ => panic!("expected S3"),
+        }
+
+        // Explicit override wins in both directions.
+        let off = StorageBackendConfig::from_url(
+            "s3://bucket?endpoint=http://minio:9000&allow_http=false",
+        )
+        .unwrap();
+        match off {
+            StorageBackendConfig::S3 { allow_http, .. } => assert!(!allow_http),
+            _ => panic!("expected S3"),
+        }
+        let on = StorageBackendConfig::from_url("s3://bucket?allow_http=true").unwrap();
+        match on {
+            StorageBackendConfig::S3 { allow_http, .. } => assert!(allow_http),
+            _ => panic!("expected S3"),
+        }
+        let https =
+            StorageBackendConfig::from_url("s3://bucket?endpoint=https://s3.example").unwrap();
+        match https {
+            StorageBackendConfig::S3 { allow_http, .. } => assert!(!allow_http),
+            _ => panic!("expected S3"),
+        }
     }
 
     #[test]

--- a/crates/kafka-backup-core/src/util.rs
+++ b/crates/kafka-backup-core/src/util.rs
@@ -1,0 +1,114 @@
+//! Small shared utilities.
+
+use crate::Error;
+
+/// Parse a human duration like `30d`, `12h`, `45m`, `3600s`, `500ms`, `2w`,
+/// or a concatenation (`1d12h`). Bare integers are rejected — every duration
+/// in the configuration carries its unit, either in the field name (`_secs`,
+/// `_ms`) or, here, in the value.
+pub fn parse_duration(input: &str) -> crate::Result<std::time::Duration> {
+    let s = input.trim();
+    if s.is_empty() {
+        return Err(Error::Config("duration must not be empty".to_string()));
+    }
+
+    let mut total_ms: u128 = 0;
+    let mut number = String::new();
+    let mut chars = s.chars().peekable();
+    let mut parsed_any = false;
+
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() {
+            number.push(c);
+            chars.next();
+            continue;
+        }
+        if number.is_empty() {
+            return Err(Error::Config(format!(
+                "invalid duration '{input}': expected a number before '{c}'"
+            )));
+        }
+        let mut unit = String::new();
+        while let Some(&u) = chars.peek() {
+            if u.is_ascii_alphabetic() {
+                unit.push(u);
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        let value: u128 = number
+            .parse()
+            .map_err(|_| Error::Config(format!("invalid duration '{input}': number too large")))?;
+        let ms: u128 = match unit.as_str() {
+            "ms" => value,
+            "s" => value * 1_000,
+            "m" => value * 60_000,
+            "h" => value * 3_600_000,
+            "d" => value * 86_400_000,
+            "w" => value * 604_800_000,
+            other => {
+                return Err(Error::Config(format!(
+                    "invalid duration '{input}': unknown unit '{other}' \
+                     (expected ms, s, m, h, d or w)"
+                )))
+            }
+        };
+        total_ms = total_ms
+            .checked_add(ms)
+            .ok_or_else(|| Error::Config(format!("duration '{input}' overflows")))?;
+        number.clear();
+        parsed_any = true;
+    }
+
+    if !number.is_empty() {
+        return Err(Error::Config(format!(
+            "invalid duration '{input}': missing unit after '{number}' \
+             (write e.g. '{number}s' or '{number}d')"
+        )));
+    }
+    if !parsed_any {
+        return Err(Error::Config(format!("invalid duration '{input}'")));
+    }
+    if total_ms == 0 {
+        return Err(Error::Config(format!(
+            "duration '{input}' must be greater than zero"
+        )));
+    }
+    u64::try_from(total_ms)
+        .map(std::time::Duration::from_millis)
+        .map_err(|_| Error::Config(format!("duration '{input}' overflows")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_duration;
+    use std::time::Duration;
+
+    #[test]
+    fn parses_all_units_and_concatenation() {
+        for (input, expected_ms) in [
+            ("500ms", 500u64),
+            ("3600s", 3_600_000),
+            ("45m", 2_700_000),
+            ("12h", 43_200_000),
+            ("30d", 2_592_000_000),
+            ("2w", 1_209_600_000),
+            ("1d12h", 129_600_000),
+            (" 5m ", 300_000),
+        ] {
+            assert_eq!(
+                parse_duration(input).unwrap(),
+                Duration::from_millis(expected_ms),
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bare_numbers_zero_and_garbage() {
+        for input in ["30", "", "d", "5x", "0s", "-5m", "1d5"] {
+            assert!(parse_duration(input).is_err(), "{input} should be rejected");
+        }
+    }
+}

--- a/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
@@ -5,7 +5,6 @@
 //! Requires Docker.
 
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use tempfile::TempDir;

--- a/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
@@ -1,0 +1,168 @@
+//! issue #169 — `backup.retention` prunes an incremental backup set safely:
+//! aged segments are deleted, the manifest is rewritten first, the removal is
+//! recorded as a `pruned` range, and a later run does not resurrect it.
+//!
+//! Requires Docker.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::{
+    BackupOptions, CompressionType, Config, KafkaConfig, Mode, OffsetStorageConfig,
+    RetentionOptions, SecurityConfig, TopicSelection,
+};
+use kafka_backup_core::manifest::BackupManifest;
+use kafka_backup_core::storage::StorageBackendConfig;
+
+use super::common::{generate_test_records, KafkaTestCluster};
+
+const TOPIC: &str = "issue-169-retention";
+const BACKUP_ID: &str = "issue-169-backup";
+const PARTITIONS: usize = 3;
+
+fn config(bootstrap: &str, storage: &TempDir, offset_db: &Path, retention: bool) -> Config {
+    Config {
+        mode: Mode::Backup,
+        backup_id: BACKUP_ID.to_string(),
+        source: Some(KafkaConfig {
+            bootstrap_servers: vec![bootstrap.to_string()],
+            security: SecurityConfig::default(),
+            topics: TopicSelection {
+                include: vec![TOPIC.to_string()],
+                exclude: vec![],
+            },
+            connection: Default::default(),
+        }),
+        target: None,
+        storage: StorageBackendConfig::Filesystem {
+            path: storage.path().to_path_buf(),
+        },
+        backup: Some(BackupOptions {
+            // Tiny segments so each run writes several.
+            segment_max_bytes: 4 * 1024,
+            segment_max_records: Some(5),
+            segment_max_interval_ms: 10_000,
+            compression: CompressionType::Zstd,
+            stop_at_current_offsets: true,
+            continuous: false,
+            retention: retention.then(|| RetentionOptions {
+                // Everything written before this run is "aged" immediately.
+                max_age: Some("1s".to_string()),
+                max_total_bytes: None,
+                keep_segments: 1,
+            }),
+            ..Default::default()
+        }),
+        restore: None,
+        offset_storage: Some(OffsetStorageConfig {
+            db_path: offset_db.to_path_buf(),
+            ..Default::default()
+        }),
+        metrics: None,
+    }
+}
+
+async fn run_backup(config: Config) {
+    let engine = BackupEngine::new_with_metrics(config, None)
+        .await
+        .expect("failed to create backup engine");
+    tokio::time::timeout(Duration::from_secs(60), engine.run())
+        .await
+        .expect("backup timed out")
+        .expect("backup run failed");
+}
+
+async fn produce(cluster: &KafkaTestCluster, count: usize, offset_hint: usize) {
+    let client = cluster.create_client();
+    client.connect().await.expect("failed to connect");
+    for (i, record) in generate_test_records(count, TOPIC).iter().enumerate() {
+        let partition = ((offset_hint + i) % PARTITIONS) as i32;
+        client
+            .produce(TOPIC, partition, vec![record.clone()], -1, 30_000)
+            .await
+            .expect("failed to produce");
+    }
+    sleep(Duration::from_secs(2)).await;
+}
+
+fn load_manifest(storage: &TempDir) -> BackupManifest {
+    let bytes = std::fs::read(storage.path().join(format!("{BACKUP_ID}/manifest.json")))
+        .expect("manifest.json present");
+    serde_json::from_slice(&bytes).expect("manifest parses")
+}
+
+fn segment_files_on_disk(storage: &TempDir, manifest: &BackupManifest) -> (usize, usize) {
+    let mut referenced_present = 0;
+    let mut referenced_missing = 0;
+    for topic in &manifest.topics {
+        for partition in &topic.partitions {
+            for segment in &partition.segments {
+                if storage.path().join(&segment.key).exists() {
+                    referenced_present += 1;
+                } else {
+                    referenced_missing += 1;
+                }
+            }
+        }
+    }
+    (referenced_present, referenced_missing)
+}
+
+#[tokio::test]
+#[ignore] // Requires Docker
+async fn retention_prunes_aged_segments_and_the_next_run_does_not_resurrect_them() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster.create_topic(TOPIC).await.expect("create topic");
+
+    let storage = TempDir::new().unwrap();
+    let offset_dir = TempDir::new().unwrap();
+    let offset_db = offset_dir.path().join("offsets.db");
+    let bootstrap = cluster.bootstrap_servers();
+
+    // Run 1 (no retention): seed the archive.
+    produce(&cluster, 30, 0).await;
+    run_backup(config(&bootstrap, &storage, &offset_db, false)).await;
+    let m1 = load_manifest(&storage);
+    let segments_after_run1 = m1.total_segments();
+    assert!(segments_after_run1 >= PARTITIONS, "run 1 wrote segments");
+    assert_eq!(m1.total_pruned(), 0);
+
+    // Age everything past the 1s cutoff, produce more, run 2 WITH retention.
+    sleep(Duration::from_secs(2)).await;
+    produce(&cluster, 15, 30).await;
+    run_backup(config(&bootstrap, &storage, &offset_db, true)).await;
+
+    let m2 = load_manifest(&storage);
+    assert!(
+        m2.total_pruned() >= 1,
+        "run 2 must record pruned ranges, got manifest: {:?}",
+        m2.total_pruned()
+    );
+    assert!(
+        m2.total_segments() < segments_after_run1 + m2.total_pruned(),
+        "aged segments must have been removed from the manifest"
+    );
+    // Every segment the manifest references still exists on disk (manifest
+    // was rewritten before deletion) and pruned objects are actually gone.
+    let (present, missing) = segment_files_on_disk(&storage, &m2);
+    assert!(present > 0);
+    assert_eq!(missing, 0, "manifest must never reference deleted segments");
+
+    // Run 3 (no retention): resume works and pruned segments stay pruned.
+    produce(&cluster, 10, 45).await;
+    run_backup(config(&bootstrap, &storage, &offset_db, false)).await;
+    let m3 = load_manifest(&storage);
+    assert!(
+        m3.total_pruned() >= m2.total_pruned(),
+        "pruned ranges survive merges"
+    );
+    let (_, missing3) = segment_files_on_disk(&storage, &m3);
+    assert_eq!(missing3, 0, "no resurrection of pruned segment entries");
+}

--- a/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_169_retention.rs
@@ -119,12 +119,15 @@ async fn retention_prunes_aged_segments_and_the_next_run_does_not_resurrect_them
     let cluster = KafkaTestCluster::start()
         .await
         .expect("failed to start Kafka");
-    cluster.create_topic(TOPIC).await.expect("create topic");
+    cluster
+        .create_topic(TOPIC, PARTITIONS)
+        .await
+        .expect("create topic");
 
     let storage = TempDir::new().unwrap();
     let offset_dir = TempDir::new().unwrap();
     let offset_db = offset_dir.path().join("offsets.db");
-    let bootstrap = cluster.bootstrap_servers();
+    let bootstrap = cluster.bootstrap_servers.clone();
 
     // Run 1 (no retention): seed the archive.
     produce(&cluster, 30, 0).await;

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -22,6 +22,7 @@ pub mod issue_146_connection_errors;
 pub mod issue_148_offset_reset_after_restore;
 pub mod issue_154_offset_headers;
 pub mod issue_155_null_header_value;
+pub mod issue_169_retention;
 pub mod issue_56_missing_topic;
 pub mod issue_57_incremental_snapshot_target;
 pub mod issue_67_fixes;

--- a/crates/kafka-backup-core/tests/preflight_contract_test.rs
+++ b/crates/kafka-backup-core/tests/preflight_contract_test.rs
@@ -158,6 +158,8 @@ fn write_legacy_json_segment(
         record_count: count,
         uncompressed_size: 0,
         compressed_size: 0,
+        sha256: String::new(),
+        uploaded_at: 0,
     }
 }
 
@@ -256,11 +258,13 @@ async fn full_coverage_passes_offset_recovery() {
                 partition_id: 0,
                 segments: vec![seg0],
                 gaps: Vec::new(),
+                pruned: Vec::new(),
             },
             PartitionBackup {
                 partition_id: 1,
                 segments: vec![seg1],
                 gaps: Vec::new(),
+                pruned: Vec::new(),
             },
         ],
     );
@@ -295,6 +299,7 @@ async fn missing_headers_fails_recovery_but_warns_without() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -342,6 +347,7 @@ async fn null_valued_tracking_headers_do_not_count_as_coverage() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -373,6 +379,7 @@ async fn partial_coverage_fails_offset_recovery() {
             partition_id: 0,
             segments: vec![seg_with, seg_without],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -403,6 +410,7 @@ async fn legacy_json_segments_are_scanned_and_flagged() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -429,6 +437,7 @@ async fn legacy_json_segments_are_scanned_and_flagged() {
             partition_id: 0,
             segments: vec![seg2],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
     let report2 = scan(
@@ -451,6 +460,7 @@ async fn empty_backup_is_never_a_positive_pass() {
             partition_id: 0,
             segments: vec![],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -500,6 +510,7 @@ async fn corrupt_segment_is_detected() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -529,6 +540,7 @@ async fn missing_segment_object_is_detected() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -587,6 +599,7 @@ async fn string_encoded_headers_count_as_coverage() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -612,6 +625,7 @@ async fn time_window_limits_the_scan_to_restorable_segments() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -639,6 +653,7 @@ async fn auto_consumer_groups_requires_snapshot() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -698,6 +713,7 @@ async fn reset_request_that_can_never_act_fails() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -729,6 +745,7 @@ async fn skip_mode_never_blocks_but_warns_loudly() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -750,6 +767,7 @@ async fn auto_mode_without_recovery_reports_indeterminate_without_scanning() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -784,6 +802,7 @@ async fn validate_phase1_headers_returns_structured_report() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -809,6 +828,7 @@ async fn run_all_phases_fails_preflight_before_target_connection() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -839,6 +859,7 @@ async fn restore_engine_fails_preflight_before_target_connection() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 
@@ -864,6 +885,7 @@ async fn restore_engine_fails_preflight_before_target_connection() {
             partition_id: 0,
             segments: vec![seg2],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
     write_consumer_group_snapshot(
@@ -891,6 +913,7 @@ async fn dry_run_embeds_preflight_and_blocks_invalid_recovery() {
             partition_id: 0,
             segments: vec![seg],
             gaps: Vec::new(),
+            pruned: Vec::new(),
         }],
     );
 

--- a/crates/kafka-backup-core/tests/unit_suite/helpers.rs
+++ b/crates/kafka-backup-core/tests/unit_suite/helpers.rs
@@ -96,6 +96,8 @@ pub fn create_segment_metadata(
         record_count: end_offset - start_offset + 1,
         compressed_size: 1024,
         uncompressed_size: 4096,
+        sha256: String::new(),
+        uploaded_at: 0,
     }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -458,7 +458,33 @@ This ensures consistent "point-in-time" snapshots for disaster recovery, even wi
 
 > **Note:** `stop_at_current_offsets` is incompatible with `continuous: true`. Use snapshot mode for scheduled backups (CronJobs), and continuous mode for streaming replication.
 
-#### Retention deleting data before it is fetched
+### Backup Retention
+
+Prune aged or oversized segments from this backup set at the end of every
+backup cycle. Safe for incremental sets — the manifest is rewritten before
+any object is deleted and every removal is recorded as a `pruned` range
+(shown by `describe`/`validate`). **Never use bucket lifecycle rules on an
+incremental set** (see the storage guide). The on-demand form is
+`kafka-backup prune`.
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `retention.max_age` | string | No | - | Prune segments older than this (`30d`, `12h`, `1d12h`; units ms/s/m/h/d/w) |
+| `retention.max_total_bytes` | int | No | - | Then prune oldest-first until the set fits under this many compressed bytes |
+| `retention.keep_segments` | int | No | `1` | Never prune a partition below this many newest segments |
+
+```yaml
+backup:
+  retention:
+    max_age: 30d
+    keep_segments: 1
+```
+
+Segments are aged by upload time (`uploaded_at`, recorded since 0.21) or,
+for older segments, by their newest record timestamp. The segment holding
+the resume position is never pruned.
+
+#### Kafka retention deleting data before it is fetched
 
 The offsets a backup starts from are captured before the fetch happens — for
 every partition up front in snapshot mode, and from the checkpoint on resume.
@@ -664,6 +690,8 @@ metrics:
 | `kafka_backup_bytes_total` | Counter | Total bytes backed up |
 | `kafka_backup_offset_gaps_total` | Counter | Offset ranges skipped because the source no longer had the records (see [retention gaps](#retention-deleting-data-before-it-is-fetched)) |
 | `kafka_backup_offsets_skipped_total` | Counter | Source offsets skipped across all recorded gaps |
+| `kafka_backup_segments_pruned_total` | Counter | Segments deliberately deleted by retention (`prune` / `backup.retention`) |
+| `kafka_backup_bytes_pruned_total` | Counter | Compressed bytes deleted by retention |
 | `kafka_backup_compression_ratio` | Gauge | Compression efficiency |
 | `kafka_backup_storage_write_latency_seconds` | Histogram | Storage write latency |
 | `kafka_backup_storage_write_bytes_total` | Counter | Storage I/O bytes |
@@ -682,6 +710,7 @@ Options specific to restore operations.
 | `dry_run` | bool | No | `false` | Simulate restore without writing |
 | `include_original_offset_header` | bool | No | `false` | Add `x-original-offset`, `x-original-timestamp` and `x-source-partition` headers to every record as it is produced (also implied by `consumer_group_strategy: header-based`) |
 | `strip_offset_headers` | bool | No | `false` | Remove the headers kafka-backup added at backup time (`x-original-*`, `x-source-*`) before producing, for a header-for-header identical restore — see [Offset-tracking headers](#offset-tracking-headers) |
+| `dry_run_check_segments` | bool | No | `false` | `validate-restore`/dry-run: HEAD every segment in the window instead of only the oldest per partition (the default canary that catches lifecycle-rule expiry) |
 | `purge_topics` | bool | No | `false` | **Irreversible.** Advance every target partition's log-start-offset to its end-offset (`DeleteRecords`) before restoring, so the topic appears empty without being deleted (Strimzi-managed topics) |
 
 Note the two header options govern different sides of the pipeline:
@@ -990,6 +1019,26 @@ kafka-backup validate --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 | `--path` | Path to storage location |
 | `--backup-id` | Backup identifier |
 | `--deep` | Perform deep validation |
+
+### Prune Command
+
+Delete aged/oversized segments from a backup set, safely (plan-only unless
+`--execute`; see [Backup Retention](#backup-retention)):
+
+```bash
+kafka-backup prune --config backup.yaml --older-than 30d            # plan
+kafka-backup prune --config backup.yaml --older-than 30d --execute  # delete
+kafka-backup prune --path s3://bucket/prefix --backup-id daily \
+  --before 2026-08-01T00:00:00Z --keep-segments 2 --execute
+```
+
+Only a contiguous oldest-first prefix per partition is ever pruned; the
+resume position and the newest `--keep-segments` segments are protected; the
+manifest is rewritten before objects are deleted and each removal is
+recorded as a `pruned` range. Refuses while a backup run looks live unless
+`--force`. `--max-total-bytes` keeps pruning oldest-first until the set fits
+(compressed bytes). Never use bucket lifecycle rules for this — see the
+storage guide.
 
 ### Validate-Restore Command
 

--- a/docs/storage_guide.md
+++ b/docs/storage_guide.md
@@ -862,21 +862,40 @@ storage:
   # Enable server-side encryption (configure in bucket policy)
 ```
 
-#### 3. Configure Lifecycle Policies
+#### 3. Retention: use `prune`, not bucket lifecycle rules
 
-Set up bucket lifecycle policies to automatically delete old backups:
+**Do not put an age-based lifecycle rule on an incremental backup set.** An
+incremental set (a stable `backup_id` with `offset_storage` configured, or a
+continuous backup) appends segments under one prefix and rewrites
+`manifest.json` and `offsets.db` on every run. An expiry rule therefore:
 
-**S3 Lifecycle Policy:**
-```json
-{
-  "Rules": [{
-    "ID": "DeleteOldBackups",
-    "Status": "Enabled",
-    "Filter": {"Prefix": "backups/"},
-    "Expiration": {"Days": 30}
-  }]
-}
+- deletes the oldest **segments while the manifest still references them** —
+  `restore` fails partway, `validate` reports the backup INVALID, and
+  `validate-restore` (before 0.21) said nothing;
+- never expires `manifest.json`/`offsets.db`, whose age resets on every run.
+
+Use built-in retention instead — it rewrites the manifest first and records
+every removal as a `pruned` range:
+
+```bash
+# On demand (plan first, then execute):
+kafka-backup prune --config backup.yaml --older-than 30d
+kafka-backup prune --config backup.yaml --older-than 30d --execute
 ```
+
+```yaml
+# Or automatically at the end of every backup cycle:
+backup:
+  retention:
+    max_age: 30d
+    keep_segments: 1
+```
+
+Lifecycle rules remain fine for **per-run backup IDs** (a unique
+`backup_id`/prefix per scheduled run, the Kubernetes operators' default when
+`offsetStorage` is unset) — expiring a whole self-contained run is safe.
+Avoid Archive/Glacier tiering on any prefix a restore may need: `get` fails
+until objects are rehydrated.
 
 #### 4. Use Prefixes for Multi-Tenancy
 


### PR DESCRIPTION
Closes #169. Stacked on #176 (the 0.21.0 release train): merge this into the feature branch, then #176 into `main` — one merge, one release.

## Why
An age-based bucket lifecycle rule on an incremental backup set deletes segments the manifest still references — `restore` partially fails, `validate` reports INVALID, `describe`/dry-run said nothing — and never expires `manifest.json`/`offsets.db` (rewritten every run). Our own storage guide recommended exactly that rule.

## What
- **`kafka-backup prune`** — plan-only by default, `--execute` to delete; `--older-than 30d` / `--before <RFC3339|epoch-ms>` / `--max-total-bytes`; only a contiguous oldest-first prefix per partition; the resume position (from `offsets.db`) and the newest `--keep-segments` are protected; **manifest first, objects second** (a crash leaves harmless orphans, never a broken manifest); refuses while a run looks live (offset checkpoint < 2 min) unless `--force`; each removal recorded as a `PrunedRange` (`describe`/`validate`/`validate-restore` explain it, never fail on it).
- **`backup.retention`** (`max_age` human grammar via new `util::parse_duration`, `max_total_bytes`, `keep_segments`) — same prune at the end of every backup cycle.
- **No resurrection**: `merge_manifests` unions `pruned` first and drops any segment inside a merged range — covers both a stale stored manifest and a mid-flight in-memory one (both regression-tested).
- **`SegmentMetadata.sha256` + `uploaded_at`** (serde-defaulted) — retention ages by upload time when present; the digest is groundwork for deep validation and the enterprise redaction design.
- **Dry-run hardening**: `validate-restore` HEADs the oldest segment per partition (catches a lifecycle-wiped archive at one request per partition; `restore.dry_run_check_segments: true` sweeps everything) and fails on a missing segment.
- Metrics `kafka_backup_segments_pruned_total` / `kafka_backup_bytes_pruned_total`; docs rewritten (`storage_guide` retention section, `configuration.md` Backup Retention + Prune Command, README storage layout corrected).

## Test plan (local, end to end)
1. `cargo test` — 529 unit/e2e tests including the new CLI harness (`issue_169_prune.rs`: plan-only default → `--execute` deletes and records the range → second run no-op → `validate` VALID with the range listed → `describe` shows `PRUNED offsets 0..19`).
2. `cargo test -- --ignored issue_169` (Docker) — two-run incremental retention: aged segments pruned, manifest never references a deleted object, third run does not resurrect.
3. Demo: `kafka-backup-demos/cli/retention-prune/demo.sh` (separate PR) walks backup → age → prune plan → execute → validate/describe → restore of the surviving window against Kafka+MinIO from the repo's compose file.
4. `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check` — clean.

Follow-ups noted in #172/#175: conditional-put manifest CAS; enrich restore's segment-NotFound error with the pruned-range hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN