### PR TITLE
chore(release): 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2026-09-07
+
+### Added
+- `backup.on_missing_topic: fail | warn` — what to do when a literal (non-glob)
+  `topics.include` entry does not exist in the cluster. `fail` (default) keeps
+  the current behaviour; `warn` logs, records the absent names in the manifest's
+  new `missing_topics` field, exposes the `kafka_backup_missing_topics` gauge
+  (re-evaluated every cycle) and continues — a run with nothing left to back up
+  still fails. `describe` and `validate` show the recorded topics (informational,
+  never an integrity failure). Globs that match nothing are unaffected.
+  ([#167](https://github.com/osodevops/kafka-backup/issues/167))
+- `describe` and `validate` accept `--config backup.yaml` (parity with `status`
+  and `prune`): storage — including `prefix` — and `backup_id` come from the
+  backup configuration. `--path` + `--backup-id` still work; the two forms are
+  mutually exclusive. ([#168](https://github.com/osodevops/kafka-backup/issues/168))
+- S3 config accepts `access_key_id` / `secret_access_key` as aliases of
+  `access_key` / `secret_key` — the configuration reference documented the
+  former, so configs written from it were silently dropping credentials.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+
+### Fixed
+- S3 `path_style` was discarded by the backend factory; path-style requests are
+  now used when set explicitly or implied by a custom `endpoint` (plain-AWS
+  default unchanged). ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+- A YAML `storage.endpoint` starting with `http://` now implies `allow_http`
+  (logged at info), matching the `--path` URL behaviour, so on-prem HTTP stores
+  (Ceph RGW, MinIO) work without `AWS_ALLOW_HTTP`.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+- Azure Workload Identity: YAML `client_id` / `tenant_id` now take precedence
+  over the webhook-injected `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` (they were
+  ignored on that path).
+- `offset_storage.sync_interval_secs` is honoured: it overrides
+  `backup.sync_interval_secs` for the offset-database sync; when unset the
+  backup value applies. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- Documentation: the S3 and Azure sections of the configuration reference now
+  list the real option names (`allow_http`, `use_workload_identity`, `client_id`,
+  `tenant_id`, `client_secret`, `endpoint`), the Azure credential precedence and
+  environment variables (including `AZURE_FEDERATED_TOKEN_FILE`), the `--path`
+  URL query parameters, and an AKS Workload Identity example as a Job.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+
+### Deprecated
+- `offset_storage.s3_key` — ignored; the offset database is always stored at
+  `{backup_id}/offsets.db` under the storage prefix (`prune`, `status` and the
+  operators rely on it). A warning is logged when set.
+  ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- `offset_storage.backend: memory` — not implemented; `sqlite` is used and a
+  warning is logged. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- `backup.checkpoint_interval_secs` — never had an effect; offsets are
+  checkpointed at the end of every backup cycle. A warning is logged when set to
+  a non-default value. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+
+### Changed
+- **Breaking (library API):** `BackupOptions` gains `on_missing_topic`,
+  `BackupManifest` gains `missing_topics`, `OffsetStorageConfig::sync_interval_secs`
+  is now `Option<u64>`, and `storage::S3Config` gains `path_style`. Consumers
+  that build these structs by literal (the generic kafka-backup-operator does)
+  must add the fields — `..Default::default()` where available.
+
 ## [0.21.0] - 2026-08-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,9 +255,11 @@ kafka-backup list --path s3://bucket/prefix
 
 # Describe backup
 kafka-backup describe --path s3://bucket --backup-id backup-001 --format json
+kafka-backup describe --config backup.yaml --format json   # storage + backup_id from the config
 
 # Validate backup integrity
 kafka-backup validate --path s3://bucket --backup-id backup-001 --deep
+kafka-backup validate --config backup.yaml --deep
 
 # Offset management
 kafka-backup offset-reset plan --path s3://bucket --backup-id backup-001 --groups my-group
@@ -314,7 +316,7 @@ storage:
 backup:
   compression: zstd | lz4 | none
   segment_max_bytes: 134217728  # 128MB
-  checkpoint_interval_secs: 5
+  on_missing_topic: fail           # or warn: skip absent literal topics, record them (0.22.0)
   max_concurrent_partitions: 8
   include_offset_headers: true  # default; adds x-original-offset / x-original-timestamp to every archived record
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -103,6 +103,16 @@ fn print_manifest_text(manifest: &BackupManifest) {
             )
         );
     }
+    if !manifest.missing_topics.is_empty() {
+        println!(
+            "║ Missing Topics: {:55} ║",
+            format!(
+                "{} (configured but absent at last run: {})",
+                manifest.missing_topics.len(),
+                manifest.missing_topics.join(", ")
+            )
+        );
+    }
 
     // Calculate total size
     let total_compressed: u64 = manifest

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -23,6 +23,9 @@ struct ValidationReport {
     /// Ranges deliberately deleted by retention (`prune` /
     /// `backup.retention`). Informational, never an integrity failure.
     pruned_ranges: Vec<String>,
+    /// Literal include topics absent from the cluster at the last backup run
+    /// and skipped (`backup.on_missing_topic: warn`). Not an integrity failure.
+    missing_topics: Vec<String>,
 }
 
 impl ValidationReport {
@@ -39,6 +42,7 @@ impl ValidationReport {
         println!("Records Validated:  {}", self.records_validated);
         println!("Data Gaps:          {}", self.data_gaps.len());
         println!("Pruned Ranges:      {}", self.pruned_ranges.len());
+        println!("Missing Topics:     {}", self.missing_topics.len());
 
         if !self.issues.is_empty() {
             println!("\nIssues Found:");
@@ -62,6 +66,16 @@ impl ValidationReport {
             println!("\nPruned Ranges (deliberately deleted by retention — not data loss):");
             for range in &self.pruned_ranges {
                 println!("  - {}", range);
+            }
+        }
+
+        if !self.missing_topics.is_empty() {
+            println!(
+                "\nMissing Topics (configured with backup.on_missing_topic: warn and absent during \
+                 the backup — not an integrity failure):"
+            );
+            for topic in &self.missing_topics {
+                println!("  - {}", topic);
             }
         }
 
@@ -156,6 +170,9 @@ pub async fn run(
             when
         ));
     }
+
+    // Literal include topics skipped under on_missing_topic: warn (issue #167).
+    report.missing_topics = manifest.missing_topics.clone();
 
     // Validate each segment
     for topic in &manifest.topics {

--- a/crates/kafka-backup-cli/tests/issue_167_missing_topics.rs
+++ b/crates/kafka-backup-cli/tests/issue_167_missing_topics.rs
@@ -1,0 +1,135 @@
+//! Issue #167 — a manifest that records literal include topics skipped under
+//! `backup.on_missing_topic: warn` is surfaced by `describe` and `validate`
+//! without being treated as an integrity failure.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kb-issue167-{}-{}-{}",
+        name,
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn create_backup_set(root: &Path, backup_id: &str, missing: &[&str]) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+    let name = "segment-00000000000000000000.bin.zst";
+    let payload = "fake-segment";
+    fs::write(seg_dir.join(name), payload).unwrap();
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 60_000,
+        "compression": "zstd",
+        "missing_topics": missing,
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": [{
+                "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+                "start_offset": 0,
+                "end_offset": 9,
+                "start_timestamp": now - 60_000,
+                "end_timestamp": now - 1_000,
+                "record_count": 10,
+                "uncompressed_size": payload.len() * 4,
+                "compressed_size": payload.len(),
+                "uploaded_at": now,
+            }]}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .unwrap()
+}
+
+fn text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn describe_reports_missing_topics() {
+    let dir = scratch_dir("describe");
+    create_backup_set(&dir, "daily", &["payments", "ghost"]);
+    let root = dir.to_str().unwrap();
+
+    let out = run(&["describe", "--path", root, "--backup-id", "daily"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Missing Topics: 2"), "{all}");
+    assert!(all.contains("payments, ghost"), "{all}");
+
+    let out = run(&[
+        "describe",
+        "--path",
+        root,
+        "--backup-id",
+        "daily",
+        "--format",
+        "json",
+    ]);
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(
+        value["missing_topics"],
+        serde_json::json!(["payments", "ghost"])
+    );
+}
+
+#[test]
+fn validate_lists_missing_topics_and_stays_valid() {
+    let dir = scratch_dir("validate");
+    create_backup_set(&dir, "daily", &["ghost"]);
+
+    let out = run(&[
+        "validate",
+        "--path",
+        dir.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+    ]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Missing Topics:     1"), "{all}");
+    assert!(all.contains("not an integrity failure"), "{all}");
+    assert!(all.contains("- ghost"), "{all}");
+    assert!(all.contains("Result: VALID"), "{all}");
+}
+
+#[test]
+fn manifests_without_the_field_are_unaffected() {
+    let dir = scratch_dir("legacy");
+    create_backup_set(&dir, "daily", &[]);
+
+    let out = run(&[
+        "describe",
+        "--path",
+        dir.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+    ]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(!all.contains("Missing Topics"), "{all}");
+}

--- a/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
+++ b/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
@@ -97,7 +97,13 @@ fn describe_accepts_config() {
     create_backup_set(&storage, "daily");
     let config = write_config(&dir, &storage, "daily");
 
-    let out = run(&["describe", "--config", config.to_str().unwrap(), "--format", "json"]);
+    let out = run(&[
+        "describe",
+        "--config",
+        config.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
     let all = text(&out);
     assert!(out.status.success(), "{all}");
     let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json manifest");
@@ -114,7 +120,10 @@ fn describe_accepts_config() {
         "json",
     ]);
     assert!(out_path.status.success(), "{}", text(&out_path));
-    assert_eq!(out.stdout, out_path.stdout, "--config and --path must agree");
+    assert_eq!(
+        out.stdout, out_path.stdout,
+        "--config and --path must agree"
+    );
 }
 
 #[test]
@@ -165,7 +174,13 @@ fn prune_still_resolves_from_config() {
     let config = write_config(&dir, &storage, "daily");
 
     // Plan-only prune through the shared resolver (regression for #169).
-    let out = run(&["prune", "--config", config.to_str().unwrap(), "--older-than", "30d"]);
+    let out = run(&[
+        "prune",
+        "--config",
+        config.to_str().unwrap(),
+        "--older-than",
+        "30d",
+    ]);
     let all = text(&out);
     assert!(out.status.success(), "{all}");
     assert!(all.contains("Prune plan for 'daily'"), "{all}");

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -568,7 +568,7 @@ impl BackupEngine {
             // the cycle. This catches topics deleted while a backup is running
             // before a zero-record/empty-artifact result can be reported as
             // successful.
-            self.ensure_literal_topic_includes_exist(&source.topics)
+            self.ensure_literal_topic_includes_exist(&source.topics, &backup_opts)
                 .await?;
 
             // Checkpoint offsets
@@ -773,7 +773,8 @@ impl BackupEngine {
         // Fetch ALL topic metadata in a single bulk call
         let all_topics = self.router.fetch_metadata(None).await?;
 
-        fail_if_literal_topic_includes_missing(selection, &all_topics)?;
+        let missing =
+            check_literal_topic_includes(backup_opts.on_missing_topic, selection, &all_topics)?;
 
         let mut selected = Vec::new();
         for topic in all_topics {
@@ -816,12 +817,53 @@ impl BackupEngine {
 
         // Sort by topic name for consistent ordering
         selected.sort_by(|a, b| a.name.cmp(&b.name));
+        missing_topics_outcome(&missing, selected.len())?;
+        self.record_missing_topics(missing, false).await;
         Ok(selected)
     }
 
-    async fn ensure_literal_topic_includes_exist(&self, selection: &TopicSelection) -> Result<()> {
+    /// Record the literal include topics skipped under `on_missing_topic: warn`
+    /// in the manifest and the `kafka_backup_missing_topics` gauge. With
+    /// `union = false` the list replaces the previous cycle's (so a topic
+    /// created later clears the record); with `union = true` (mid-run check)
+    /// it is added to it.
+    async fn record_missing_topics(&self, missing: Vec<String>, union: bool) {
+        if !missing.is_empty() {
+            warn!(
+                topics = ?missing,
+                "configured backup topic(s) not found in Kafka cluster; continuing (backup.on_missing_topic: warn)"
+            );
+        }
+        let recorded = {
+            let mut manifest = self.manifest.lock().await;
+            if union {
+                let mut all: Vec<String> =
+                    manifest.missing_topics.drain(..).chain(missing).collect();
+                all.sort();
+                all.dedup();
+                manifest.missing_topics = all;
+            } else {
+                manifest.missing_topics = missing;
+            }
+            manifest.missing_topics.len()
+        };
+        if let Some(prom) = &self.prometheus_metrics {
+            prom.set_missing_topics(&self.config.backup_id, recorded);
+        }
+    }
+
+    async fn ensure_literal_topic_includes_exist(
+        &self,
+        selection: &TopicSelection,
+        backup_opts: &BackupOptions,
+    ) -> Result<()> {
         let all_topics = self.router.fetch_metadata(None).await?;
-        fail_if_literal_topic_includes_missing(selection, &all_topics)
+        let missing =
+            check_literal_topic_includes(backup_opts.on_missing_topic, selection, &all_topics)?;
+        if !missing.is_empty() {
+            self.record_missing_topics(missing, true).await;
+        }
+        Ok(())
     }
 
     /// Save the manifest to storage, merging with any existing manifest.
@@ -1646,6 +1688,10 @@ async fn save_manifest_snapshot(
 fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> BackupManifest {
     use std::collections::HashMap as HM;
 
+    // Latest discovery pass wins: the field must be copied here or every
+    // save_manifest (which starts from the stored manifest) would drop it.
+    existing.missing_topics = current.missing_topics.clone();
+
     for cur_topic in current.topics {
         if let Some(ex_topic) = existing
             .topics
@@ -1732,19 +1778,38 @@ fn glob_match(pattern: &str, text: &str) -> bool {
     glob_match_impl(&pattern_chars, &text_chars)
 }
 
-fn fail_if_literal_topic_includes_missing(
+/// Check literal `topics.include` entries against the cluster. In `fail` mode
+/// any missing entry is an error; in `warn` mode the missing names are
+/// returned for the caller to record (issue #167).
+fn check_literal_topic_includes(
+    mode: crate::config::OnMissingTopic,
     selection: &TopicSelection,
     existing_topics: &[TopicMetadata],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     let missing = missing_literal_topic_includes(selection, existing_topics);
     if missing.is_empty() {
-        return Ok(());
+        return Ok(missing);
     }
+    match mode {
+        crate::config::OnMissingTopic::Fail => Err(Error::TopicNotFound(format!(
+            "configured backup topic(s) not found in Kafka cluster: {}",
+            missing.join(", ")
+        ))),
+        crate::config::OnMissingTopic::Warn => Ok(missing),
+    }
+}
 
-    Err(Error::TopicNotFound(format!(
-        "configured backup topic(s) not found in Kafka cluster: {}",
-        missing.join(", ")
-    )))
+/// `warn` mode still refuses a run that has nothing left to back up. A
+/// selection that is empty for other reasons (globs matching nothing) keeps
+/// the existing warn-and-skip behaviour.
+fn missing_topics_outcome(missing: &[String], selected_count: usize) -> Result<()> {
+    if !missing.is_empty() && selected_count == 0 {
+        return Err(Error::TopicNotFound(format!(
+            "all configured backup topics are missing from the Kafka cluster: {}",
+            missing.join(", ")
+        )));
+    }
+    Ok(())
 }
 
 fn missing_literal_topic_includes(
@@ -2868,5 +2933,71 @@ mod tests {
         };
         assert_eq!(effective_offset_sync_secs(Some(&set), &backup), 60);
         assert_eq!(offsets_key("daily"), "daily/offsets.db");
+    }
+
+    #[test]
+    fn check_literal_topic_includes_mode_matrix() {
+        use crate::config::OnMissingTopic;
+        let selection = TopicSelection {
+            include: vec![
+                "orders".to_string(),
+                "ghost".to_string(),
+                "logs-*".to_string(),
+            ],
+            exclude: vec![],
+        };
+        let existing = vec![topic_metadata("orders")];
+
+        let err =
+            check_literal_topic_includes(OnMissingTopic::Fail, &selection, &existing).unwrap_err();
+        assert!(err.to_string().contains("ghost"), "{err}");
+
+        let missing =
+            check_literal_topic_includes(OnMissingTopic::Warn, &selection, &existing).unwrap();
+        assert_eq!(
+            missing,
+            vec!["ghost".to_string()],
+            "globs are never reported"
+        );
+
+        let all_present = vec![topic_metadata("orders"), topic_metadata("ghost")];
+        assert!(
+            check_literal_topic_includes(OnMissingTopic::Fail, &selection, &all_present)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn missing_topics_outcome_rules() {
+        let missing = vec!["ghost".to_string()];
+        assert!(
+            missing_topics_outcome(&missing, 2).is_ok(),
+            "something left to back up"
+        );
+        assert!(
+            missing_topics_outcome(&missing, 0).is_err(),
+            "nothing left to back up"
+        );
+        assert!(
+            missing_topics_outcome(&[], 0).is_ok(),
+            "empty glob selection keeps today's behaviour"
+        );
+    }
+
+    #[test]
+    fn merge_manifests_carries_missing_topics() {
+        let mut existing = BackupManifest::new("m".to_string());
+        existing.missing_topics = vec!["stale".to_string()];
+        let mut current = BackupManifest::new("m".to_string());
+        current.missing_topics = vec!["ghost".to_string()];
+        let merged = merge_manifests(existing, current);
+        assert_eq!(merged.missing_topics, vec!["ghost".to_string()]);
+
+        let cleared = merge_manifests(merged, BackupManifest::new("m".to_string()));
+        assert!(
+            cleared.missing_topics.is_empty(),
+            "a clean pass clears the record"
+        );
     }
 }

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -405,6 +405,22 @@ pub enum StorageBackendType {
     S3,
 }
 
+/// What to do when a literal (non-glob) `topics.include` entry does not exist
+/// in the cluster (issue #167). Glob patterns that match nothing are always
+/// skipped silently.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnMissingTopic {
+    /// Fail the run (default) — a requested topic that is absent must not
+    /// produce a "successful" backup with zero records for it.
+    #[default]
+    Fail,
+    /// Log a warning, record the topic in the manifest's `missing_topics`,
+    /// expose it via `kafka_backup_missing_topics`, and continue. The run
+    /// still fails if nothing is left to back up.
+    Warn,
+}
+
 /// Backup-specific options
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupOptions {
@@ -439,6 +455,11 @@ pub struct BackupOptions {
     /// Internal topics to backup (e.g., __consumer_offsets, __transaction_state)
     #[serde(default)]
     pub internal_topics: Vec<String>,
+
+    /// Behaviour when a literal `topics.include` entry is absent from the
+    /// cluster: `fail` (default) or `warn` (skip it, record it, continue).
+    #[serde(default)]
+    pub on_missing_topic: OnMissingTopic,
 
     /// **Deprecated since 0.22.0 — no effect.** Offsets are checkpointed at
     /// the end of every backup cycle; a warning is logged when this is set to
@@ -634,6 +655,7 @@ impl Default for BackupOptions {
             continuous: false,
             include_internal_topics: false,
             internal_topics: Vec::new(),
+            on_missing_topic: OnMissingTopic::default(),
             checkpoint_interval_secs: default_checkpoint_interval_secs(),
             sync_interval_secs: default_sync_interval_secs(),
             include_offset_headers: default_include_offset_headers(),
@@ -1759,5 +1781,30 @@ offset_storage:
             None,
             "unset means: use backup.sync_interval_secs"
         );
+    }
+
+    #[test]
+    fn on_missing_topic_parses_and_defaults_to_fail() {
+        let base = r#"
+mode: backup
+backup_id: omt
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+"#;
+        let config: Config = serde_yaml::from_str(base).unwrap();
+        assert_eq!(
+            config.backup.unwrap_or_default().on_missing_topic,
+            OnMissingTopic::Fail
+        );
+        let warn = format!("{base}backup:\n  on_missing_topic: warn\n");
+        let config: Config = serde_yaml::from_str(&warn).unwrap();
+        assert_eq!(
+            config.backup.unwrap().on_missing_topic,
+            OnMissingTopic::Warn
+        );
+        let bad = format!("{base}backup:\n  on_missing_topic: ignore\n");
+        assert!(serde_yaml::from_str::<Config>(&bad).is_err());
     }
 }

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -26,6 +26,12 @@ pub struct BackupManifest {
 
     /// Topics included in this backup
     pub topics: Vec<TopicBackup>,
+
+    /// Literal `topics.include` entries that were absent from the cluster at
+    /// the last discovery pass and skipped because `backup.on_missing_topic`
+    /// is `warn` (issue #167). Empty — and omitted from JSON — otherwise.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_topics: Vec<String>,
 }
 
 impl BackupManifest {
@@ -38,6 +44,7 @@ impl BackupManifest {
             source_brokers: Vec::new(),
             compression: "zstd".to_string(),
             topics: Vec::new(),
+            missing_topics: Vec::new(),
         }
     }
 
@@ -1628,5 +1635,23 @@ mod tests {
         assert!(manifest.topics[0].partitions[0].gaps.is_empty());
         assert_eq!(manifest.total_gaps(), 0);
         assert_eq!(manifest.gaps().count(), 0);
+    }
+
+    #[test]
+    fn missing_topics_round_trip_and_omitted_when_empty() {
+        let mut manifest = BackupManifest::new("m".to_string());
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(!json.contains("missing_topics"), "{json}");
+
+        manifest.missing_topics = vec!["ghost".to_string()];
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(json.contains("\"missing_topics\":[\"ghost\"]"), "{json}");
+        let back: BackupManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.missing_topics, vec!["ghost".to_string()]);
+
+        // Manifests written before the field existed still load.
+        let legacy = r#"{"backup_id":"old","created_at":1,"topics":[]}"#;
+        let old: BackupManifest = serde_json::from_str(legacy).unwrap();
+        assert!(old.missing_topics.is_empty());
     }
 }

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -93,6 +93,11 @@ pub struct PrometheusMetrics {
     /// Cumulative compressed bytes deleted by retention.
     pub bytes_pruned_total: Family<BackupLabels, Counter>,
 
+    /// Literal `topics.include` entries absent from the cluster at the last
+    /// discovery pass and skipped (`backup.on_missing_topic: warn`,
+    /// issue #167). Re-evaluated every cycle; 0 once they exist again.
+    pub missing_topics: Family<BackupLabels, Gauge>,
+
     // ========================================
     // Operation Duration Metrics
     // ========================================
@@ -221,6 +226,7 @@ impl PrometheusMetrics {
         let offsets_skipped_total = Family::<BackupLabels, Counter>::default();
         let segments_pruned_total = Family::<BackupLabels, Counter>::default();
         let bytes_pruned_total = Family::<BackupLabels, Counter>::default();
+        let missing_topics = Family::<BackupLabels, Gauge>::default();
 
         // Operation Duration Metrics
         let backup_duration_seconds =
@@ -343,6 +349,11 @@ impl PrometheusMetrics {
             "Cumulative compressed bytes deleted by retention",
             bytes_pruned_total.clone(),
         );
+        registry.register(
+            "kafka_backup_missing_topics",
+            "Literal include topics absent from the cluster at the last discovery pass (backup.on_missing_topic: warn)",
+            missing_topics.clone(),
+        );
 
         // Operation Duration Metrics
         registry.register(
@@ -461,6 +472,7 @@ impl PrometheusMetrics {
             offsets_skipped_total,
             segments_pruned_total,
             bytes_pruned_total,
+            missing_topics,
             backup_duration_seconds,
             restore_duration_seconds,
             storage_write_latency_seconds,
@@ -638,6 +650,13 @@ impl PrometheusMetrics {
             .get_or_create(&labels)
             .inc_by(segments);
         self.bytes_pruned_total.get_or_create(&labels).inc_by(bytes);
+    }
+
+    /// Set the number of literal include topics absent at the last discovery
+    /// pass (`backup.on_missing_topic: warn`). Re-evaluated every cycle.
+    pub fn set_missing_topics(&self, backup_id: &str, count: usize) {
+        let labels = BackupLabels::new(backup_id);
+        self.missing_topics.get_or_create(&labels).set(count as i64);
     }
 
     /// Increment cumulative bytes counter.
@@ -1148,5 +1167,20 @@ mod tests {
         ] {
             assert!(encoded.contains(name), "missing counter series: {name}");
         }
+    }
+
+    #[test]
+    fn missing_topics_gauge_encodes_and_resets() {
+        let metrics = PrometheusMetrics::with_max_labels(10);
+        metrics.set_missing_topics("daily", 2);
+        let text = metrics.encode();
+        assert!(
+            text.contains("kafka_backup_missing_topics{backup_id=\"daily\"} 2"),
+            "{text}"
+        );
+        metrics.set_missing_topics("daily", 0);
+        assert!(metrics
+            .encode()
+            .contains("kafka_backup_missing_topics{backup_id=\"daily\"} 0"));
     }
 }

--- a/crates/kafka-backup-core/tests/integration_suite/issue_167_on_missing_topic.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_167_on_missing_topic.rs
@@ -1,0 +1,119 @@
+//! Issue #167 — `backup.on_missing_topic: warn` skips literal include topics
+//! that do not exist, records them in the manifest, and keeps backing up the
+//! rest. A run with nothing left to back up still fails, and the default
+//! (`fail`) keeps the operator #56 guarantee (see `issue_56_missing_topic`).
+
+use std::time::Duration;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::OnMissingTopic;
+use kafka_backup_core::manifest::BackupManifest;
+
+use super::common::{create_backup_config, create_temp_storage, KafkaTestCluster};
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn warn_mode_skips_missing_topic_and_records_it() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let real_topic = "issue167-real";
+    let ghost_topic = "issue167-ghost";
+    cluster
+        .create_topic(real_topic, 20)
+        .await
+        .expect("create topic");
+
+    let temp_dir = create_temp_storage();
+    let backup_id = "issue167-warn";
+    let mut config = create_backup_config(
+        &cluster.bootstrap_servers,
+        temp_dir.path().to_path_buf(),
+        backup_id,
+        vec![real_topic.to_string(), ghost_topic.to_string()],
+    );
+    config
+        .backup
+        .as_mut()
+        .expect("backup options")
+        .on_missing_topic = OnMissingTopic::Warn;
+
+    let engine = BackupEngine::new(config)
+        .await
+        .expect("backup engine should initialize");
+    engine
+        .run()
+        .await
+        .expect("warn mode must back up the remaining topics");
+
+    let manifest_path = temp_dir.path().join(backup_id).join("manifest.json");
+    let manifest: BackupManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path).expect("manifest written"))
+            .expect("manifest parses");
+
+    assert_eq!(
+        manifest.missing_topics,
+        vec![ghost_topic.to_string()],
+        "the absent literal topic is recorded"
+    );
+    let real = manifest
+        .topics
+        .iter()
+        .find(|t| t.name == real_topic)
+        .expect("existing topic backed up");
+    let records: i64 = real
+        .partitions
+        .iter()
+        .flat_map(|p| p.segments.iter())
+        .map(|s| s.record_count)
+        .sum();
+    assert_eq!(records, 20, "all records of the existing topic archived");
+    assert!(
+        !manifest.topics.iter().any(|t| t.name == ghost_topic),
+        "no manifest entry for the missing topic"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn warn_mode_still_fails_when_nothing_is_left() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let temp_dir = create_temp_storage();
+    let ghost_topic = "issue167-only-ghost";
+    let mut config = create_backup_config(
+        &cluster.bootstrap_servers,
+        temp_dir.path().to_path_buf(),
+        "issue167-all-missing",
+        vec![ghost_topic.to_string()],
+    );
+    config
+        .backup
+        .as_mut()
+        .expect("backup options")
+        .on_missing_topic = OnMissingTopic::Warn;
+
+    let engine = BackupEngine::new(config)
+        .await
+        .expect("backup engine should initialize");
+    let error = engine
+        .run()
+        .await
+        .expect_err("a run with every topic missing must still fail");
+    let message = error.to_string();
+    assert!(
+        message.contains(ghost_topic) && message.contains("all configured backup topics"),
+        "unexpected error: {message}"
+    );
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -14,6 +14,7 @@
 //! - Issue #148: consumer group offsets applied in Phase 3 after restore
 //! - Issue #154: default offset headers are documented, logged, and strippable on restore
 //! - Issue #155: null header values survive backup and restore
+//! - Issue #167: backup.on_missing_topic warn/fail behaviour
 //! - strimzi-backup-operator#57: snapshot progress gauges describe the current run
 
 pub mod common;
@@ -22,6 +23,7 @@ pub mod issue_146_connection_errors;
 pub mod issue_148_offset_reset_after_restore;
 pub mod issue_154_offset_headers;
 pub mod issue_155_null_header_value;
+pub mod issue_167_on_missing_topic;
 pub mod issue_169_retention;
 pub mod issue_56_missing_topic;
 pub mod issue_57_incremental_snapshot_target;

--- a/crates/kafka-backup-core/tests/preflight_contract_test.rs
+++ b/crates/kafka-backup-core/tests/preflight_contract_test.rs
@@ -177,6 +177,7 @@ fn write_manifest(dir: &Path, partitions: Vec<PartitionBackup>) -> BackupManifes
             configurations: Default::default(),
             partitions,
         }],
+        missing_topics: Vec::new(),
     };
     let path = dir.join(BACKUP_ID).join("manifest.json");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -407,6 +407,7 @@ the values in `kafka-backup-core`'s `BackupOptions::default()`.
 | `source_cluster_id` | string | No | unset | Recorded in the `x-source-cluster` header (only with `include_offset_headers`) |
 | `include_internal_topics` | bool | No | `false` | Also back up internal topics listed in `internal_topics` |
 | `internal_topics` | list[string] | No | `[]` | Internal topics to include (e.g. `__consumer_offsets`) when `include_internal_topics` is set |
+| `on_missing_topic` | string | No | `fail` | When a literal (non-glob) `topics.include` entry is absent from the cluster: `fail` errors (default, protects one-shot runs from a zero-record "success"); `warn` logs, records the names in the manifest's `missing_topics`, exposes `kafka_backup_missing_topics`, and continues — the run still fails if nothing is left to back up. Globs that match nothing are always skipped silently |
 | `consumer_group_snapshot` | bool | No | `false` | Write `consumer-groups-snapshot.json` after each cycle for `auto_consumer_groups` restores |
 
 ### Offset-tracking headers
@@ -698,6 +699,7 @@ metrics:
 | `kafka_backup_bytes_total` | Counter | Total bytes backed up |
 | `kafka_backup_offset_gaps_total` | Counter | Offset ranges skipped because the source no longer had the records (see [retention gaps](#retention-deleting-data-before-it-is-fetched)) |
 | `kafka_backup_offsets_skipped_total` | Counter | Source offsets skipped across all recorded gaps |
+| `kafka_backup_missing_topics` | Gauge | Literal include topics absent from the cluster at the last discovery pass (`backup.on_missing_topic: warn`); returns to 0 once they exist |
 | `kafka_backup_segments_pruned_total` | Counter | Segments deliberately deleted by retention (`prune` / `backup.retention`) |
 | `kafka_backup_bytes_pruned_total` | Counter | Compressed bytes deleted by retention |
 | `kafka_backup_compression_ratio` | Gauge | Compression efficiency |


### PR DESCRIPTION
Part 5 of the 0.22.0 release branch: version bump, CHANGELOG `## [0.22.0] - 2026-09-07` (Added / Fixed / Deprecated / Changed with the library-API note), CLAUDE.md usage lines.

After this merges, the release branch is squash-merged to `main` in one PR (full CI incl. the version guard; `release-tagger` then cuts `v0.22.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN