### PR TITLE
fix(storage): path_style honoured, http:// endpoint implies allow_http, legacy key aliases, Azure WI ids from YAML (#166)

### DIFF
--- a/crates/kafka-backup-core/src/storage/azure.rs
+++ b/crates/kafka-backup-core/src/storage/azure.rs
@@ -37,6 +37,18 @@ pub struct AzureConfig {
     pub sas_token: Option<String>,
 }
 
+/// Resolve Workload Identity parameters: explicit config values take precedence
+/// over the environment variables injected by the AKS Workload Identity webhook.
+fn resolve_workload_identity(
+    config: &AzureConfig,
+    env: impl Fn(&str) -> Option<String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let client_id = config.client_id.clone().or_else(|| env("AZURE_CLIENT_ID"));
+    let tenant_id = config.tenant_id.clone().or_else(|| env("AZURE_TENANT_ID"));
+    let token_file = env("AZURE_FEDERATED_TOKEN_FILE");
+    (client_id, tenant_id, token_file)
+}
+
 /// Azure Blob Storage backend
 pub struct AzureBackend {
     store: Arc<dyn ObjectStore>,
@@ -50,7 +62,8 @@ impl AzureBackend {
     /// 1. SAS token (`sas_token`)
     /// 2. Storage account key (`account_key`)
     /// 3. Service principal (`client_id` + `client_secret` + `tenant_id`)
-    /// 4. Workload Identity (`use_workload_identity` or AZURE_FEDERATED_TOKEN_FILE env var)
+    /// 4. Workload Identity (`use_workload_identity` or AZURE_FEDERATED_TOKEN_FILE env var);
+    ///    YAML `client_id` / `tenant_id` override the webhook-injected env vars
     /// 5. DefaultAzureCredential chain (environment, managed identity, CLI)
     pub fn new(config: AzureConfig) -> Result<Self> {
         let mut builder = MicrosoftAzureBuilder::new()
@@ -97,11 +110,12 @@ impl AzureBackend {
         } else if config.use_workload_identity.unwrap_or(false)
             || std::env::var("AZURE_FEDERATED_TOKEN_FILE").is_ok()
         {
-            // Workload Identity - explicitly configure federated token authentication
-            // Read from environment variables set by Azure Workload Identity webhook
-            let client_id = std::env::var("AZURE_CLIENT_ID").ok();
-            let tenant_id = std::env::var("AZURE_TENANT_ID").ok();
-            let token_file = std::env::var("AZURE_FEDERATED_TOKEN_FILE").ok();
+            // Workload Identity - explicitly configure federated token authentication.
+            // YAML `client_id` / `tenant_id` win; otherwise the values injected by the
+            // Azure Workload Identity webhook (AZURE_CLIENT_ID / AZURE_TENANT_ID) are
+            // used. The token file always comes from AZURE_FEDERATED_TOKEN_FILE.
+            let (client_id, tenant_id, token_file) =
+                resolve_workload_identity(&config, |name| std::env::var(name).ok());
 
             if let Some(ref file) = token_file {
                 builder = builder.with_federated_token_file(file);
@@ -350,5 +364,54 @@ mod tests {
         backend.delete("test-key").await.unwrap();
         backend.delete("test-key-copy").await.unwrap();
         assert!(!backend.exists("test-key").await.unwrap());
+    }
+
+    fn wi_config(client_id: Option<&str>, tenant_id: Option<&str>) -> AzureConfig {
+        AzureConfig {
+            account_name: "acct".to_string(),
+            container_name: "backups".to_string(),
+            account_key: None,
+            prefix: None,
+            endpoint: None,
+            use_workload_identity: Some(true),
+            client_id: client_id.map(str::to_string),
+            tenant_id: tenant_id.map(str::to_string),
+            client_secret: None,
+            sas_token: None,
+        }
+    }
+
+    fn fake_env(name: &str) -> Option<String> {
+        match name {
+            "AZURE_CLIENT_ID" => Some("env-client".to_string()),
+            "AZURE_TENANT_ID" => Some("env-tenant".to_string()),
+            "AZURE_FEDERATED_TOKEN_FILE" => {
+                Some("/var/run/secrets/azure/tokens/azure-identity-token".to_string())
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn workload_identity_prefers_yaml_ids_over_env() {
+        let (client_id, tenant_id, token_file) = resolve_workload_identity(
+            &wi_config(Some("yaml-client"), Some("yaml-tenant")),
+            fake_env,
+        );
+        assert_eq!(client_id.as_deref(), Some("yaml-client"));
+        assert_eq!(tenant_id.as_deref(), Some("yaml-tenant"));
+        assert_eq!(
+            token_file.as_deref(),
+            Some("/var/run/secrets/azure/tokens/azure-identity-token")
+        );
+    }
+
+    #[test]
+    fn workload_identity_falls_back_to_env() {
+        let (client_id, tenant_id, _) = resolve_workload_identity(&wi_config(None, None), fake_env);
+        assert_eq!(client_id.as_deref(), Some("env-client"));
+        assert_eq!(tenant_id.as_deref(), Some("env-tenant"));
+        let (client_id, _, token) = resolve_workload_identity(&wi_config(None, None), |_| None);
+        assert!(client_id.is_none() && token.is_none());
     }
 }

--- a/crates/kafka-backup-core/src/storage/config.rs
+++ b/crates/kafka-backup-core/src/storage/config.rs
@@ -25,11 +25,13 @@ pub enum StorageBackendConfig {
         /// Custom endpoint URL (for S3-compatible services like MinIO)
         #[serde(default)]
         endpoint: Option<String>,
-        /// Access key ID (falls back to AWS_ACCESS_KEY_ID env var)
-        #[serde(default)]
+        /// Access key ID (falls back to AWS_ACCESS_KEY_ID env var).
+        /// `access_key_id` is accepted as an alias (issue #166).
+        #[serde(default, alias = "access_key_id")]
         access_key: Option<String>,
-        /// Secret access key (falls back to AWS_SECRET_ACCESS_KEY env var)
-        #[serde(default)]
+        /// Secret access key (falls back to AWS_SECRET_ACCESS_KEY env var).
+        /// `secret_access_key` is accepted as an alias (issue #166).
+        #[serde(default, alias = "secret_access_key")]
         secret_key: Option<String>,
         /// Key prefix for all operations
         #[serde(default)]
@@ -107,6 +109,14 @@ pub enum StorageBackendConfig {
     Memory,
 }
 
+/// Plain-HTTP S3 endpoints (in-cluster MinIO / Ceph RGW) need `allow_http` or
+/// the client refuses to build. An explicit `allow_http: true` always wins;
+/// otherwise an `endpoint` starting with `http://` implies it (issue #166).
+/// Shared by the YAML and `--path` URL code paths.
+pub(crate) fn implied_allow_http(endpoint: Option<&str>, explicit: bool) -> bool {
+    explicit || endpoint.is_some_and(|e| e.starts_with("http://"))
+}
+
 impl StorageBackendConfig {
     /// Parse configuration from a URL string
     ///
@@ -150,11 +160,7 @@ impl StorageBackendConfig {
                     .query_pairs()
                     .find(|(k, _)| k == "allow_http")
                     .map(|(_, v)| v == "true")
-                    .unwrap_or_else(|| {
-                        endpoint
-                            .as_deref()
-                            .is_some_and(|e| e.starts_with("http://"))
-                    });
+                    .unwrap_or_else(|| implied_allow_http(endpoint.as_deref(), false));
 
                 Ok(Self::S3 {
                     bucket,
@@ -411,5 +417,36 @@ backend: memory
 "#;
         let config: StorageBackendConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(matches!(config, StorageBackendConfig::Memory));
+    }
+
+    #[test]
+    fn yaml_accepts_legacy_access_key_id_aliases() {
+        let yaml = r#"
+backend: s3
+bucket: backups
+access_key_id: AKIA
+secret_access_key: shh
+"#;
+        let config: StorageBackendConfig = serde_yaml::from_str(yaml).unwrap();
+        match config {
+            StorageBackendConfig::S3 {
+                access_key,
+                secret_key,
+                ..
+            } => {
+                assert_eq!(access_key.as_deref(), Some("AKIA"));
+                assert_eq!(secret_key.as_deref(), Some("shh"));
+            }
+            _ => panic!("expected S3"),
+        }
+    }
+
+    #[test]
+    fn implied_allow_http_cases() {
+        assert!(implied_allow_http(Some("http://minio:9000"), false));
+        assert!(!implied_allow_http(Some("https://s3.example"), false));
+        assert!(!implied_allow_http(None, false));
+        assert!(implied_allow_http(None, true));
+        assert!(implied_allow_http(Some("https://s3.example"), true));
     }
 }

--- a/crates/kafka-backup-core/src/storage/mod.rs
+++ b/crates/kafka-backup-core/src/storage/mod.rs
@@ -52,9 +52,16 @@ pub fn create_backend_from_config(
             access_key,
             secret_key,
             prefix,
-            path_style: _,
+            path_style,
             allow_http,
         } => {
+            let effective_allow_http =
+                crate::storage::config::implied_allow_http(endpoint.as_deref(), *allow_http);
+            if effective_allow_http && !*allow_http {
+                tracing::info!(
+                    "storage.endpoint uses http://; enabling allow_http (set storage.allow_http: true to make this explicit)"
+                );
+            }
             let s3_config = S3Config {
                 bucket: bucket.clone(),
                 region: region.clone(),
@@ -62,7 +69,8 @@ pub fn create_backend_from_config(
                 access_key_id: access_key.clone(),
                 secret_access_key: secret_key.clone(),
                 prefix: prefix.clone(),
-                allow_http: *allow_http,
+                path_style: *path_style,
+                allow_http: effective_allow_http,
             };
             Ok(Arc::new(S3Backend::new(s3_config)?))
         }
@@ -156,6 +164,7 @@ pub fn create_backend_legacy(
                 access_key_id: config.access_key.clone(),
                 secret_access_key: config.secret_key.clone(),
                 prefix: config.prefix.clone(),
+                path_style: false,
                 allow_http: config
                     .endpoint
                     .as_ref()

--- a/crates/kafka-backup-core/src/storage/s3.rs
+++ b/crates/kafka-backup-core/src/storage/s3.rs
@@ -27,6 +27,9 @@ pub struct S3Config {
     pub secret_access_key: Option<String>,
     /// Key prefix for all operations
     pub prefix: Option<String>,
+    /// Use path-style requests (bucket in the path, not the host). Implied by
+    /// a custom `endpoint`; set explicitly for path-style-only AWS setups.
+    pub path_style: bool,
     /// Allow HTTP (insecure) connections
     pub allow_http: bool,
 }
@@ -40,9 +43,17 @@ impl Default for S3Config {
             access_key_id: None,
             secret_access_key: None,
             prefix: None,
+            path_style: false,
             allow_http: false,
         }
     }
+}
+
+/// Path-style requests are used when asked for explicitly, or implied by a
+/// custom endpoint (MinIO / Ceph RGW). Before 0.22.0 the flag was silently
+/// discarded and only the endpoint side effect applied (issue #166).
+pub(crate) fn use_path_style(endpoint: Option<&str>, path_style: bool) -> bool {
+    path_style || endpoint.is_some()
 }
 
 /// S3 storage backend
@@ -62,7 +73,9 @@ impl S3Backend {
 
         if let Some(endpoint) = &config.endpoint {
             builder = builder.with_endpoint(endpoint);
-            // For custom endpoints, we typically need virtual hosted style disabled
+        }
+
+        if use_path_style(config.endpoint.as_deref(), config.path_style) {
             builder = builder.with_virtual_hosted_style_request(false);
         }
 
@@ -282,5 +295,21 @@ mod tests {
         // Test delete
         backend.delete("test-key").await.unwrap();
         assert!(!backend.exists("test-key").await.unwrap());
+    }
+
+    #[test]
+    fn use_path_style_cases() {
+        assert!(
+            use_path_style(Some("http://minio:9000"), false),
+            "endpoint implies path style"
+        );
+        assert!(
+            use_path_style(None, true),
+            "explicit flag honoured without endpoint"
+        );
+        assert!(
+            !use_path_style(None, false),
+            "plain AWS keeps the client default"
+        );
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,12 +307,13 @@ storage:
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `bucket` | string | Yes | - | S3 bucket name |
-| `region` | string | Yes | - | AWS region |
+| `region` | string | No | - | AWS region |
 | `prefix` | string | No | `""` | Key prefix (folder) |
-| `endpoint` | string | No | - | Custom endpoint (for MinIO, etc.) |
-| `path_style` | bool | No | `false` | Use path-style URLs |
-| `access_key_id` | string | No | - | AWS access key (or use env/IAM) |
-| `secret_access_key` | string | No | - | AWS secret key |
+| `endpoint` | string | No | - | Custom endpoint (MinIO, Ceph RGW, etc.). Setting one implies path-style requests |
+| `path_style` | bool | No | `false` | Force path-style requests (bucket in the path) even without a custom endpoint |
+| `allow_http` | bool | No | `false` | Allow a plain-HTTP endpoint. Since 0.22.0 an `endpoint` starting with `http://` implies it |
+| `access_key` | string | No | - | AWS access key (or use env/IAM). `access_key_id` is accepted as an alias |
+| `secret_key` | string | No | - | AWS secret key. `secret_access_key` is accepted as an alias |
 
 ```yaml
 storage:
@@ -328,10 +329,10 @@ storage:
 storage:
   backend: s3
   bucket: kafka-backups
-  endpoint: http://minio.local:9000
-  path_style: true
-  access_key_id: minioadmin
-  secret_access_key: ${MINIO_SECRET}
+  endpoint: http://minio.local:9000   # http:// implies allow_http (0.22.0+) and path-style
+  allow_http: true                     # explicit is clearer for on-prem stores (Ceph RGW, MinIO)
+  access_key: minioadmin
+  secret_key: ${MINIO_SECRET}
 ```
 
 ### Azure Blob Storage Backend
@@ -341,9 +342,18 @@ storage:
 | `account_name` | string | Yes | - | Azure storage account name |
 | `container_name` | string | Yes | - | Blob container name |
 | `prefix` | string | No | `""` | Blob prefix (folder) |
-| `account_key` | string | No | - | Account key (or use managed identity) |
-| `sas_token` | string | No | - | SAS token |
-| `use_managed_identity` | bool | No | `false` | Use managed identity |
+| `endpoint` | string | No | - | Custom endpoint (sovereign clouds) |
+| `sas_token` | string | No | - | Shared access signature |
+| `account_key` | string | No | - | Storage account key (`AZURE_STORAGE_KEY` env fallback) |
+| `client_id` | string | No | - | Azure AD client ID (service principal or Workload Identity) |
+| `tenant_id` | string | No | - | Azure AD tenant ID |
+| `client_secret` | string | No | - | Service-principal secret |
+| `use_workload_identity` | bool | No | auto | AKS Workload Identity (federated token). Auto-enabled when `AZURE_FEDERATED_TOKEN_FILE` is set |
+
+Credential precedence: `sas_token` → `account_key` → service principal (`client_secret`) →
+Workload Identity → `DefaultAzureCredential` chain (environment, managed identity, Azure CLI).
+For Workload Identity, YAML `client_id`/`tenant_id` override the webhook-injected
+`AZURE_CLIENT_ID`/`AZURE_TENANT_ID`; the token file always comes from `AZURE_FEDERATED_TOKEN_FILE`.
 
 ```yaml
 storage:
@@ -351,7 +361,7 @@ storage:
   account_name: mybackupstorage
   container_name: kafka-backups
   prefix: production/
-  use_managed_identity: true
+  use_workload_identity: true   # AKS: pod label azure.workload.identity/use=true + SA annotation
 ```
 
 ### Google Cloud Storage Backend
@@ -944,8 +954,13 @@ source:
 | `AWS_ACCESS_KEY_ID` | AWS access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
 | `AWS_REGION` | AWS region |
+| `AWS_ENDPOINT` | Custom S3 endpoint (alternative to `storage.endpoint`) |
+| `AWS_ALLOW_HTTP` | `true` to allow a plain-HTTP S3 endpoint (alternative to `storage.allow_http`) |
 | `AZURE_STORAGE_ACCOUNT` | Azure storage account |
 | `AZURE_STORAGE_KEY` | Azure storage key |
+| `AZURE_STORAGE_SAS_TOKEN` | Azure SAS token |
+| `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_CLIENT_SECRET` | Azure AD service principal (client secret) or Workload Identity ids |
+| `AZURE_FEDERATED_TOKEN_FILE` | Projected token path injected by the AKS Workload Identity webhook; its presence enables Workload Identity |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP credentials |
 | `RUST_LOG` | Logging level (debug, info, warn, error) |
 

--- a/docs/storage_guide.md
+++ b/docs/storage_guide.md
@@ -448,24 +448,36 @@ storage:
   account_name: mystorageaccount
   container_name: kafka-backups
 
-  # Optional - Account key (uses DefaultAzureCredential if omitted)
+  # Optional - Account key (uses the credential chain below if omitted)
   account_key: your-account-key
 
   # Optional - Key prefix for all operations
   prefix: cluster-prod
+
+  # Optional - sovereign cloud endpoint (Azure Government, Azure China)
+  # endpoint: https://mystorageaccount.blob.core.usgovcloudapi.net
+
+  # Optional - other credential types
+  # sas_token: "sv=2023-...&sig=..."
+  # client_id: <app-or-managed-identity-client-id>
+  # tenant_id: <tenant-id>
+  # client_secret: ${AZURE_CLIENT_SECRET}      # service principal
+  # use_workload_identity: true                 # AKS Workload Identity (federated token)
 ```
 
 **Environment Variables:**
 - `AZURE_STORAGE_KEY` - Account key (fallback)
-- `AZURE_TENANT_ID` - Tenant ID for service principal
-- `AZURE_CLIENT_ID` - Client ID for service principal
+- `AZURE_STORAGE_SAS_TOKEN` - SAS token (fallback)
+- `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` - Tenant / client ID (service principal or Workload Identity)
 - `AZURE_CLIENT_SECRET` - Client secret for service principal
+- `AZURE_FEDERATED_TOKEN_FILE` - Projected token file injected by the AKS Workload Identity webhook; when set, Workload Identity is used automatically
 
-**Credential Chain (when account_key omitted):**
-1. Environment variables (service principal)
-2. Managed Identity
-3. Azure CLI credentials
-4. Azure Developer CLI credentials
+**Credential precedence:**
+1. `sas_token`
+2. `account_key`
+3. Service principal (`client_id` + `tenant_id` + `client_secret`)
+4. Workload Identity (`use_workload_identity: true` or `AZURE_FEDERATED_TOKEN_FILE` present) — YAML `client_id`/`tenant_id` override the webhook-injected `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`
+5. `DefaultAzureCredential` chain (environment, managed identity, Azure CLI, Azure Developer CLI)
 
 ### Google Cloud Storage
 
@@ -512,7 +524,7 @@ storage:
 
 | Backend | URL Format |
 |---------|------------|
-| S3 | `s3://bucket?region=us-east-1&endpoint=http://host:9000` |
+| S3 | `s3://bucket/prefix?region=us-east-1&endpoint=http://host:9000&path_style=true&allow_http=true` — an `endpoint=http://…` implies `allow_http=true` (and path-style); pass `allow_http=false` to override |
 | Azure | `azure://account.blob.core.windows.net/container` |
 | GCS | `gcs://bucket` or `gs://bucket` |
 | Filesystem | `file:///path/to/storage` |
@@ -770,9 +782,26 @@ spec:
                 name: kafka-backup-config
 ```
 
-### Azure Kubernetes Service (AKS) with Managed Identity
+### Azure Kubernetes Service (AKS) with Workload Identity
 
-#### Enable Workload Identity
+Works for the CLI running as a plain Kubernetes Job (no operator required). The AKS
+Workload Identity webhook injects `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+`AZURE_AUTHORITY_HOST` and `AZURE_FEDERATED_TOKEN_FILE` into any pod that carries the
+`azure.workload.identity/use: "true"` label and runs under an annotated ServiceAccount.
+
+#### 1. Federated credential (Azure side, once)
+
+```bash
+AKS_OIDC_ISSUER=$(az aks show -g <rg> -n <cluster> --query oidcIssuerProfile.issuerUrl -o tsv)
+az identity federated-credential create \
+  --name kafka-backup --identity-name <managed-identity> -g <rg> \
+  --issuer "$AKS_OIDC_ISSUER" \
+  --subject system:serviceaccount:<namespace>:kafka-backup \
+  --audiences api://AzureADTokenExchange
+# The identity needs "Storage Blob Data Contributor" on the container/account.
+```
+
+#### 2. ServiceAccount + Job
 
 ```yaml
 apiVersion: v1
@@ -782,32 +811,40 @@ metadata:
   annotations:
     azure.workload.identity/client-id: <MANAGED_IDENTITY_CLIENT_ID>
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: kafka-backup
 spec:
   template:
     metadata:
       labels:
-        azure.workload.identity/use: "true"
+        azure.workload.identity/use: "true"   # required: triggers the token injection
     spec:
       serviceAccountName: kafka-backup
+      restartPolicy: OnFailure
       containers:
         - name: kafka-backup
-          image: kafka-backup:latest
+          image: osodevops/kafka-backup:latest
+          args: ["backup", "--config", "/config/backup.yaml"]
           # No credentials needed - uses Workload Identity
 ```
 
-#### Storage Config (No account_key)
+#### 3. Storage config
 
 ```yaml
 storage:
   backend: azure
   account_name: mystorageaccount
   container_name: kafka-backups
-  # account_key omitted - uses Managed Identity
+  use_workload_identity: true
+  # client_id / tenant_id are optional: the webhook-injected AZURE_CLIENT_ID /
+  # AZURE_TENANT_ID are used unless set here.
 ```
+
+Troubleshooting: run with `RUST_LOG=debug` — the backend logs
+`Azure authentication: Workload Identity (client_id=…, tenant_id=…, token_file=…)`;
+a `not set` token file means the pod label or ServiceAccount annotation is missing.
 
 ### Google Kubernetes Engine (GKE) with Workload Identity
 


### PR DESCRIPTION
Part 1 of the 0.22.0 release branch (`release/0.22.0` → one squash to main).

Closes the code side of #166 and two bugs found alongside it:
- **`path_style` was silently discarded** by `create_backend_from_config` (`storage/mod.rs`); path-style is now used when set explicitly or implied by a custom `endpoint` (plain-AWS default unchanged).
- **YAML `endpoint: http://…` implies `allow_http`** (info log), matching the `--path` URL behaviour — on-prem HTTP stores (Ceph RGW / MinIO) no longer need `AWS_ALLOW_HTTP`. One shared `implied_allow_http` helper for both paths.
- **`access_key_id` / `secret_access_key` accepted as aliases** — the reference documented those (nonexistent) names, so configs written from the docs were silently dropping credentials.
- **Azure Workload Identity**: YAML `client_id`/`tenant_id` now override the webhook-injected env vars (they were ignored). Pure `resolve_workload_identity` helper, tested with an injected env closure.
- Docs: `docs/configuration.md` S3/Azure tables + examples use the real keys, document `allow_http`, the Azure precedence chain and env vars; `docs/storage_guide.md` URL query params, Azure fields, and the AKS example rewritten as a Job with `use_workload_identity: true` + federated-credential setup.

Tests: alias round-trip, `implied_allow_http`, `use_path_style`, Azure WI precedence. `cargo test -p kafka-backup-core --lib` 354 green; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN