### PR TITLE
fix(config): honour offset_storage.sync_interval_secs; warn on ignored offset-storage keys (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ kafka-backup three-phase-restore --config restore.yaml   # restore + offset reco
 # Inspect backups
 kafka-backup list --path s3://bucket/prefix
 kafka-backup describe --path s3://bucket --backup-id backup-001 --format json
+kafka-backup describe --config backup.yaml                 # same, using the backup config
 kafka-backup status --config backup.yaml --watch          # live monitoring
 kafka-backup validate --path s3://bucket --backup-id backup-001 --deep
+kafka-backup validate --config backup.yaml --deep
 
 # Restore validation (dry-run)
 kafka-backup validate-restore --config restore.yaml

--- a/config/example-backup-azure.yaml
+++ b/config/example-backup-azure.yaml
@@ -67,8 +67,7 @@ backup:
   segment_max_bytes: 134217728
   segment_max_interval_ms: 60000
 
-  # Checkpoint settings
-  checkpoint_interval_secs: 5
+  # Remote sync interval for the manifest and offset store
   sync_interval_secs: 30
 
   # Offset-tracking headers (default: true) — adds x-original-offset /

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use kafka_backup_core::BackupManifest;
 use tracing::info;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 /// Describe command output format
 pub enum OutputFormat {
@@ -21,8 +21,13 @@ impl OutputFormat {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, format: &str) -> Result<()> {
-    let storage = backend_from_path(path)?;
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    format: &str,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     let output_format = OutputFormat::from_str(format);
 
     info!("Loading backup manifest: {}", backup_id);

--- a/crates/kafka-backup-cli/src/commands/prune.rs
+++ b/crates/kafka-backup-cli/src/commands/prune.rs
@@ -5,12 +5,12 @@ use anyhow::{bail, Context, Result};
 use kafka_backup_core::backup::prune::{self, PruneCriteria, PrunePlan};
 use kafka_backup_core::manifest::{BackupManifest, PruneReason};
 use kafka_backup_core::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
-use kafka_backup_core::storage::{create_backend, StorageBackend};
+use kafka_backup_core::storage::StorageBackend;
 use kafka_backup_core::util::parse_duration;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -25,16 +25,8 @@ pub async fn run(
     force: bool,
     format: &str,
 ) -> Result<()> {
-    let (storage, backup_id): (Arc<dyn StorageBackend>, String) = match (config, path, backup_id) {
-        (Some(config_path), None, None) => {
-            let content = tokio::fs::read_to_string(config_path).await?;
-            let content = super::config::expand_env_vars(&content);
-            let cfg = super::config::parse_config(&content)?;
-            (create_backend(&cfg.storage)?, cfg.backup_id)
-        }
-        (None, Some(path), Some(id)) => (backend_from_path(path)?, id.to_string()),
-        _ => bail!("pass either --config, or --path together with --backup-id"),
-    };
+    let (storage, backup_id): (Arc<dyn StorageBackend>, String) =
+        resolve_target(config, path, backup_id).await?;
 
     let cutoff = match (older_than, before) {
         (Some(raw), None) => {

--- a/crates/kafka-backup-cli/src/commands/storage_path.rs
+++ b/crates/kafka-backup-cli/src/commands/storage_path.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use kafka_backup_core::storage::{
     create_backend, FilesystemBackend, StorageBackend, StorageBackendConfig,
 };
@@ -12,4 +12,25 @@ pub fn backend_from_path(path: &str) -> Result<Arc<dyn StorageBackend>> {
     }
 
     Ok(Arc::new(FilesystemBackend::new(PathBuf::from(path))))
+}
+
+/// Resolve the storage backend and backup id from either `--config` (the
+/// backup/restore config file — its storage `prefix` and `backup_id` apply) or
+/// an explicit `--path` + `--backup-id` pair. Shared by prune / describe /
+/// validate so the two conventions behave identically (issue #168).
+pub async fn resolve_target(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+) -> Result<(Arc<dyn StorageBackend>, String)> {
+    match (config, path, backup_id) {
+        (Some(config_path), None, None) => {
+            let content = tokio::fs::read_to_string(config_path).await?;
+            let content = super::config::expand_env_vars(&content);
+            let cfg = super::config::parse_config(&content)?;
+            Ok((create_backend(&cfg.storage)?, cfg.backup_id))
+        }
+        (None, Some(path), Some(id)) => Ok((backend_from_path(path)?, id.to_string())),
+        _ => bail!("pass either --config, or --path together with --backup-id"),
+    }
 }

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -3,7 +3,7 @@ use kafka_backup_core::segment::SegmentReader;
 use kafka_backup_core::BackupManifest;
 use tracing::{error, info, warn};
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[derive(Debug, Default)]
 struct ValidationReport {
@@ -77,10 +77,14 @@ impl ValidationReport {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    deep: bool,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     info!("Validating backup: {} (deep={})", backup_id, deep);
-
-    let storage = backend_from_path(path)?;
     let mut report = ValidationReport::default();
 
     // Load manifest

--- a/crates/kafka-backup-cli/src/main.rs
+++ b/crates/kafka-backup-cli/src/main.rs
@@ -94,16 +94,20 @@ enum Commands {
 
     /// Validate a backup's integrity (checksums, segment counts, manifests)
     #[command(
-        after_help = "Examples:\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
+        after_help = "Examples:\n  kafka-backup validate --config backup.yaml\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
     )]
     Validate {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to validate
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Perform deep validation (read and verify each segment)
         #[arg(long, default_value = "false")]
@@ -159,14 +163,21 @@ enum Commands {
     },
 
     /// Show detailed backup manifest (topics, partitions, time ranges, record counts)
+    #[command(
+        after_help = "Examples:\n  kafka-backup describe --config backup.yaml\n  kafka-backup describe --path s3://bucket --backup-id my-backup --format json"
+    )]
     Describe {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to describe
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Output format (text, json, yaml)
         #[arg(short, long, default_value = "text")]
@@ -584,11 +595,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Validate {
+            config,
             path,
             backup_id,
             deep,
         } => {
-            commands::validate::run(&path, &backup_id, deep).await?;
+            commands::validate::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                deep,
+            )
+            .await?;
         }
         Commands::Prune {
             config,
@@ -617,11 +635,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Describe {
+            config,
             path,
             backup_id,
             format,
         } => {
-            commands::describe::run(&path, &backup_id, &format).await?;
+            commands::describe::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                &format,
+            )
+            .await?;
         }
         Commands::ValidateRestore { config, format } => {
             commands::validate_restore::run(&config, &format).await?;

--- a/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
+++ b/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
@@ -1,0 +1,172 @@
+//! Issue #168 — `describe` and `validate` accept `--config` (parity with
+//! `status` / `prune`), resolving storage (including `prefix`) and the backup
+//! id from the backup configuration file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kb-issue168-{}-{}-{}",
+        name,
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A minimal backup set (manifest + segment files) under `root/<backup_id>/`.
+fn create_backup_set(root: &Path, backup_id: &str) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+    let name = "segment-00000000000000000000.bin.zst";
+    let payload = "fake-segment";
+    fs::write(seg_dir.join(name), payload).unwrap();
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 60_000,
+        "compression": "zstd",
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": [{
+                "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+                "start_offset": 0,
+                "end_offset": 9,
+                "start_timestamp": now - 60_000,
+                "end_timestamp": now - 1_000,
+                "record_count": 10,
+                "uncompressed_size": payload.len() * 4,
+                "compressed_size": payload.len(),
+                "uploaded_at": now,
+            }]}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_config(dir: &Path, storage_root: &Path, backup_id: &str) -> PathBuf {
+    let path = dir.join("backup.yaml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+mode: backup
+backup_id: {backup_id}
+source:
+  bootstrap_servers: ["127.0.0.1:1"]
+storage:
+  backend: filesystem
+  path: {root}
+"#,
+            root = storage_root.display()
+        ),
+    )
+    .unwrap();
+    path
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .unwrap()
+}
+
+fn text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn describe_accepts_config() {
+    let dir = scratch_dir("describe");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["describe", "--config", config.to_str().unwrap(), "--format", "json"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json manifest");
+    assert_eq!(value["backup_id"], serde_json::json!("daily"), "{all}");
+
+    // Same result as the explicit --path/--backup-id form.
+    let out_path = run(&[
+        "describe",
+        "--path",
+        storage.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+        "--format",
+        "json",
+    ]);
+    assert!(out_path.status.success(), "{}", text(&out_path));
+    assert_eq!(out.stdout, out_path.stdout, "--config and --path must agree");
+}
+
+#[test]
+fn validate_accepts_config() {
+    let dir = scratch_dir("validate");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["validate", "--config", config.to_str().unwrap()]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("VALID"), "{all}");
+}
+
+#[test]
+fn config_and_path_are_mutually_exclusive() {
+    let dir = scratch_dir("conflict");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    for cmd in ["describe", "validate"] {
+        let out = run(&[
+            cmd,
+            "--config",
+            config.to_str().unwrap(),
+            "--path",
+            storage.to_str().unwrap(),
+            "--backup-id",
+            "daily",
+        ]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+
+        // --path without --backup-id (and vice versa) is a usage error too.
+        let out = run(&[cmd, "--path", storage.to_str().unwrap()]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+        let out = run(&[cmd, "--backup-id", "daily"]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+    }
+}
+
+#[test]
+fn prune_still_resolves_from_config() {
+    let dir = scratch_dir("prune");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    // Plan-only prune through the shared resolver (regression for #169).
+    let out = run(&["prune", "--config", config.to_str().unwrap(), "--older-than", "30d"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Prune plan for 'daily'"), "{all}");
+}

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -93,6 +93,23 @@ struct OffsetPersistence {
     sync_interval: Duration,
 }
 
+/// Remote key of the offset database for a backup set. Fixed by design —
+/// `prune`, `status` and the operators all assume it (issue #161).
+pub fn offsets_key(backup_id: &str) -> String {
+    format!("{}/offsets.db", backup_id)
+}
+
+/// `offset_storage.sync_interval_secs` overrides `backup.sync_interval_secs`
+/// for the offset database sync; the backup value applies when unset.
+fn effective_offset_sync_secs(
+    offset_storage: Option<&crate::config::OffsetStorageConfig>,
+    backup: &crate::config::BackupOptions,
+) -> u64 {
+    offset_storage
+        .and_then(|os| os.sync_interval_secs)
+        .unwrap_or(backup.sync_interval_secs)
+}
+
 impl OffsetPersistence {
     fn new(
         backup_id: String,
@@ -112,10 +129,7 @@ impl OffsetPersistence {
     async fn sync_now(&self) -> Result<()> {
         let mut last_sync = self.sync_lock.lock().await;
         self.offset_store
-            .sync_to_storage(
-                self.storage.as_ref(),
-                &format!("{}/offsets.db", self.backup_id),
-            )
+            .sync_to_storage(self.storage.as_ref(), &offsets_key(&self.backup_id))
             .await?;
 
         *last_sync = Some(Instant::now());
@@ -129,10 +143,7 @@ impl OffsetPersistence {
         }
 
         self.offset_store
-            .sync_to_storage(
-                self.storage.as_ref(),
-                &format!("{}/offsets.db", self.backup_id),
-            )
+            .sync_to_storage(self.storage.as_ref(), &offsets_key(&self.backup_id))
             .await?;
         *last_sync = Some(Instant::now());
         Ok(())
@@ -220,9 +231,12 @@ impl BackupEngine {
 
             let offset_config = OffsetStoreConfig {
                 db_path,
-                s3_key: Some(format!("{}/offsets.db", config.backup_id)),
+                s3_key: Some(offsets_key(&config.backup_id)),
                 checkpoint_interval_secs: backup_opts.checkpoint_interval_secs,
-                sync_interval_secs: backup_opts.sync_interval_secs,
+                sync_interval_secs: effective_offset_sync_secs(
+                    config.offset_storage.as_ref(),
+                    &backup_opts,
+                ),
             };
             Some(Arc::new(SqliteOffsetStore::new(offset_config).await?))
         } else {
@@ -243,7 +257,10 @@ impl BackupEngine {
                 config.backup_id.clone(),
                 storage.clone(),
                 offset_store.clone(),
-                Duration::from_secs(backup_opts.sync_interval_secs),
+                Duration::from_secs(effective_offset_sync_secs(
+                    config.offset_storage.as_ref(),
+                    &backup_opts,
+                )),
             ))
         });
 
@@ -322,10 +339,7 @@ impl BackupEngine {
         // Try to load offset store from remote if continuous
         if let Some(ref offset_store) = self.offset_store {
             if let Err(e) = offset_store
-                .try_load_from_storage(
-                    self.storage.as_ref(),
-                    &format!("{}/offsets.db", self.config.backup_id),
-                )
+                .try_load_from_storage(self.storage.as_ref(), &offsets_key(&self.config.backup_id))
                 .await
             {
                 warn!("Failed to load offset store from remote: {}", e);
@@ -2833,5 +2847,26 @@ mod tests {
         let (topic, partition, gap) = merged.gaps().next().unwrap();
         assert_eq!((topic, partition), ("orders", 1));
         assert_eq!(gap, &make_gap(0, 50));
+    }
+
+    #[test]
+    fn effective_offset_sync_secs_precedence() {
+        use crate::config::{BackupOptions, OffsetStorageConfig};
+        let backup = BackupOptions {
+            sync_interval_secs: 5,
+            ..Default::default()
+        };
+        // No offset_storage section → backup value.
+        assert_eq!(effective_offset_sync_secs(None, &backup), 5);
+        // Section present but interval unset → backup value (no silent reset to 30).
+        let unset = OffsetStorageConfig::default();
+        assert_eq!(effective_offset_sync_secs(Some(&unset), &backup), 5);
+        // Explicit override wins.
+        let set = OffsetStorageConfig {
+            sync_interval_secs: Some(60),
+            ..Default::default()
+        };
+        assert_eq!(effective_offset_sync_secs(Some(&set), &backup), 60);
+        assert_eq!(offsets_key("daily"), "daily/offsets.db");
     }
 }

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use tracing::warn;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,7 +121,8 @@ fn default_max_partition_labels() -> usize {
 /// Offset storage configuration for tracking backup progress
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OffsetStorageConfig {
-    /// Storage backend type (sqlite or memory)
+    /// Storage backend type. **Deprecated since 0.22.0** — only `sqlite` is
+    /// implemented; `memory` is accepted but ignored (a warning is logged).
     #[serde(default)]
     pub backend: OffsetStorageBackend,
 
@@ -128,13 +130,17 @@ pub struct OffsetStorageConfig {
     #[serde(default = "default_db_path")]
     pub db_path: PathBuf,
 
-    /// S3 key for syncing offset database
+    /// **Deprecated since 0.22.0 — ignored.** The offset database is always
+    /// stored at `{backup_id}/offsets.db` under the storage prefix (`prune`,
+    /// `status` and the operator rely on that location). A warning is logged
+    /// when this is set.
     #[serde(default)]
     pub s3_key: Option<String>,
 
-    /// Sync interval to remote storage in seconds (default: 30)
-    #[serde(default = "default_sync_interval_secs")]
-    pub sync_interval_secs: u64,
+    /// Override `backup.sync_interval_secs` for syncing the offset database to
+    /// remote storage. When unset the backup value (default 30) applies.
+    #[serde(default)]
+    pub sync_interval_secs: Option<u64>,
 }
 
 impl Default for OffsetStorageConfig {
@@ -143,7 +149,7 @@ impl Default for OffsetStorageConfig {
             backend: OffsetStorageBackend::default(),
             db_path: default_db_path(),
             s3_key: None,
-            sync_interval_secs: default_sync_interval_secs(),
+            sync_interval_secs: None,
         }
     }
 }
@@ -434,7 +440,9 @@ pub struct BackupOptions {
     #[serde(default)]
     pub internal_topics: Vec<String>,
 
-    /// Checkpoint interval in seconds (default: 5)
+    /// **Deprecated since 0.22.0 — no effect.** Offsets are checkpointed at
+    /// the end of every backup cycle; a warning is logged when this is set to
+    /// a non-default value.
     #[serde(default = "default_checkpoint_interval_secs")]
     pub checkpoint_interval_secs: u64,
 
@@ -1104,8 +1112,44 @@ impl Config {
         Ok((config, ignored))
     }
 
+    /// Keys that are accepted for backwards compatibility but have no effect
+    /// (issue #161). Pure so it can be unit-tested; `validate()` logs each one.
+    pub fn deprecation_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if let Some(os) = &self.offset_storage {
+            if os.s3_key.is_some() {
+                warnings.push(
+                    "offset_storage.s3_key is ignored (deprecated since 0.22.0): the offset \
+                     database is always stored at {backup_id}/offsets.db under the storage prefix"
+                        .to_string(),
+                );
+            }
+            if os.backend == OffsetStorageBackend::Memory {
+                warnings.push(
+                    "offset_storage.backend: memory is not implemented (deprecated since 0.22.0); \
+                     sqlite is used"
+                        .to_string(),
+                );
+            }
+        }
+        if let Some(backup) = &self.backup {
+            if backup.checkpoint_interval_secs != default_checkpoint_interval_secs() {
+                warnings.push(
+                    "backup.checkpoint_interval_secs has no effect (deprecated since 0.22.0): \
+                     offsets are checkpointed at the end of every backup cycle"
+                        .to_string(),
+                );
+            }
+        }
+        warnings
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> crate::Result<()> {
+        for warning in self.deprecation_warnings() {
+            warn!("{}", warning);
+        }
+
         match self.mode {
             Mode::Backup => {
                 if self.source.is_none() {
@@ -1662,5 +1706,58 @@ repartitioning:
             },
         );
         assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn deprecation_warnings_list_ignored_offset_keys() {
+        let yaml = r#"
+mode: backup
+backup_id: dep
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+backup:
+  checkpoint_interval_secs: 30
+offset_storage:
+  backend: memory
+  s3_key: custom/offsets.db
+  sync_interval_secs: 60
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let warnings = config.deprecation_warnings();
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings.iter().any(|w| w.contains("offset_storage.s3_key")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("offset_storage.backend")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("backup.checkpoint_interval_secs")));
+        assert_eq!(
+            config.offset_storage.as_ref().unwrap().sync_interval_secs,
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn deprecation_warnings_empty_for_defaults() {
+        let yaml = r#"
+mode: backup
+backup_id: clean
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+offset_storage:
+  db_path: /tmp/offsets.db
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.deprecation_warnings().is_empty());
+        assert_eq!(
+            config.offset_storage.as_ref().unwrap().sync_interval_secs,
+            None,
+            "unset means: use backup.sync_interval_secs"
+        );
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1014,25 +1014,29 @@ kafka-backup list --path /path/to/storage [OPTIONS]
 ### Describe Command
 
 ```bash
+kafka-backup describe --config backup.yaml [OPTIONS]
 kafka-backup describe --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--format` | Output format |
 
 ### Validate Command
 
 ```bash
+kafka-backup validate --config backup.yaml [OPTIONS]
 kafka-backup validate --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--deep` | Perform deep validation |
 
 ### Prune Command

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -401,8 +401,8 @@ the values in `kafka-backup-core`'s `BackupOptions::default()`.
 | `segment_max_interval_ms` | int | No | `60000` | Rotate a segment after this many milliseconds even if it is not full |
 | `segment_max_records` | int | No | unset | Rotate a segment after this many records (no record limit when unset) |
 | `fetch_max_bytes` | int | No | unset | Max bytes per Kafka Fetch request; when unset, `min(segment_max_bytes, 16MB)` |
-| `checkpoint_interval_secs` | int | No | `5` | How often partition progress is checkpointed to the offset store |
-| `sync_interval_secs` | int | No | `30` | How often the offset store is synced to remote storage |
+| `checkpoint_interval_secs` | int | No | `5` | **Deprecated (0.22.0) — no effect.** Offsets are checkpointed at the end of every backup cycle; a warning is logged if set |
+| `sync_interval_secs` | int | No | `30` | How often the manifest and the offset store are synced to remote storage (`offset_storage.sync_interval_secs` overrides it for the offset store) |
 | `include_offset_headers` | bool | No | **`true`** | Add `x-original-offset` / `x-original-timestamp` headers to every archived record — see [Offset-tracking headers](#offset-tracking-headers) |
 | `source_cluster_id` | string | No | unset | Recorded in the `x-source-cluster` header (only with `include_offset_headers`) |
 | `include_internal_topics` | bool | No | `false` | Also back up internal topics listed in `internal_topics` |
@@ -544,7 +544,6 @@ broker-side codec (including gzip and snappy) is decoded on fetch.
 backup:
   compression: zstd
   continuous: true
-  checkpoint_interval_secs: 30
   segment_max_records: 50000
   segment_max_bytes: 52428800     # 50MB
   segment_max_interval_ms: 1800000 # 30 minutes
@@ -560,7 +559,6 @@ backup:
   stop_at_current_offsets: true  # Exit when caught up
   include_offset_headers: true    # Default; x-original-* headers for offset recovery on restore
   source_cluster_id: prod-eu      # Optional; recorded as x-source-cluster
-  checkpoint_interval_secs: 30
   segment_max_bytes: 134217728    # 128MB
 ```
 
@@ -580,10 +578,10 @@ Configuration for the local SQLite database used to track backup progress. When 
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `offset_storage.backend` | string | No | `sqlite` | Storage backend: `sqlite` or `memory` |
+| `offset_storage.backend` | string | No | `sqlite` | Only `sqlite` is implemented; `memory` is **deprecated (0.22.0)** and ignored with a warning |
 | `offset_storage.db_path` | string | No | `$TMPDIR/{backup_id}-offsets.db` | Path to local SQLite database file |
-| `offset_storage.s3_key` | string | No | - | Remote storage key for syncing the database |
-| `offset_storage.sync_interval_secs` | int | No | `30` | How often to sync the local DB to remote storage |
+| `offset_storage.s3_key` | string | No | - | **Deprecated (0.22.0) — ignored.** The database is always stored at `{backup_id}/offsets.db` under the storage prefix (`prune`/`status`/operators rely on it); a warning is logged if set |
+| `offset_storage.sync_interval_secs` | int | No | `backup.sync_interval_secs` | Override for how often the local DB is synced to remote storage (honoured since 0.22.0) |
 
 The offset store is created when `continuous: true` is set **or** when `offset_storage` is explicitly configured. This allows incremental one-shot and snapshot backups by adding the `offset_storage` section to your config:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -368,7 +368,6 @@ Run backup continuously to capture all changes:
 ```yaml
 backup:
   continuous: true
-  checkpoint_interval_secs: 5
 ```
 
 ### 3. Consumer Offset Management


### PR DESCRIPTION
Part 3 of the 0.22.0 release branch (includes #181's commits until it merges).

Closes #161 (option A — deprecate rather than implement `s3_key`; the remote offsets.db location is fixed by design because `prune`, `status` and both operators assume `{backup_id}/offsets.db`, and the generic operator even prefixes its `s3_key` value, which would double-prefix if honoured).

- **Honoured:** `offset_storage.sync_interval_secs` now overrides `backup.sync_interval_secs` for the offset-DB sync. The field became `Option<u64>` so 'unset' is distinguishable from 30 — otherwise a tuned `backup.sync_interval_secs` would silently regress whenever an `offset_storage:` block is present.
- **Warned (deprecated since 0.22.0, no behaviour change):** `offset_storage.s3_key`, `offset_storage.backend: memory`, non-default `backup.checkpoint_interval_secs` (it never had a read site; offsets are checkpointed every cycle). `Config::deprecation_warnings()` is pure and tested; `validate()` logs each entry, so both the CLI and library users (operators) see it once per run.
- `offsets_key()` + `effective_offset_sync_secs()` helpers in the engine; docs updated (rows marked, backup examples no longer show `checkpoint_interval_secs`).

Library API note for the release changelog: `OffsetStorageConfig.sync_interval_secs: Option<u64>` (the generic operator builds this struct by literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN