### PR TITLE
feat(cli): describe and validate accept --config (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ kafka-backup three-phase-restore --config restore.yaml   # restore + offset reco
 # Inspect backups
 kafka-backup list --path s3://bucket/prefix
 kafka-backup describe --path s3://bucket --backup-id backup-001 --format json
+kafka-backup describe --config backup.yaml                 # same, using the backup config
 kafka-backup status --config backup.yaml --watch          # live monitoring
 kafka-backup validate --path s3://bucket --backup-id backup-001 --deep
+kafka-backup validate --config backup.yaml --deep
 
 # Restore validation (dry-run)
 kafka-backup validate-restore --config restore.yaml

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use kafka_backup_core::BackupManifest;
 use tracing::info;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 /// Describe command output format
 pub enum OutputFormat {
@@ -21,8 +21,13 @@ impl OutputFormat {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, format: &str) -> Result<()> {
-    let storage = backend_from_path(path)?;
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    format: &str,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     let output_format = OutputFormat::from_str(format);
 
     info!("Loading backup manifest: {}", backup_id);

--- a/crates/kafka-backup-cli/src/commands/prune.rs
+++ b/crates/kafka-backup-cli/src/commands/prune.rs
@@ -5,12 +5,12 @@ use anyhow::{bail, Context, Result};
 use kafka_backup_core::backup::prune::{self, PruneCriteria, PrunePlan};
 use kafka_backup_core::manifest::{BackupManifest, PruneReason};
 use kafka_backup_core::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
-use kafka_backup_core::storage::{create_backend, StorageBackend};
+use kafka_backup_core::storage::StorageBackend;
 use kafka_backup_core::util::parse_duration;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -25,16 +25,8 @@ pub async fn run(
     force: bool,
     format: &str,
 ) -> Result<()> {
-    let (storage, backup_id): (Arc<dyn StorageBackend>, String) = match (config, path, backup_id) {
-        (Some(config_path), None, None) => {
-            let content = tokio::fs::read_to_string(config_path).await?;
-            let content = super::config::expand_env_vars(&content);
-            let cfg = super::config::parse_config(&content)?;
-            (create_backend(&cfg.storage)?, cfg.backup_id)
-        }
-        (None, Some(path), Some(id)) => (backend_from_path(path)?, id.to_string()),
-        _ => bail!("pass either --config, or --path together with --backup-id"),
-    };
+    let (storage, backup_id): (Arc<dyn StorageBackend>, String) =
+        resolve_target(config, path, backup_id).await?;
 
     let cutoff = match (older_than, before) {
         (Some(raw), None) => {

--- a/crates/kafka-backup-cli/src/commands/storage_path.rs
+++ b/crates/kafka-backup-cli/src/commands/storage_path.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use kafka_backup_core::storage::{
     create_backend, FilesystemBackend, StorageBackend, StorageBackendConfig,
 };
@@ -12,4 +12,25 @@ pub fn backend_from_path(path: &str) -> Result<Arc<dyn StorageBackend>> {
     }
 
     Ok(Arc::new(FilesystemBackend::new(PathBuf::from(path))))
+}
+
+/// Resolve the storage backend and backup id from either `--config` (the
+/// backup/restore config file — its storage `prefix` and `backup_id` apply) or
+/// an explicit `--path` + `--backup-id` pair. Shared by prune / describe /
+/// validate so the two conventions behave identically (issue #168).
+pub async fn resolve_target(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+) -> Result<(Arc<dyn StorageBackend>, String)> {
+    match (config, path, backup_id) {
+        (Some(config_path), None, None) => {
+            let content = tokio::fs::read_to_string(config_path).await?;
+            let content = super::config::expand_env_vars(&content);
+            let cfg = super::config::parse_config(&content)?;
+            Ok((create_backend(&cfg.storage)?, cfg.backup_id))
+        }
+        (None, Some(path), Some(id)) => Ok((backend_from_path(path)?, id.to_string())),
+        _ => bail!("pass either --config, or --path together with --backup-id"),
+    }
 }

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -3,7 +3,7 @@ use kafka_backup_core::segment::SegmentReader;
 use kafka_backup_core::BackupManifest;
 use tracing::{error, info, warn};
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[derive(Debug, Default)]
 struct ValidationReport {
@@ -77,10 +77,14 @@ impl ValidationReport {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    deep: bool,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     info!("Validating backup: {} (deep={})", backup_id, deep);
-
-    let storage = backend_from_path(path)?;
     let mut report = ValidationReport::default();
 
     // Load manifest

--- a/crates/kafka-backup-cli/src/main.rs
+++ b/crates/kafka-backup-cli/src/main.rs
@@ -94,16 +94,20 @@ enum Commands {
 
     /// Validate a backup's integrity (checksums, segment counts, manifests)
     #[command(
-        after_help = "Examples:\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
+        after_help = "Examples:\n  kafka-backup validate --config backup.yaml\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
     )]
     Validate {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to validate
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Perform deep validation (read and verify each segment)
         #[arg(long, default_value = "false")]
@@ -159,14 +163,21 @@ enum Commands {
     },
 
     /// Show detailed backup manifest (topics, partitions, time ranges, record counts)
+    #[command(
+        after_help = "Examples:\n  kafka-backup describe --config backup.yaml\n  kafka-backup describe --path s3://bucket --backup-id my-backup --format json"
+    )]
     Describe {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to describe
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Output format (text, json, yaml)
         #[arg(short, long, default_value = "text")]
@@ -584,11 +595,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Validate {
+            config,
             path,
             backup_id,
             deep,
         } => {
-            commands::validate::run(&path, &backup_id, deep).await?;
+            commands::validate::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                deep,
+            )
+            .await?;
         }
         Commands::Prune {
             config,
@@ -617,11 +635,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Describe {
+            config,
             path,
             backup_id,
             format,
         } => {
-            commands::describe::run(&path, &backup_id, &format).await?;
+            commands::describe::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                &format,
+            )
+            .await?;
         }
         Commands::ValidateRestore { config, format } => {
             commands::validate_restore::run(&config, &format).await?;

--- a/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
+++ b/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
@@ -1,0 +1,172 @@
+//! Issue #168 — `describe` and `validate` accept `--config` (parity with
+//! `status` / `prune`), resolving storage (including `prefix`) and the backup
+//! id from the backup configuration file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kb-issue168-{}-{}-{}",
+        name,
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A minimal backup set (manifest + segment files) under `root/<backup_id>/`.
+fn create_backup_set(root: &Path, backup_id: &str) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+    let name = "segment-00000000000000000000.bin.zst";
+    let payload = "fake-segment";
+    fs::write(seg_dir.join(name), payload).unwrap();
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 60_000,
+        "compression": "zstd",
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": [{
+                "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+                "start_offset": 0,
+                "end_offset": 9,
+                "start_timestamp": now - 60_000,
+                "end_timestamp": now - 1_000,
+                "record_count": 10,
+                "uncompressed_size": payload.len() * 4,
+                "compressed_size": payload.len(),
+                "uploaded_at": now,
+            }]}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_config(dir: &Path, storage_root: &Path, backup_id: &str) -> PathBuf {
+    let path = dir.join("backup.yaml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+mode: backup
+backup_id: {backup_id}
+source:
+  bootstrap_servers: ["127.0.0.1:1"]
+storage:
+  backend: filesystem
+  path: {root}
+"#,
+            root = storage_root.display()
+        ),
+    )
+    .unwrap();
+    path
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .unwrap()
+}
+
+fn text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn describe_accepts_config() {
+    let dir = scratch_dir("describe");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["describe", "--config", config.to_str().unwrap(), "--format", "json"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json manifest");
+    assert_eq!(value["backup_id"], serde_json::json!("daily"), "{all}");
+
+    // Same result as the explicit --path/--backup-id form.
+    let out_path = run(&[
+        "describe",
+        "--path",
+        storage.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+        "--format",
+        "json",
+    ]);
+    assert!(out_path.status.success(), "{}", text(&out_path));
+    assert_eq!(out.stdout, out_path.stdout, "--config and --path must agree");
+}
+
+#[test]
+fn validate_accepts_config() {
+    let dir = scratch_dir("validate");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["validate", "--config", config.to_str().unwrap()]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("VALID"), "{all}");
+}
+
+#[test]
+fn config_and_path_are_mutually_exclusive() {
+    let dir = scratch_dir("conflict");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    for cmd in ["describe", "validate"] {
+        let out = run(&[
+            cmd,
+            "--config",
+            config.to_str().unwrap(),
+            "--path",
+            storage.to_str().unwrap(),
+            "--backup-id",
+            "daily",
+        ]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+
+        // --path without --backup-id (and vice versa) is a usage error too.
+        let out = run(&[cmd, "--path", storage.to_str().unwrap()]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+        let out = run(&[cmd, "--backup-id", "daily"]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+    }
+}
+
+#[test]
+fn prune_still_resolves_from_config() {
+    let dir = scratch_dir("prune");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    // Plan-only prune through the shared resolver (regression for #169).
+    let out = run(&["prune", "--config", config.to_str().unwrap(), "--older-than", "30d"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Prune plan for 'daily'"), "{all}");
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1014,25 +1014,29 @@ kafka-backup list --path /path/to/storage [OPTIONS]
 ### Describe Command
 
 ```bash
+kafka-backup describe --config backup.yaml [OPTIONS]
 kafka-backup describe --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--format` | Output format |
 
 ### Validate Command
 
 ```bash
+kafka-backup validate --config backup.yaml [OPTIONS]
 kafka-backup validate --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--deep` | Perform deep validation |
 
 ### Prune Command


### PR DESCRIPTION
Part 2 of the 0.22.0 release branch — stacked on #180 (base retargets to `release/0.22.0` when #180 merges).

Closes #168. `describe` and `validate` now take `--config backup.yaml` like `status` and `prune`, resolving storage (including `prefix`) and `backup_id` from the config; `--path` + `--backup-id` still work and the two forms are mutually exclusive (clap `conflicts_with_all` / `requires`). One shared resolver `commands/storage_path.rs::resolve_target`, lifted from prune, used by all three commands.

Tests: `tests/issue_168_config_flag.rs` — `describe --config` == `--path` JSON, `validate --config` VALID, conflicts and missing pairs exit 2, prune regression through the shared resolver. Docs: README usage lines, `docs/configuration.md` describe/validate tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN