### PR TITLE
release: 0.22.0 — skip-missing-topics, describe/validate --config, storage config fixes, offset-storage key cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2026-09-07
+
+### Added
+- `backup.on_missing_topic: fail | warn` — what to do when a literal (non-glob)
+  `topics.include` entry does not exist in the cluster. `fail` (default) keeps
+  the current behaviour; `warn` logs, records the absent names in the manifest's
+  new `missing_topics` field, exposes the `kafka_backup_missing_topics` gauge
+  (re-evaluated every cycle) and continues — a run with nothing left to back up
+  still fails. `describe` and `validate` show the recorded topics (informational,
+  never an integrity failure). Globs that match nothing are unaffected.
+  ([#167](https://github.com/osodevops/kafka-backup/issues/167))
+- `describe` and `validate` accept `--config backup.yaml` (parity with `status`
+  and `prune`): storage — including `prefix` — and `backup_id` come from the
+  backup configuration. `--path` + `--backup-id` still work; the two forms are
+  mutually exclusive. ([#168](https://github.com/osodevops/kafka-backup/issues/168))
+- S3 config accepts `access_key_id` / `secret_access_key` as aliases of
+  `access_key` / `secret_key` — the configuration reference documented the
+  former, so configs written from it were silently dropping credentials.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+
+### Fixed
+- S3 `path_style` was discarded by the backend factory; path-style requests are
+  now used when set explicitly or implied by a custom `endpoint` (plain-AWS
+  default unchanged). ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+- A YAML `storage.endpoint` starting with `http://` now implies `allow_http`
+  (logged at info), matching the `--path` URL behaviour, so on-prem HTTP stores
+  (Ceph RGW, MinIO) work without `AWS_ALLOW_HTTP`.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+- Azure Workload Identity: YAML `client_id` / `tenant_id` now take precedence
+  over the webhook-injected `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` (they were
+  ignored on that path).
+- `offset_storage.sync_interval_secs` is honoured: it overrides
+  `backup.sync_interval_secs` for the offset-database sync; when unset the
+  backup value applies. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- Documentation: the S3 and Azure sections of the configuration reference now
+  list the real option names (`allow_http`, `use_workload_identity`, `client_id`,
+  `tenant_id`, `client_secret`, `endpoint`), the Azure credential precedence and
+  environment variables (including `AZURE_FEDERATED_TOKEN_FILE`), the `--path`
+  URL query parameters, and an AKS Workload Identity example as a Job.
+  ([#166](https://github.com/osodevops/kafka-backup/issues/166))
+
+### Deprecated
+- `offset_storage.s3_key` — ignored; the offset database is always stored at
+  `{backup_id}/offsets.db` under the storage prefix (`prune`, `status` and the
+  operators rely on it). A warning is logged when set.
+  ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- `offset_storage.backend: memory` — not implemented; `sqlite` is used and a
+  warning is logged. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+- `backup.checkpoint_interval_secs` — never had an effect; offsets are
+  checkpointed at the end of every backup cycle. A warning is logged when set to
+  a non-default value. ([#161](https://github.com/osodevops/kafka-backup/issues/161))
+
+### Changed
+- **Breaking (library API):** `BackupOptions` gains `on_missing_topic`,
+  `BackupManifest` gains `missing_topics`, `OffsetStorageConfig::sync_interval_secs`
+  is now `Option<u64>`, and `storage::S3Config` gains `path_style`. Consumers
+  that build these structs by literal (the generic kafka-backup-operator does)
+  must add the fields — `..Default::default()` where available.
+
 ## [0.21.0] - 2026-08-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,9 +255,11 @@ kafka-backup list --path s3://bucket/prefix
 
 # Describe backup
 kafka-backup describe --path s3://bucket --backup-id backup-001 --format json
+kafka-backup describe --config backup.yaml --format json   # storage + backup_id from the config
 
 # Validate backup integrity
 kafka-backup validate --path s3://bucket --backup-id backup-001 --deep
+kafka-backup validate --config backup.yaml --deep
 
 # Offset management
 kafka-backup offset-reset plan --path s3://bucket --backup-id backup-001 --groups my-group
@@ -314,7 +316,7 @@ storage:
 backup:
   compression: zstd | lz4 | none
   segment_max_bytes: 134217728  # 128MB
-  checkpoint_interval_secs: 5
+  on_missing_topic: fail           # or warn: skip absent literal topics, record them (0.22.0)
   max_concurrent_partitions: 8
   include_offset_headers: true  # default; adds x-original-offset / x-original-timestamp to every archived record
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-backup-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 authors = ["OSO"]

--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ kafka-backup three-phase-restore --config restore.yaml   # restore + offset reco
 # Inspect backups
 kafka-backup list --path s3://bucket/prefix
 kafka-backup describe --path s3://bucket --backup-id backup-001 --format json
+kafka-backup describe --config backup.yaml                 # same, using the backup config
 kafka-backup status --config backup.yaml --watch          # live monitoring
 kafka-backup validate --path s3://bucket --backup-id backup-001 --deep
+kafka-backup validate --config backup.yaml --deep
 
 # Restore validation (dry-run)
 kafka-backup validate-restore --config restore.yaml

--- a/config/example-backup-azure.yaml
+++ b/config/example-backup-azure.yaml
@@ -67,8 +67,7 @@ backup:
   segment_max_bytes: 134217728
   segment_max_interval_ms: 60000
 
-  # Checkpoint settings
-  checkpoint_interval_secs: 5
+  # Remote sync interval for the manifest and offset store
   sync_interval_secs: 30
 
   # Offset-tracking headers (default: true) — adds x-original-offset /

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -103,6 +103,16 @@ fn print_manifest_text(manifest: &BackupManifest) {
             )
         );
     }
+    if !manifest.missing_topics.is_empty() {
+        println!(
+            "║ Missing Topics: {:55} ║",
+            format!(
+                "{} (configured but absent at last run: {})",
+                manifest.missing_topics.len(),
+                manifest.missing_topics.join(", ")
+            )
+        );
+    }
 
     // Calculate total size
     let total_compressed: u64 = manifest

--- a/crates/kafka-backup-cli/src/commands/describe.rs
+++ b/crates/kafka-backup-cli/src/commands/describe.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use kafka_backup_core::BackupManifest;
 use tracing::info;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 /// Describe command output format
 pub enum OutputFormat {
@@ -21,8 +21,13 @@ impl OutputFormat {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, format: &str) -> Result<()> {
-    let storage = backend_from_path(path)?;
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    format: &str,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     let output_format = OutputFormat::from_str(format);
 
     info!("Loading backup manifest: {}", backup_id);

--- a/crates/kafka-backup-cli/src/commands/prune.rs
+++ b/crates/kafka-backup-cli/src/commands/prune.rs
@@ -5,12 +5,12 @@ use anyhow::{bail, Context, Result};
 use kafka_backup_core::backup::prune::{self, PruneCriteria, PrunePlan};
 use kafka_backup_core::manifest::{BackupManifest, PruneReason};
 use kafka_backup_core::offset_store::{OffsetStore, OffsetStoreConfig, SqliteOffsetStore};
-use kafka_backup_core::storage::{create_backend, StorageBackend};
+use kafka_backup_core::storage::StorageBackend;
 use kafka_backup_core::util::parse_duration;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -25,16 +25,8 @@ pub async fn run(
     force: bool,
     format: &str,
 ) -> Result<()> {
-    let (storage, backup_id): (Arc<dyn StorageBackend>, String) = match (config, path, backup_id) {
-        (Some(config_path), None, None) => {
-            let content = tokio::fs::read_to_string(config_path).await?;
-            let content = super::config::expand_env_vars(&content);
-            let cfg = super::config::parse_config(&content)?;
-            (create_backend(&cfg.storage)?, cfg.backup_id)
-        }
-        (None, Some(path), Some(id)) => (backend_from_path(path)?, id.to_string()),
-        _ => bail!("pass either --config, or --path together with --backup-id"),
-    };
+    let (storage, backup_id): (Arc<dyn StorageBackend>, String) =
+        resolve_target(config, path, backup_id).await?;
 
     let cutoff = match (older_than, before) {
         (Some(raw), None) => {

--- a/crates/kafka-backup-cli/src/commands/storage_path.rs
+++ b/crates/kafka-backup-cli/src/commands/storage_path.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use kafka_backup_core::storage::{
     create_backend, FilesystemBackend, StorageBackend, StorageBackendConfig,
 };
@@ -12,4 +12,25 @@ pub fn backend_from_path(path: &str) -> Result<Arc<dyn StorageBackend>> {
     }
 
     Ok(Arc::new(FilesystemBackend::new(PathBuf::from(path))))
+}
+
+/// Resolve the storage backend and backup id from either `--config` (the
+/// backup/restore config file — its storage `prefix` and `backup_id` apply) or
+/// an explicit `--path` + `--backup-id` pair. Shared by prune / describe /
+/// validate so the two conventions behave identically (issue #168).
+pub async fn resolve_target(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+) -> Result<(Arc<dyn StorageBackend>, String)> {
+    match (config, path, backup_id) {
+        (Some(config_path), None, None) => {
+            let content = tokio::fs::read_to_string(config_path).await?;
+            let content = super::config::expand_env_vars(&content);
+            let cfg = super::config::parse_config(&content)?;
+            Ok((create_backend(&cfg.storage)?, cfg.backup_id))
+        }
+        (None, Some(path), Some(id)) => Ok((backend_from_path(path)?, id.to_string())),
+        _ => bail!("pass either --config, or --path together with --backup-id"),
+    }
 }

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -3,7 +3,7 @@ use kafka_backup_core::segment::SegmentReader;
 use kafka_backup_core::BackupManifest;
 use tracing::{error, info, warn};
 
-use super::storage_path::backend_from_path;
+use super::storage_path::resolve_target;
 
 #[derive(Debug, Default)]
 struct ValidationReport {
@@ -77,10 +77,14 @@ impl ValidationReport {
     }
 }
 
-pub async fn run(path: &str, backup_id: &str, deep: bool) -> Result<()> {
+pub async fn run(
+    config: Option<&str>,
+    path: Option<&str>,
+    backup_id: Option<&str>,
+    deep: bool,
+) -> Result<()> {
+    let (storage, backup_id) = resolve_target(config, path, backup_id).await?;
     info!("Validating backup: {} (deep={})", backup_id, deep);
-
-    let storage = backend_from_path(path)?;
     let mut report = ValidationReport::default();
 
     // Load manifest

--- a/crates/kafka-backup-cli/src/commands/validate.rs
+++ b/crates/kafka-backup-cli/src/commands/validate.rs
@@ -23,6 +23,9 @@ struct ValidationReport {
     /// Ranges deliberately deleted by retention (`prune` /
     /// `backup.retention`). Informational, never an integrity failure.
     pruned_ranges: Vec<String>,
+    /// Literal include topics absent from the cluster at the last backup run
+    /// and skipped (`backup.on_missing_topic: warn`). Not an integrity failure.
+    missing_topics: Vec<String>,
 }
 
 impl ValidationReport {
@@ -39,6 +42,7 @@ impl ValidationReport {
         println!("Records Validated:  {}", self.records_validated);
         println!("Data Gaps:          {}", self.data_gaps.len());
         println!("Pruned Ranges:      {}", self.pruned_ranges.len());
+        println!("Missing Topics:     {}", self.missing_topics.len());
 
         if !self.issues.is_empty() {
             println!("\nIssues Found:");
@@ -62,6 +66,16 @@ impl ValidationReport {
             println!("\nPruned Ranges (deliberately deleted by retention — not data loss):");
             for range in &self.pruned_ranges {
                 println!("  - {}", range);
+            }
+        }
+
+        if !self.missing_topics.is_empty() {
+            println!(
+                "\nMissing Topics (configured with backup.on_missing_topic: warn and absent during \
+                 the backup — not an integrity failure):"
+            );
+            for topic in &self.missing_topics {
+                println!("  - {}", topic);
             }
         }
 
@@ -156,6 +170,9 @@ pub async fn run(
             when
         ));
     }
+
+    // Literal include topics skipped under on_missing_topic: warn (issue #167).
+    report.missing_topics = manifest.missing_topics.clone();
 
     // Validate each segment
     for topic in &manifest.topics {

--- a/crates/kafka-backup-cli/src/main.rs
+++ b/crates/kafka-backup-cli/src/main.rs
@@ -94,16 +94,20 @@ enum Commands {
 
     /// Validate a backup's integrity (checksums, segment counts, manifests)
     #[command(
-        after_help = "Examples:\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
+        after_help = "Examples:\n  kafka-backup validate --config backup.yaml\n  kafka-backup validate --path s3://bucket --backup-id my-backup\n  kafka-backup validate --path s3://bucket --backup-id my-backup --deep"
     )]
     Validate {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to validate
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Perform deep validation (read and verify each segment)
         #[arg(long, default_value = "false")]
@@ -159,14 +163,21 @@ enum Commands {
     },
 
     /// Show detailed backup manifest (topics, partitions, time ranges, record counts)
+    #[command(
+        after_help = "Examples:\n  kafka-backup describe --config backup.yaml\n  kafka-backup describe --path s3://bucket --backup-id my-backup --format json"
+    )]
     Describe {
+        /// Path to the backup configuration file (storage + backup_id come from it)
+        #[arg(short, long, conflicts_with_all = ["path", "backup_id"])]
+        config: Option<String>,
+
         /// Storage path (local path or s3://bucket/prefix, azure://..., gcs://...)
-        #[arg(short, long)]
-        path: String,
+        #[arg(short, long, requires = "backup_id")]
+        path: Option<String>,
 
         /// Backup ID to describe
-        #[arg(short, long)]
-        backup_id: String,
+        #[arg(short, long, requires = "path")]
+        backup_id: Option<String>,
 
         /// Output format (text, json, yaml)
         #[arg(short, long, default_value = "text")]
@@ -584,11 +595,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Validate {
+            config,
             path,
             backup_id,
             deep,
         } => {
-            commands::validate::run(&path, &backup_id, deep).await?;
+            commands::validate::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                deep,
+            )
+            .await?;
         }
         Commands::Prune {
             config,
@@ -617,11 +635,18 @@ async fn main() -> Result<()> {
             .await?;
         }
         Commands::Describe {
+            config,
             path,
             backup_id,
             format,
         } => {
-            commands::describe::run(&path, &backup_id, &format).await?;
+            commands::describe::run(
+                config.as_deref(),
+                path.as_deref(),
+                backup_id.as_deref(),
+                &format,
+            )
+            .await?;
         }
         Commands::ValidateRestore { config, format } => {
             commands::validate_restore::run(&config, &format).await?;

--- a/crates/kafka-backup-cli/tests/issue_167_missing_topics.rs
+++ b/crates/kafka-backup-cli/tests/issue_167_missing_topics.rs
@@ -1,0 +1,135 @@
+//! Issue #167 — a manifest that records literal include topics skipped under
+//! `backup.on_missing_topic: warn` is surfaced by `describe` and `validate`
+//! without being treated as an integrity failure.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kb-issue167-{}-{}-{}",
+        name,
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn create_backup_set(root: &Path, backup_id: &str, missing: &[&str]) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+    let name = "segment-00000000000000000000.bin.zst";
+    let payload = "fake-segment";
+    fs::write(seg_dir.join(name), payload).unwrap();
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 60_000,
+        "compression": "zstd",
+        "missing_topics": missing,
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": [{
+                "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+                "start_offset": 0,
+                "end_offset": 9,
+                "start_timestamp": now - 60_000,
+                "end_timestamp": now - 1_000,
+                "record_count": 10,
+                "uncompressed_size": payload.len() * 4,
+                "compressed_size": payload.len(),
+                "uploaded_at": now,
+            }]}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .unwrap()
+}
+
+fn text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn describe_reports_missing_topics() {
+    let dir = scratch_dir("describe");
+    create_backup_set(&dir, "daily", &["payments", "ghost"]);
+    let root = dir.to_str().unwrap();
+
+    let out = run(&["describe", "--path", root, "--backup-id", "daily"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Missing Topics: 2"), "{all}");
+    assert!(all.contains("payments, ghost"), "{all}");
+
+    let out = run(&[
+        "describe",
+        "--path",
+        root,
+        "--backup-id",
+        "daily",
+        "--format",
+        "json",
+    ]);
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json");
+    assert_eq!(
+        value["missing_topics"],
+        serde_json::json!(["payments", "ghost"])
+    );
+}
+
+#[test]
+fn validate_lists_missing_topics_and_stays_valid() {
+    let dir = scratch_dir("validate");
+    create_backup_set(&dir, "daily", &["ghost"]);
+
+    let out = run(&[
+        "validate",
+        "--path",
+        dir.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+    ]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Missing Topics:     1"), "{all}");
+    assert!(all.contains("not an integrity failure"), "{all}");
+    assert!(all.contains("- ghost"), "{all}");
+    assert!(all.contains("Result: VALID"), "{all}");
+}
+
+#[test]
+fn manifests_without_the_field_are_unaffected() {
+    let dir = scratch_dir("legacy");
+    create_backup_set(&dir, "daily", &[]);
+
+    let out = run(&[
+        "describe",
+        "--path",
+        dir.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+    ]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(!all.contains("Missing Topics"), "{all}");
+}

--- a/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
+++ b/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
@@ -1,0 +1,172 @@
+//! Issue #168 — `describe` and `validate` accept `--config` (parity with
+//! `status` / `prune`), resolving storage (including `prefix`) and the backup
+//! id from the backup configuration file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "kb-issue168-{}-{}-{}",
+        name,
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A minimal backup set (manifest + segment files) under `root/<backup_id>/`.
+fn create_backup_set(root: &Path, backup_id: &str) {
+    let now = chrono::Utc::now().timestamp_millis();
+    let seg_dir = root.join(backup_id).join("topics/orders/partition=0");
+    fs::create_dir_all(&seg_dir).unwrap();
+    let name = "segment-00000000000000000000.bin.zst";
+    let payload = "fake-segment";
+    fs::write(seg_dir.join(name), payload).unwrap();
+    let manifest = serde_json::json!({
+        "backup_id": backup_id,
+        "created_at": now - 60_000,
+        "compression": "zstd",
+        "topics": [{
+            "name": "orders",
+            "original_partition_count": 1,
+            "partitions": [{"partition_id": 0, "segments": [{
+                "key": format!("{backup_id}/topics/orders/partition=0/{name}"),
+                "start_offset": 0,
+                "end_offset": 9,
+                "start_timestamp": now - 60_000,
+                "end_timestamp": now - 1_000,
+                "record_count": 10,
+                "uncompressed_size": payload.len() * 4,
+                "compressed_size": payload.len(),
+                "uploaded_at": now,
+            }]}]
+        }]
+    });
+    fs::write(
+        root.join(backup_id).join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_config(dir: &Path, storage_root: &Path, backup_id: &str) -> PathBuf {
+    let path = dir.join("backup.yaml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+mode: backup
+backup_id: {backup_id}
+source:
+  bootstrap_servers: ["127.0.0.1:1"]
+storage:
+  backend: filesystem
+  path: {root}
+"#,
+            root = storage_root.display()
+        ),
+    )
+    .unwrap();
+    path
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kafka-backup"))
+        .args(args)
+        .env("RUST_LOG", "warn")
+        .output()
+        .unwrap()
+}
+
+fn text(output: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn describe_accepts_config() {
+    let dir = scratch_dir("describe");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["describe", "--config", config.to_str().unwrap(), "--format", "json"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json manifest");
+    assert_eq!(value["backup_id"], serde_json::json!("daily"), "{all}");
+
+    // Same result as the explicit --path/--backup-id form.
+    let out_path = run(&[
+        "describe",
+        "--path",
+        storage.to_str().unwrap(),
+        "--backup-id",
+        "daily",
+        "--format",
+        "json",
+    ]);
+    assert!(out_path.status.success(), "{}", text(&out_path));
+    assert_eq!(out.stdout, out_path.stdout, "--config and --path must agree");
+}
+
+#[test]
+fn validate_accepts_config() {
+    let dir = scratch_dir("validate");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    let out = run(&["validate", "--config", config.to_str().unwrap()]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("VALID"), "{all}");
+}
+
+#[test]
+fn config_and_path_are_mutually_exclusive() {
+    let dir = scratch_dir("conflict");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    for cmd in ["describe", "validate"] {
+        let out = run(&[
+            cmd,
+            "--config",
+            config.to_str().unwrap(),
+            "--path",
+            storage.to_str().unwrap(),
+            "--backup-id",
+            "daily",
+        ]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+
+        // --path without --backup-id (and vice versa) is a usage error too.
+        let out = run(&[cmd, "--path", storage.to_str().unwrap()]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+        let out = run(&[cmd, "--backup-id", "daily"]);
+        assert_eq!(out.status.code(), Some(2), "{cmd}: {}", text(&out));
+    }
+}
+
+#[test]
+fn prune_still_resolves_from_config() {
+    let dir = scratch_dir("prune");
+    let storage = dir.join("storage");
+    create_backup_set(&storage, "daily");
+    let config = write_config(&dir, &storage, "daily");
+
+    // Plan-only prune through the shared resolver (regression for #169).
+    let out = run(&["prune", "--config", config.to_str().unwrap(), "--older-than", "30d"]);
+    let all = text(&out);
+    assert!(out.status.success(), "{all}");
+    assert!(all.contains("Prune plan for 'daily'"), "{all}");
+}

--- a/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
+++ b/crates/kafka-backup-cli/tests/issue_168_config_flag.rs
@@ -97,7 +97,13 @@ fn describe_accepts_config() {
     create_backup_set(&storage, "daily");
     let config = write_config(&dir, &storage, "daily");
 
-    let out = run(&["describe", "--config", config.to_str().unwrap(), "--format", "json"]);
+    let out = run(&[
+        "describe",
+        "--config",
+        config.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
     let all = text(&out);
     assert!(out.status.success(), "{all}");
     let value: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json manifest");
@@ -114,7 +120,10 @@ fn describe_accepts_config() {
         "json",
     ]);
     assert!(out_path.status.success(), "{}", text(&out_path));
-    assert_eq!(out.stdout, out_path.stdout, "--config and --path must agree");
+    assert_eq!(
+        out.stdout, out_path.stdout,
+        "--config and --path must agree"
+    );
 }
 
 #[test]
@@ -165,7 +174,13 @@ fn prune_still_resolves_from_config() {
     let config = write_config(&dir, &storage, "daily");
 
     // Plan-only prune through the shared resolver (regression for #169).
-    let out = run(&["prune", "--config", config.to_str().unwrap(), "--older-than", "30d"]);
+    let out = run(&[
+        "prune",
+        "--config",
+        config.to_str().unwrap(),
+        "--older-than",
+        "30d",
+    ]);
     let all = text(&out);
     assert!(out.status.success(), "{all}");
     assert!(all.contains("Prune plan for 'daily'"), "{all}");

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -568,7 +568,7 @@ impl BackupEngine {
             // the cycle. This catches topics deleted while a backup is running
             // before a zero-record/empty-artifact result can be reported as
             // successful.
-            self.ensure_literal_topic_includes_exist(&source.topics)
+            self.ensure_literal_topic_includes_exist(&source.topics, &backup_opts)
                 .await?;
 
             // Checkpoint offsets
@@ -773,7 +773,8 @@ impl BackupEngine {
         // Fetch ALL topic metadata in a single bulk call
         let all_topics = self.router.fetch_metadata(None).await?;
 
-        fail_if_literal_topic_includes_missing(selection, &all_topics)?;
+        let missing =
+            check_literal_topic_includes(backup_opts.on_missing_topic, selection, &all_topics)?;
 
         let mut selected = Vec::new();
         for topic in all_topics {
@@ -816,12 +817,53 @@ impl BackupEngine {
 
         // Sort by topic name for consistent ordering
         selected.sort_by(|a, b| a.name.cmp(&b.name));
+        missing_topics_outcome(&missing, selected.len())?;
+        self.record_missing_topics(missing, false).await;
         Ok(selected)
     }
 
-    async fn ensure_literal_topic_includes_exist(&self, selection: &TopicSelection) -> Result<()> {
+    /// Record the literal include topics skipped under `on_missing_topic: warn`
+    /// in the manifest and the `kafka_backup_missing_topics` gauge. With
+    /// `union = false` the list replaces the previous cycle's (so a topic
+    /// created later clears the record); with `union = true` (mid-run check)
+    /// it is added to it.
+    async fn record_missing_topics(&self, missing: Vec<String>, union: bool) {
+        if !missing.is_empty() {
+            warn!(
+                topics = ?missing,
+                "configured backup topic(s) not found in Kafka cluster; continuing (backup.on_missing_topic: warn)"
+            );
+        }
+        let recorded = {
+            let mut manifest = self.manifest.lock().await;
+            if union {
+                let mut all: Vec<String> =
+                    manifest.missing_topics.drain(..).chain(missing).collect();
+                all.sort();
+                all.dedup();
+                manifest.missing_topics = all;
+            } else {
+                manifest.missing_topics = missing;
+            }
+            manifest.missing_topics.len()
+        };
+        if let Some(prom) = &self.prometheus_metrics {
+            prom.set_missing_topics(&self.config.backup_id, recorded);
+        }
+    }
+
+    async fn ensure_literal_topic_includes_exist(
+        &self,
+        selection: &TopicSelection,
+        backup_opts: &BackupOptions,
+    ) -> Result<()> {
         let all_topics = self.router.fetch_metadata(None).await?;
-        fail_if_literal_topic_includes_missing(selection, &all_topics)
+        let missing =
+            check_literal_topic_includes(backup_opts.on_missing_topic, selection, &all_topics)?;
+        if !missing.is_empty() {
+            self.record_missing_topics(missing, true).await;
+        }
+        Ok(())
     }
 
     /// Save the manifest to storage, merging with any existing manifest.
@@ -1646,6 +1688,10 @@ async fn save_manifest_snapshot(
 fn merge_manifests(mut existing: BackupManifest, current: BackupManifest) -> BackupManifest {
     use std::collections::HashMap as HM;
 
+    // Latest discovery pass wins: the field must be copied here or every
+    // save_manifest (which starts from the stored manifest) would drop it.
+    existing.missing_topics = current.missing_topics.clone();
+
     for cur_topic in current.topics {
         if let Some(ex_topic) = existing
             .topics
@@ -1732,19 +1778,38 @@ fn glob_match(pattern: &str, text: &str) -> bool {
     glob_match_impl(&pattern_chars, &text_chars)
 }
 
-fn fail_if_literal_topic_includes_missing(
+/// Check literal `topics.include` entries against the cluster. In `fail` mode
+/// any missing entry is an error; in `warn` mode the missing names are
+/// returned for the caller to record (issue #167).
+fn check_literal_topic_includes(
+    mode: crate::config::OnMissingTopic,
     selection: &TopicSelection,
     existing_topics: &[TopicMetadata],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     let missing = missing_literal_topic_includes(selection, existing_topics);
     if missing.is_empty() {
-        return Ok(());
+        return Ok(missing);
     }
+    match mode {
+        crate::config::OnMissingTopic::Fail => Err(Error::TopicNotFound(format!(
+            "configured backup topic(s) not found in Kafka cluster: {}",
+            missing.join(", ")
+        ))),
+        crate::config::OnMissingTopic::Warn => Ok(missing),
+    }
+}
 
-    Err(Error::TopicNotFound(format!(
-        "configured backup topic(s) not found in Kafka cluster: {}",
-        missing.join(", ")
-    )))
+/// `warn` mode still refuses a run that has nothing left to back up. A
+/// selection that is empty for other reasons (globs matching nothing) keeps
+/// the existing warn-and-skip behaviour.
+fn missing_topics_outcome(missing: &[String], selected_count: usize) -> Result<()> {
+    if !missing.is_empty() && selected_count == 0 {
+        return Err(Error::TopicNotFound(format!(
+            "all configured backup topics are missing from the Kafka cluster: {}",
+            missing.join(", ")
+        )));
+    }
+    Ok(())
 }
 
 fn missing_literal_topic_includes(
@@ -2868,5 +2933,71 @@ mod tests {
         };
         assert_eq!(effective_offset_sync_secs(Some(&set), &backup), 60);
         assert_eq!(offsets_key("daily"), "daily/offsets.db");
+    }
+
+    #[test]
+    fn check_literal_topic_includes_mode_matrix() {
+        use crate::config::OnMissingTopic;
+        let selection = TopicSelection {
+            include: vec![
+                "orders".to_string(),
+                "ghost".to_string(),
+                "logs-*".to_string(),
+            ],
+            exclude: vec![],
+        };
+        let existing = vec![topic_metadata("orders")];
+
+        let err =
+            check_literal_topic_includes(OnMissingTopic::Fail, &selection, &existing).unwrap_err();
+        assert!(err.to_string().contains("ghost"), "{err}");
+
+        let missing =
+            check_literal_topic_includes(OnMissingTopic::Warn, &selection, &existing).unwrap();
+        assert_eq!(
+            missing,
+            vec!["ghost".to_string()],
+            "globs are never reported"
+        );
+
+        let all_present = vec![topic_metadata("orders"), topic_metadata("ghost")];
+        assert!(
+            check_literal_topic_includes(OnMissingTopic::Fail, &selection, &all_present)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn missing_topics_outcome_rules() {
+        let missing = vec!["ghost".to_string()];
+        assert!(
+            missing_topics_outcome(&missing, 2).is_ok(),
+            "something left to back up"
+        );
+        assert!(
+            missing_topics_outcome(&missing, 0).is_err(),
+            "nothing left to back up"
+        );
+        assert!(
+            missing_topics_outcome(&[], 0).is_ok(),
+            "empty glob selection keeps today's behaviour"
+        );
+    }
+
+    #[test]
+    fn merge_manifests_carries_missing_topics() {
+        let mut existing = BackupManifest::new("m".to_string());
+        existing.missing_topics = vec!["stale".to_string()];
+        let mut current = BackupManifest::new("m".to_string());
+        current.missing_topics = vec!["ghost".to_string()];
+        let merged = merge_manifests(existing, current);
+        assert_eq!(merged.missing_topics, vec!["ghost".to_string()]);
+
+        let cleared = merge_manifests(merged, BackupManifest::new("m".to_string()));
+        assert!(
+            cleared.missing_topics.is_empty(),
+            "a clean pass clears the record"
+        );
     }
 }

--- a/crates/kafka-backup-core/src/backup/engine.rs
+++ b/crates/kafka-backup-core/src/backup/engine.rs
@@ -93,6 +93,23 @@ struct OffsetPersistence {
     sync_interval: Duration,
 }
 
+/// Remote key of the offset database for a backup set. Fixed by design —
+/// `prune`, `status` and the operators all assume it (issue #161).
+pub fn offsets_key(backup_id: &str) -> String {
+    format!("{}/offsets.db", backup_id)
+}
+
+/// `offset_storage.sync_interval_secs` overrides `backup.sync_interval_secs`
+/// for the offset database sync; the backup value applies when unset.
+fn effective_offset_sync_secs(
+    offset_storage: Option<&crate::config::OffsetStorageConfig>,
+    backup: &crate::config::BackupOptions,
+) -> u64 {
+    offset_storage
+        .and_then(|os| os.sync_interval_secs)
+        .unwrap_or(backup.sync_interval_secs)
+}
+
 impl OffsetPersistence {
     fn new(
         backup_id: String,
@@ -112,10 +129,7 @@ impl OffsetPersistence {
     async fn sync_now(&self) -> Result<()> {
         let mut last_sync = self.sync_lock.lock().await;
         self.offset_store
-            .sync_to_storage(
-                self.storage.as_ref(),
-                &format!("{}/offsets.db", self.backup_id),
-            )
+            .sync_to_storage(self.storage.as_ref(), &offsets_key(&self.backup_id))
             .await?;
 
         *last_sync = Some(Instant::now());
@@ -129,10 +143,7 @@ impl OffsetPersistence {
         }
 
         self.offset_store
-            .sync_to_storage(
-                self.storage.as_ref(),
-                &format!("{}/offsets.db", self.backup_id),
-            )
+            .sync_to_storage(self.storage.as_ref(), &offsets_key(&self.backup_id))
             .await?;
         *last_sync = Some(Instant::now());
         Ok(())
@@ -220,9 +231,12 @@ impl BackupEngine {
 
             let offset_config = OffsetStoreConfig {
                 db_path,
-                s3_key: Some(format!("{}/offsets.db", config.backup_id)),
+                s3_key: Some(offsets_key(&config.backup_id)),
                 checkpoint_interval_secs: backup_opts.checkpoint_interval_secs,
-                sync_interval_secs: backup_opts.sync_interval_secs,
+                sync_interval_secs: effective_offset_sync_secs(
+                    config.offset_storage.as_ref(),
+                    &backup_opts,
+                ),
             };
             Some(Arc::new(SqliteOffsetStore::new(offset_config).await?))
         } else {
@@ -243,7 +257,10 @@ impl BackupEngine {
                 config.backup_id.clone(),
                 storage.clone(),
                 offset_store.clone(),
-                Duration::from_secs(backup_opts.sync_interval_secs),
+                Duration::from_secs(effective_offset_sync_secs(
+                    config.offset_storage.as_ref(),
+                    &backup_opts,
+                )),
             ))
         });
 
@@ -322,10 +339,7 @@ impl BackupEngine {
         // Try to load offset store from remote if continuous
         if let Some(ref offset_store) = self.offset_store {
             if let Err(e) = offset_store
-                .try_load_from_storage(
-                    self.storage.as_ref(),
-                    &format!("{}/offsets.db", self.config.backup_id),
-                )
+                .try_load_from_storage(self.storage.as_ref(), &offsets_key(&self.config.backup_id))
                 .await
             {
                 warn!("Failed to load offset store from remote: {}", e);
@@ -2833,5 +2847,26 @@ mod tests {
         let (topic, partition, gap) = merged.gaps().next().unwrap();
         assert_eq!((topic, partition), ("orders", 1));
         assert_eq!(gap, &make_gap(0, 50));
+    }
+
+    #[test]
+    fn effective_offset_sync_secs_precedence() {
+        use crate::config::{BackupOptions, OffsetStorageConfig};
+        let backup = BackupOptions {
+            sync_interval_secs: 5,
+            ..Default::default()
+        };
+        // No offset_storage section → backup value.
+        assert_eq!(effective_offset_sync_secs(None, &backup), 5);
+        // Section present but interval unset → backup value (no silent reset to 30).
+        let unset = OffsetStorageConfig::default();
+        assert_eq!(effective_offset_sync_secs(Some(&unset), &backup), 5);
+        // Explicit override wins.
+        let set = OffsetStorageConfig {
+            sync_interval_secs: Some(60),
+            ..Default::default()
+        };
+        assert_eq!(effective_offset_sync_secs(Some(&set), &backup), 60);
+        assert_eq!(offsets_key("daily"), "daily/offsets.db");
     }
 }

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use tracing::warn;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,7 +121,8 @@ fn default_max_partition_labels() -> usize {
 /// Offset storage configuration for tracking backup progress
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OffsetStorageConfig {
-    /// Storage backend type (sqlite or memory)
+    /// Storage backend type. **Deprecated since 0.22.0** — only `sqlite` is
+    /// implemented; `memory` is accepted but ignored (a warning is logged).
     #[serde(default)]
     pub backend: OffsetStorageBackend,
 
@@ -128,13 +130,17 @@ pub struct OffsetStorageConfig {
     #[serde(default = "default_db_path")]
     pub db_path: PathBuf,
 
-    /// S3 key for syncing offset database
+    /// **Deprecated since 0.22.0 — ignored.** The offset database is always
+    /// stored at `{backup_id}/offsets.db` under the storage prefix (`prune`,
+    /// `status` and the operator rely on that location). A warning is logged
+    /// when this is set.
     #[serde(default)]
     pub s3_key: Option<String>,
 
-    /// Sync interval to remote storage in seconds (default: 30)
-    #[serde(default = "default_sync_interval_secs")]
-    pub sync_interval_secs: u64,
+    /// Override `backup.sync_interval_secs` for syncing the offset database to
+    /// remote storage. When unset the backup value (default 30) applies.
+    #[serde(default)]
+    pub sync_interval_secs: Option<u64>,
 }
 
 impl Default for OffsetStorageConfig {
@@ -143,7 +149,7 @@ impl Default for OffsetStorageConfig {
             backend: OffsetStorageBackend::default(),
             db_path: default_db_path(),
             s3_key: None,
-            sync_interval_secs: default_sync_interval_secs(),
+            sync_interval_secs: None,
         }
     }
 }
@@ -434,7 +440,9 @@ pub struct BackupOptions {
     #[serde(default)]
     pub internal_topics: Vec<String>,
 
-    /// Checkpoint interval in seconds (default: 5)
+    /// **Deprecated since 0.22.0 — no effect.** Offsets are checkpointed at
+    /// the end of every backup cycle; a warning is logged when this is set to
+    /// a non-default value.
     #[serde(default = "default_checkpoint_interval_secs")]
     pub checkpoint_interval_secs: u64,
 
@@ -1104,8 +1112,44 @@ impl Config {
         Ok((config, ignored))
     }
 
+    /// Keys that are accepted for backwards compatibility but have no effect
+    /// (issue #161). Pure so it can be unit-tested; `validate()` logs each one.
+    pub fn deprecation_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if let Some(os) = &self.offset_storage {
+            if os.s3_key.is_some() {
+                warnings.push(
+                    "offset_storage.s3_key is ignored (deprecated since 0.22.0): the offset \
+                     database is always stored at {backup_id}/offsets.db under the storage prefix"
+                        .to_string(),
+                );
+            }
+            if os.backend == OffsetStorageBackend::Memory {
+                warnings.push(
+                    "offset_storage.backend: memory is not implemented (deprecated since 0.22.0); \
+                     sqlite is used"
+                        .to_string(),
+                );
+            }
+        }
+        if let Some(backup) = &self.backup {
+            if backup.checkpoint_interval_secs != default_checkpoint_interval_secs() {
+                warnings.push(
+                    "backup.checkpoint_interval_secs has no effect (deprecated since 0.22.0): \
+                     offsets are checkpointed at the end of every backup cycle"
+                        .to_string(),
+                );
+            }
+        }
+        warnings
+    }
+
     /// Validate the configuration
     pub fn validate(&self) -> crate::Result<()> {
+        for warning in self.deprecation_warnings() {
+            warn!("{}", warning);
+        }
+
         match self.mode {
             Mode::Backup => {
                 if self.source.is_none() {
@@ -1662,5 +1706,58 @@ repartitioning:
             },
         );
         assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn deprecation_warnings_list_ignored_offset_keys() {
+        let yaml = r#"
+mode: backup
+backup_id: dep
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+backup:
+  checkpoint_interval_secs: 30
+offset_storage:
+  backend: memory
+  s3_key: custom/offsets.db
+  sync_interval_secs: 60
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let warnings = config.deprecation_warnings();
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings.iter().any(|w| w.contains("offset_storage.s3_key")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("offset_storage.backend")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("backup.checkpoint_interval_secs")));
+        assert_eq!(
+            config.offset_storage.as_ref().unwrap().sync_interval_secs,
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn deprecation_warnings_empty_for_defaults() {
+        let yaml = r#"
+mode: backup
+backup_id: clean
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+offset_storage:
+  db_path: /tmp/offsets.db
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.deprecation_warnings().is_empty());
+        assert_eq!(
+            config.offset_storage.as_ref().unwrap().sync_interval_secs,
+            None,
+            "unset means: use backup.sync_interval_secs"
+        );
     }
 }

--- a/crates/kafka-backup-core/src/config.rs
+++ b/crates/kafka-backup-core/src/config.rs
@@ -405,6 +405,22 @@ pub enum StorageBackendType {
     S3,
 }
 
+/// What to do when a literal (non-glob) `topics.include` entry does not exist
+/// in the cluster (issue #167). Glob patterns that match nothing are always
+/// skipped silently.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnMissingTopic {
+    /// Fail the run (default) — a requested topic that is absent must not
+    /// produce a "successful" backup with zero records for it.
+    #[default]
+    Fail,
+    /// Log a warning, record the topic in the manifest's `missing_topics`,
+    /// expose it via `kafka_backup_missing_topics`, and continue. The run
+    /// still fails if nothing is left to back up.
+    Warn,
+}
+
 /// Backup-specific options
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BackupOptions {
@@ -439,6 +455,11 @@ pub struct BackupOptions {
     /// Internal topics to backup (e.g., __consumer_offsets, __transaction_state)
     #[serde(default)]
     pub internal_topics: Vec<String>,
+
+    /// Behaviour when a literal `topics.include` entry is absent from the
+    /// cluster: `fail` (default) or `warn` (skip it, record it, continue).
+    #[serde(default)]
+    pub on_missing_topic: OnMissingTopic,
 
     /// **Deprecated since 0.22.0 — no effect.** Offsets are checkpointed at
     /// the end of every backup cycle; a warning is logged when this is set to
@@ -634,6 +655,7 @@ impl Default for BackupOptions {
             continuous: false,
             include_internal_topics: false,
             internal_topics: Vec::new(),
+            on_missing_topic: OnMissingTopic::default(),
             checkpoint_interval_secs: default_checkpoint_interval_secs(),
             sync_interval_secs: default_sync_interval_secs(),
             include_offset_headers: default_include_offset_headers(),
@@ -1759,5 +1781,30 @@ offset_storage:
             None,
             "unset means: use backup.sync_interval_secs"
         );
+    }
+
+    #[test]
+    fn on_missing_topic_parses_and_defaults_to_fail() {
+        let base = r#"
+mode: backup
+backup_id: omt
+source:
+  bootstrap_servers: ["localhost:9092"]
+storage:
+  backend: memory
+"#;
+        let config: Config = serde_yaml::from_str(base).unwrap();
+        assert_eq!(
+            config.backup.unwrap_or_default().on_missing_topic,
+            OnMissingTopic::Fail
+        );
+        let warn = format!("{base}backup:\n  on_missing_topic: warn\n");
+        let config: Config = serde_yaml::from_str(&warn).unwrap();
+        assert_eq!(
+            config.backup.unwrap().on_missing_topic,
+            OnMissingTopic::Warn
+        );
+        let bad = format!("{base}backup:\n  on_missing_topic: ignore\n");
+        assert!(serde_yaml::from_str::<Config>(&bad).is_err());
     }
 }

--- a/crates/kafka-backup-core/src/manifest.rs
+++ b/crates/kafka-backup-core/src/manifest.rs
@@ -26,6 +26,12 @@ pub struct BackupManifest {
 
     /// Topics included in this backup
     pub topics: Vec<TopicBackup>,
+
+    /// Literal `topics.include` entries that were absent from the cluster at
+    /// the last discovery pass and skipped because `backup.on_missing_topic`
+    /// is `warn` (issue #167). Empty — and omitted from JSON — otherwise.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_topics: Vec<String>,
 }
 
 impl BackupManifest {
@@ -38,6 +44,7 @@ impl BackupManifest {
             source_brokers: Vec::new(),
             compression: "zstd".to_string(),
             topics: Vec::new(),
+            missing_topics: Vec::new(),
         }
     }
 
@@ -1628,5 +1635,23 @@ mod tests {
         assert!(manifest.topics[0].partitions[0].gaps.is_empty());
         assert_eq!(manifest.total_gaps(), 0);
         assert_eq!(manifest.gaps().count(), 0);
+    }
+
+    #[test]
+    fn missing_topics_round_trip_and_omitted_when_empty() {
+        let mut manifest = BackupManifest::new("m".to_string());
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(!json.contains("missing_topics"), "{json}");
+
+        manifest.missing_topics = vec!["ghost".to_string()];
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(json.contains("\"missing_topics\":[\"ghost\"]"), "{json}");
+        let back: BackupManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.missing_topics, vec!["ghost".to_string()]);
+
+        // Manifests written before the field existed still load.
+        let legacy = r#"{"backup_id":"old","created_at":1,"topics":[]}"#;
+        let old: BackupManifest = serde_json::from_str(legacy).unwrap();
+        assert!(old.missing_topics.is_empty());
     }
 }

--- a/crates/kafka-backup-core/src/metrics/registry.rs
+++ b/crates/kafka-backup-core/src/metrics/registry.rs
@@ -93,6 +93,11 @@ pub struct PrometheusMetrics {
     /// Cumulative compressed bytes deleted by retention.
     pub bytes_pruned_total: Family<BackupLabels, Counter>,
 
+    /// Literal `topics.include` entries absent from the cluster at the last
+    /// discovery pass and skipped (`backup.on_missing_topic: warn`,
+    /// issue #167). Re-evaluated every cycle; 0 once they exist again.
+    pub missing_topics: Family<BackupLabels, Gauge>,
+
     // ========================================
     // Operation Duration Metrics
     // ========================================
@@ -221,6 +226,7 @@ impl PrometheusMetrics {
         let offsets_skipped_total = Family::<BackupLabels, Counter>::default();
         let segments_pruned_total = Family::<BackupLabels, Counter>::default();
         let bytes_pruned_total = Family::<BackupLabels, Counter>::default();
+        let missing_topics = Family::<BackupLabels, Gauge>::default();
 
         // Operation Duration Metrics
         let backup_duration_seconds =
@@ -343,6 +349,11 @@ impl PrometheusMetrics {
             "Cumulative compressed bytes deleted by retention",
             bytes_pruned_total.clone(),
         );
+        registry.register(
+            "kafka_backup_missing_topics",
+            "Literal include topics absent from the cluster at the last discovery pass (backup.on_missing_topic: warn)",
+            missing_topics.clone(),
+        );
 
         // Operation Duration Metrics
         registry.register(
@@ -461,6 +472,7 @@ impl PrometheusMetrics {
             offsets_skipped_total,
             segments_pruned_total,
             bytes_pruned_total,
+            missing_topics,
             backup_duration_seconds,
             restore_duration_seconds,
             storage_write_latency_seconds,
@@ -638,6 +650,13 @@ impl PrometheusMetrics {
             .get_or_create(&labels)
             .inc_by(segments);
         self.bytes_pruned_total.get_or_create(&labels).inc_by(bytes);
+    }
+
+    /// Set the number of literal include topics absent at the last discovery
+    /// pass (`backup.on_missing_topic: warn`). Re-evaluated every cycle.
+    pub fn set_missing_topics(&self, backup_id: &str, count: usize) {
+        let labels = BackupLabels::new(backup_id);
+        self.missing_topics.get_or_create(&labels).set(count as i64);
     }
 
     /// Increment cumulative bytes counter.
@@ -1148,5 +1167,20 @@ mod tests {
         ] {
             assert!(encoded.contains(name), "missing counter series: {name}");
         }
+    }
+
+    #[test]
+    fn missing_topics_gauge_encodes_and_resets() {
+        let metrics = PrometheusMetrics::with_max_labels(10);
+        metrics.set_missing_topics("daily", 2);
+        let text = metrics.encode();
+        assert!(
+            text.contains("kafka_backup_missing_topics{backup_id=\"daily\"} 2"),
+            "{text}"
+        );
+        metrics.set_missing_topics("daily", 0);
+        assert!(metrics
+            .encode()
+            .contains("kafka_backup_missing_topics{backup_id=\"daily\"} 0"));
     }
 }

--- a/crates/kafka-backup-core/src/storage/azure.rs
+++ b/crates/kafka-backup-core/src/storage/azure.rs
@@ -37,6 +37,18 @@ pub struct AzureConfig {
     pub sas_token: Option<String>,
 }
 
+/// Resolve Workload Identity parameters: explicit config values take precedence
+/// over the environment variables injected by the AKS Workload Identity webhook.
+fn resolve_workload_identity(
+    config: &AzureConfig,
+    env: impl Fn(&str) -> Option<String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let client_id = config.client_id.clone().or_else(|| env("AZURE_CLIENT_ID"));
+    let tenant_id = config.tenant_id.clone().or_else(|| env("AZURE_TENANT_ID"));
+    let token_file = env("AZURE_FEDERATED_TOKEN_FILE");
+    (client_id, tenant_id, token_file)
+}
+
 /// Azure Blob Storage backend
 pub struct AzureBackend {
     store: Arc<dyn ObjectStore>,
@@ -50,7 +62,8 @@ impl AzureBackend {
     /// 1. SAS token (`sas_token`)
     /// 2. Storage account key (`account_key`)
     /// 3. Service principal (`client_id` + `client_secret` + `tenant_id`)
-    /// 4. Workload Identity (`use_workload_identity` or AZURE_FEDERATED_TOKEN_FILE env var)
+    /// 4. Workload Identity (`use_workload_identity` or AZURE_FEDERATED_TOKEN_FILE env var);
+    ///    YAML `client_id` / `tenant_id` override the webhook-injected env vars
     /// 5. DefaultAzureCredential chain (environment, managed identity, CLI)
     pub fn new(config: AzureConfig) -> Result<Self> {
         let mut builder = MicrosoftAzureBuilder::new()
@@ -97,11 +110,12 @@ impl AzureBackend {
         } else if config.use_workload_identity.unwrap_or(false)
             || std::env::var("AZURE_FEDERATED_TOKEN_FILE").is_ok()
         {
-            // Workload Identity - explicitly configure federated token authentication
-            // Read from environment variables set by Azure Workload Identity webhook
-            let client_id = std::env::var("AZURE_CLIENT_ID").ok();
-            let tenant_id = std::env::var("AZURE_TENANT_ID").ok();
-            let token_file = std::env::var("AZURE_FEDERATED_TOKEN_FILE").ok();
+            // Workload Identity - explicitly configure federated token authentication.
+            // YAML `client_id` / `tenant_id` win; otherwise the values injected by the
+            // Azure Workload Identity webhook (AZURE_CLIENT_ID / AZURE_TENANT_ID) are
+            // used. The token file always comes from AZURE_FEDERATED_TOKEN_FILE.
+            let (client_id, tenant_id, token_file) =
+                resolve_workload_identity(&config, |name| std::env::var(name).ok());
 
             if let Some(ref file) = token_file {
                 builder = builder.with_federated_token_file(file);
@@ -350,5 +364,54 @@ mod tests {
         backend.delete("test-key").await.unwrap();
         backend.delete("test-key-copy").await.unwrap();
         assert!(!backend.exists("test-key").await.unwrap());
+    }
+
+    fn wi_config(client_id: Option<&str>, tenant_id: Option<&str>) -> AzureConfig {
+        AzureConfig {
+            account_name: "acct".to_string(),
+            container_name: "backups".to_string(),
+            account_key: None,
+            prefix: None,
+            endpoint: None,
+            use_workload_identity: Some(true),
+            client_id: client_id.map(str::to_string),
+            tenant_id: tenant_id.map(str::to_string),
+            client_secret: None,
+            sas_token: None,
+        }
+    }
+
+    fn fake_env(name: &str) -> Option<String> {
+        match name {
+            "AZURE_CLIENT_ID" => Some("env-client".to_string()),
+            "AZURE_TENANT_ID" => Some("env-tenant".to_string()),
+            "AZURE_FEDERATED_TOKEN_FILE" => {
+                Some("/var/run/secrets/azure/tokens/azure-identity-token".to_string())
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn workload_identity_prefers_yaml_ids_over_env() {
+        let (client_id, tenant_id, token_file) = resolve_workload_identity(
+            &wi_config(Some("yaml-client"), Some("yaml-tenant")),
+            fake_env,
+        );
+        assert_eq!(client_id.as_deref(), Some("yaml-client"));
+        assert_eq!(tenant_id.as_deref(), Some("yaml-tenant"));
+        assert_eq!(
+            token_file.as_deref(),
+            Some("/var/run/secrets/azure/tokens/azure-identity-token")
+        );
+    }
+
+    #[test]
+    fn workload_identity_falls_back_to_env() {
+        let (client_id, tenant_id, _) = resolve_workload_identity(&wi_config(None, None), fake_env);
+        assert_eq!(client_id.as_deref(), Some("env-client"));
+        assert_eq!(tenant_id.as_deref(), Some("env-tenant"));
+        let (client_id, _, token) = resolve_workload_identity(&wi_config(None, None), |_| None);
+        assert!(client_id.is_none() && token.is_none());
     }
 }

--- a/crates/kafka-backup-core/src/storage/config.rs
+++ b/crates/kafka-backup-core/src/storage/config.rs
@@ -25,11 +25,13 @@ pub enum StorageBackendConfig {
         /// Custom endpoint URL (for S3-compatible services like MinIO)
         #[serde(default)]
         endpoint: Option<String>,
-        /// Access key ID (falls back to AWS_ACCESS_KEY_ID env var)
-        #[serde(default)]
+        /// Access key ID (falls back to AWS_ACCESS_KEY_ID env var).
+        /// `access_key_id` is accepted as an alias (issue #166).
+        #[serde(default, alias = "access_key_id")]
         access_key: Option<String>,
-        /// Secret access key (falls back to AWS_SECRET_ACCESS_KEY env var)
-        #[serde(default)]
+        /// Secret access key (falls back to AWS_SECRET_ACCESS_KEY env var).
+        /// `secret_access_key` is accepted as an alias (issue #166).
+        #[serde(default, alias = "secret_access_key")]
         secret_key: Option<String>,
         /// Key prefix for all operations
         #[serde(default)]
@@ -107,6 +109,14 @@ pub enum StorageBackendConfig {
     Memory,
 }
 
+/// Plain-HTTP S3 endpoints (in-cluster MinIO / Ceph RGW) need `allow_http` or
+/// the client refuses to build. An explicit `allow_http: true` always wins;
+/// otherwise an `endpoint` starting with `http://` implies it (issue #166).
+/// Shared by the YAML and `--path` URL code paths.
+pub(crate) fn implied_allow_http(endpoint: Option<&str>, explicit: bool) -> bool {
+    explicit || endpoint.is_some_and(|e| e.starts_with("http://"))
+}
+
 impl StorageBackendConfig {
     /// Parse configuration from a URL string
     ///
@@ -150,11 +160,7 @@ impl StorageBackendConfig {
                     .query_pairs()
                     .find(|(k, _)| k == "allow_http")
                     .map(|(_, v)| v == "true")
-                    .unwrap_or_else(|| {
-                        endpoint
-                            .as_deref()
-                            .is_some_and(|e| e.starts_with("http://"))
-                    });
+                    .unwrap_or_else(|| implied_allow_http(endpoint.as_deref(), false));
 
                 Ok(Self::S3 {
                     bucket,
@@ -411,5 +417,36 @@ backend: memory
 "#;
         let config: StorageBackendConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(matches!(config, StorageBackendConfig::Memory));
+    }
+
+    #[test]
+    fn yaml_accepts_legacy_access_key_id_aliases() {
+        let yaml = r#"
+backend: s3
+bucket: backups
+access_key_id: AKIA
+secret_access_key: shh
+"#;
+        let config: StorageBackendConfig = serde_yaml::from_str(yaml).unwrap();
+        match config {
+            StorageBackendConfig::S3 {
+                access_key,
+                secret_key,
+                ..
+            } => {
+                assert_eq!(access_key.as_deref(), Some("AKIA"));
+                assert_eq!(secret_key.as_deref(), Some("shh"));
+            }
+            _ => panic!("expected S3"),
+        }
+    }
+
+    #[test]
+    fn implied_allow_http_cases() {
+        assert!(implied_allow_http(Some("http://minio:9000"), false));
+        assert!(!implied_allow_http(Some("https://s3.example"), false));
+        assert!(!implied_allow_http(None, false));
+        assert!(implied_allow_http(None, true));
+        assert!(implied_allow_http(Some("https://s3.example"), true));
     }
 }

--- a/crates/kafka-backup-core/src/storage/mod.rs
+++ b/crates/kafka-backup-core/src/storage/mod.rs
@@ -52,9 +52,16 @@ pub fn create_backend_from_config(
             access_key,
             secret_key,
             prefix,
-            path_style: _,
+            path_style,
             allow_http,
         } => {
+            let effective_allow_http =
+                crate::storage::config::implied_allow_http(endpoint.as_deref(), *allow_http);
+            if effective_allow_http && !*allow_http {
+                tracing::info!(
+                    "storage.endpoint uses http://; enabling allow_http (set storage.allow_http: true to make this explicit)"
+                );
+            }
             let s3_config = S3Config {
                 bucket: bucket.clone(),
                 region: region.clone(),
@@ -62,7 +69,8 @@ pub fn create_backend_from_config(
                 access_key_id: access_key.clone(),
                 secret_access_key: secret_key.clone(),
                 prefix: prefix.clone(),
-                allow_http: *allow_http,
+                path_style: *path_style,
+                allow_http: effective_allow_http,
             };
             Ok(Arc::new(S3Backend::new(s3_config)?))
         }
@@ -156,6 +164,7 @@ pub fn create_backend_legacy(
                 access_key_id: config.access_key.clone(),
                 secret_access_key: config.secret_key.clone(),
                 prefix: config.prefix.clone(),
+                path_style: false,
                 allow_http: config
                     .endpoint
                     .as_ref()

--- a/crates/kafka-backup-core/src/storage/s3.rs
+++ b/crates/kafka-backup-core/src/storage/s3.rs
@@ -27,6 +27,9 @@ pub struct S3Config {
     pub secret_access_key: Option<String>,
     /// Key prefix for all operations
     pub prefix: Option<String>,
+    /// Use path-style requests (bucket in the path, not the host). Implied by
+    /// a custom `endpoint`; set explicitly for path-style-only AWS setups.
+    pub path_style: bool,
     /// Allow HTTP (insecure) connections
     pub allow_http: bool,
 }
@@ -40,9 +43,17 @@ impl Default for S3Config {
             access_key_id: None,
             secret_access_key: None,
             prefix: None,
+            path_style: false,
             allow_http: false,
         }
     }
+}
+
+/// Path-style requests are used when asked for explicitly, or implied by a
+/// custom endpoint (MinIO / Ceph RGW). Before 0.22.0 the flag was silently
+/// discarded and only the endpoint side effect applied (issue #166).
+pub(crate) fn use_path_style(endpoint: Option<&str>, path_style: bool) -> bool {
+    path_style || endpoint.is_some()
 }
 
 /// S3 storage backend
@@ -62,7 +73,9 @@ impl S3Backend {
 
         if let Some(endpoint) = &config.endpoint {
             builder = builder.with_endpoint(endpoint);
-            // For custom endpoints, we typically need virtual hosted style disabled
+        }
+
+        if use_path_style(config.endpoint.as_deref(), config.path_style) {
             builder = builder.with_virtual_hosted_style_request(false);
         }
 
@@ -282,5 +295,21 @@ mod tests {
         // Test delete
         backend.delete("test-key").await.unwrap();
         assert!(!backend.exists("test-key").await.unwrap());
+    }
+
+    #[test]
+    fn use_path_style_cases() {
+        assert!(
+            use_path_style(Some("http://minio:9000"), false),
+            "endpoint implies path style"
+        );
+        assert!(
+            use_path_style(None, true),
+            "explicit flag honoured without endpoint"
+        );
+        assert!(
+            !use_path_style(None, false),
+            "plain AWS keeps the client default"
+        );
     }
 }

--- a/crates/kafka-backup-core/tests/integration_suite/issue_167_on_missing_topic.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/issue_167_on_missing_topic.rs
@@ -1,0 +1,119 @@
+//! Issue #167 — `backup.on_missing_topic: warn` skips literal include topics
+//! that do not exist, records them in the manifest, and keeps backing up the
+//! rest. A run with nothing left to back up still fails, and the default
+//! (`fail`) keeps the operator #56 guarantee (see `issue_56_missing_topic`).
+
+use std::time::Duration;
+
+use kafka_backup_core::backup::BackupEngine;
+use kafka_backup_core::config::OnMissingTopic;
+use kafka_backup_core::manifest::BackupManifest;
+
+use super::common::{create_backup_config, create_temp_storage, KafkaTestCluster};
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn warn_mode_skips_missing_topic_and_records_it() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let real_topic = "issue167-real";
+    let ghost_topic = "issue167-ghost";
+    cluster
+        .create_topic(real_topic, 20)
+        .await
+        .expect("create topic");
+
+    let temp_dir = create_temp_storage();
+    let backup_id = "issue167-warn";
+    let mut config = create_backup_config(
+        &cluster.bootstrap_servers,
+        temp_dir.path().to_path_buf(),
+        backup_id,
+        vec![real_topic.to_string(), ghost_topic.to_string()],
+    );
+    config
+        .backup
+        .as_mut()
+        .expect("backup options")
+        .on_missing_topic = OnMissingTopic::Warn;
+
+    let engine = BackupEngine::new(config)
+        .await
+        .expect("backup engine should initialize");
+    engine
+        .run()
+        .await
+        .expect("warn mode must back up the remaining topics");
+
+    let manifest_path = temp_dir.path().join(backup_id).join("manifest.json");
+    let manifest: BackupManifest =
+        serde_json::from_slice(&std::fs::read(&manifest_path).expect("manifest written"))
+            .expect("manifest parses");
+
+    assert_eq!(
+        manifest.missing_topics,
+        vec![ghost_topic.to_string()],
+        "the absent literal topic is recorded"
+    );
+    let real = manifest
+        .topics
+        .iter()
+        .find(|t| t.name == real_topic)
+        .expect("existing topic backed up");
+    let records: i64 = real
+        .partitions
+        .iter()
+        .flat_map(|p| p.segments.iter())
+        .map(|s| s.record_count)
+        .sum();
+    assert_eq!(records, 20, "all records of the existing topic archived");
+    assert!(
+        !manifest.topics.iter().any(|t| t.name == ghost_topic),
+        "no manifest entry for the missing topic"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Docker"]
+async fn warn_mode_still_fails_when_nothing_is_left() {
+    let cluster = KafkaTestCluster::start()
+        .await
+        .expect("failed to start Kafka");
+    cluster
+        .wait_for_ready(Duration::from_secs(30))
+        .await
+        .expect("Kafka not ready");
+
+    let temp_dir = create_temp_storage();
+    let ghost_topic = "issue167-only-ghost";
+    let mut config = create_backup_config(
+        &cluster.bootstrap_servers,
+        temp_dir.path().to_path_buf(),
+        "issue167-all-missing",
+        vec![ghost_topic.to_string()],
+    );
+    config
+        .backup
+        .as_mut()
+        .expect("backup options")
+        .on_missing_topic = OnMissingTopic::Warn;
+
+    let engine = BackupEngine::new(config)
+        .await
+        .expect("backup engine should initialize");
+    let error = engine
+        .run()
+        .await
+        .expect_err("a run with every topic missing must still fail");
+    let message = error.to_string();
+    assert!(
+        message.contains(ghost_topic) && message.contains("all configured backup topics"),
+        "unexpected error: {message}"
+    );
+}

--- a/crates/kafka-backup-core/tests/integration_suite/mod.rs
+++ b/crates/kafka-backup-core/tests/integration_suite/mod.rs
@@ -14,6 +14,7 @@
 //! - Issue #148: consumer group offsets applied in Phase 3 after restore
 //! - Issue #154: default offset headers are documented, logged, and strippable on restore
 //! - Issue #155: null header values survive backup and restore
+//! - Issue #167: backup.on_missing_topic warn/fail behaviour
 //! - strimzi-backup-operator#57: snapshot progress gauges describe the current run
 
 pub mod common;
@@ -22,6 +23,7 @@ pub mod issue_146_connection_errors;
 pub mod issue_148_offset_reset_after_restore;
 pub mod issue_154_offset_headers;
 pub mod issue_155_null_header_value;
+pub mod issue_167_on_missing_topic;
 pub mod issue_169_retention;
 pub mod issue_56_missing_topic;
 pub mod issue_57_incremental_snapshot_target;

--- a/crates/kafka-backup-core/tests/preflight_contract_test.rs
+++ b/crates/kafka-backup-core/tests/preflight_contract_test.rs
@@ -177,6 +177,7 @@ fn write_manifest(dir: &Path, partitions: Vec<PartitionBackup>) -> BackupManifes
             configurations: Default::default(),
             partitions,
         }],
+        missing_topics: Vec::new(),
     };
     let path = dir.join(BACKUP_ID).join("manifest.json");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,12 +307,13 @@ storage:
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
 | `bucket` | string | Yes | - | S3 bucket name |
-| `region` | string | Yes | - | AWS region |
+| `region` | string | No | - | AWS region |
 | `prefix` | string | No | `""` | Key prefix (folder) |
-| `endpoint` | string | No | - | Custom endpoint (for MinIO, etc.) |
-| `path_style` | bool | No | `false` | Use path-style URLs |
-| `access_key_id` | string | No | - | AWS access key (or use env/IAM) |
-| `secret_access_key` | string | No | - | AWS secret key |
+| `endpoint` | string | No | - | Custom endpoint (MinIO, Ceph RGW, etc.). Setting one implies path-style requests |
+| `path_style` | bool | No | `false` | Force path-style requests (bucket in the path) even without a custom endpoint |
+| `allow_http` | bool | No | `false` | Allow a plain-HTTP endpoint. Since 0.22.0 an `endpoint` starting with `http://` implies it |
+| `access_key` | string | No | - | AWS access key (or use env/IAM). `access_key_id` is accepted as an alias |
+| `secret_key` | string | No | - | AWS secret key. `secret_access_key` is accepted as an alias |
 
 ```yaml
 storage:
@@ -328,10 +329,10 @@ storage:
 storage:
   backend: s3
   bucket: kafka-backups
-  endpoint: http://minio.local:9000
-  path_style: true
-  access_key_id: minioadmin
-  secret_access_key: ${MINIO_SECRET}
+  endpoint: http://minio.local:9000   # http:// implies allow_http (0.22.0+) and path-style
+  allow_http: true                     # explicit is clearer for on-prem stores (Ceph RGW, MinIO)
+  access_key: minioadmin
+  secret_key: ${MINIO_SECRET}
 ```
 
 ### Azure Blob Storage Backend
@@ -341,9 +342,18 @@ storage:
 | `account_name` | string | Yes | - | Azure storage account name |
 | `container_name` | string | Yes | - | Blob container name |
 | `prefix` | string | No | `""` | Blob prefix (folder) |
-| `account_key` | string | No | - | Account key (or use managed identity) |
-| `sas_token` | string | No | - | SAS token |
-| `use_managed_identity` | bool | No | `false` | Use managed identity |
+| `endpoint` | string | No | - | Custom endpoint (sovereign clouds) |
+| `sas_token` | string | No | - | Shared access signature |
+| `account_key` | string | No | - | Storage account key (`AZURE_STORAGE_KEY` env fallback) |
+| `client_id` | string | No | - | Azure AD client ID (service principal or Workload Identity) |
+| `tenant_id` | string | No | - | Azure AD tenant ID |
+| `client_secret` | string | No | - | Service-principal secret |
+| `use_workload_identity` | bool | No | auto | AKS Workload Identity (federated token). Auto-enabled when `AZURE_FEDERATED_TOKEN_FILE` is set |
+
+Credential precedence: `sas_token` → `account_key` → service principal (`client_secret`) →
+Workload Identity → `DefaultAzureCredential` chain (environment, managed identity, Azure CLI).
+For Workload Identity, YAML `client_id`/`tenant_id` override the webhook-injected
+`AZURE_CLIENT_ID`/`AZURE_TENANT_ID`; the token file always comes from `AZURE_FEDERATED_TOKEN_FILE`.
 
 ```yaml
 storage:
@@ -351,7 +361,7 @@ storage:
   account_name: mybackupstorage
   container_name: kafka-backups
   prefix: production/
-  use_managed_identity: true
+  use_workload_identity: true   # AKS: pod label azure.workload.identity/use=true + SA annotation
 ```
 
 ### Google Cloud Storage Backend
@@ -944,8 +954,13 @@ source:
 | `AWS_ACCESS_KEY_ID` | AWS access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
 | `AWS_REGION` | AWS region |
+| `AWS_ENDPOINT` | Custom S3 endpoint (alternative to `storage.endpoint`) |
+| `AWS_ALLOW_HTTP` | `true` to allow a plain-HTTP S3 endpoint (alternative to `storage.allow_http`) |
 | `AZURE_STORAGE_ACCOUNT` | Azure storage account |
 | `AZURE_STORAGE_KEY` | Azure storage key |
+| `AZURE_STORAGE_SAS_TOKEN` | Azure SAS token |
+| `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_CLIENT_SECRET` | Azure AD service principal (client secret) or Workload Identity ids |
+| `AZURE_FEDERATED_TOKEN_FILE` | Projected token path injected by the AKS Workload Identity webhook; its presence enables Workload Identity |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCP credentials |
 | `RUST_LOG` | Logging level (debug, info, warn, error) |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1014,25 +1014,29 @@ kafka-backup list --path /path/to/storage [OPTIONS]
 ### Describe Command
 
 ```bash
+kafka-backup describe --config backup.yaml [OPTIONS]
 kafka-backup describe --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--format` | Output format |
 
 ### Validate Command
 
 ```bash
+kafka-backup validate --config backup.yaml [OPTIONS]
 kafka-backup validate --path /path/to/storage --backup-id BACKUP_ID [OPTIONS]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `--path` | Path to storage location |
-| `--backup-id` | Backup identifier |
+| `--config` | Backup configuration file — storage (including `prefix`) and `backup_id` are taken from it. Conflicts with `--path`/`--backup-id` |
+| `--path` | Path to storage location (requires `--backup-id`) |
+| `--backup-id` | Backup identifier (requires `--path`) |
 | `--deep` | Perform deep validation |
 
 ### Prune Command

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -401,8 +401,8 @@ the values in `kafka-backup-core`'s `BackupOptions::default()`.
 | `segment_max_interval_ms` | int | No | `60000` | Rotate a segment after this many milliseconds even if it is not full |
 | `segment_max_records` | int | No | unset | Rotate a segment after this many records (no record limit when unset) |
 | `fetch_max_bytes` | int | No | unset | Max bytes per Kafka Fetch request; when unset, `min(segment_max_bytes, 16MB)` |
-| `checkpoint_interval_secs` | int | No | `5` | How often partition progress is checkpointed to the offset store |
-| `sync_interval_secs` | int | No | `30` | How often the offset store is synced to remote storage |
+| `checkpoint_interval_secs` | int | No | `5` | **Deprecated (0.22.0) — no effect.** Offsets are checkpointed at the end of every backup cycle; a warning is logged if set |
+| `sync_interval_secs` | int | No | `30` | How often the manifest and the offset store are synced to remote storage (`offset_storage.sync_interval_secs` overrides it for the offset store) |
 | `include_offset_headers` | bool | No | **`true`** | Add `x-original-offset` / `x-original-timestamp` headers to every archived record — see [Offset-tracking headers](#offset-tracking-headers) |
 | `source_cluster_id` | string | No | unset | Recorded in the `x-source-cluster` header (only with `include_offset_headers`) |
 | `include_internal_topics` | bool | No | `false` | Also back up internal topics listed in `internal_topics` |
@@ -544,7 +544,6 @@ broker-side codec (including gzip and snappy) is decoded on fetch.
 backup:
   compression: zstd
   continuous: true
-  checkpoint_interval_secs: 30
   segment_max_records: 50000
   segment_max_bytes: 52428800     # 50MB
   segment_max_interval_ms: 1800000 # 30 minutes
@@ -560,7 +559,6 @@ backup:
   stop_at_current_offsets: true  # Exit when caught up
   include_offset_headers: true    # Default; x-original-* headers for offset recovery on restore
   source_cluster_id: prod-eu      # Optional; recorded as x-source-cluster
-  checkpoint_interval_secs: 30
   segment_max_bytes: 134217728    # 128MB
 ```
 
@@ -580,10 +578,10 @@ Configuration for the local SQLite database used to track backup progress. When 
 
 | Option | Type | Required | Default | Description |
 |--------|------|----------|---------|-------------|
-| `offset_storage.backend` | string | No | `sqlite` | Storage backend: `sqlite` or `memory` |
+| `offset_storage.backend` | string | No | `sqlite` | Only `sqlite` is implemented; `memory` is **deprecated (0.22.0)** and ignored with a warning |
 | `offset_storage.db_path` | string | No | `$TMPDIR/{backup_id}-offsets.db` | Path to local SQLite database file |
-| `offset_storage.s3_key` | string | No | - | Remote storage key for syncing the database |
-| `offset_storage.sync_interval_secs` | int | No | `30` | How often to sync the local DB to remote storage |
+| `offset_storage.s3_key` | string | No | - | **Deprecated (0.22.0) — ignored.** The database is always stored at `{backup_id}/offsets.db` under the storage prefix (`prune`/`status`/operators rely on it); a warning is logged if set |
+| `offset_storage.sync_interval_secs` | int | No | `backup.sync_interval_secs` | Override for how often the local DB is synced to remote storage (honoured since 0.22.0) |
 
 The offset store is created when `continuous: true` is set **or** when `offset_storage` is explicitly configured. This allows incremental one-shot and snapshot backups by adding the `offset_storage` section to your config:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -407,6 +407,7 @@ the values in `kafka-backup-core`'s `BackupOptions::default()`.
 | `source_cluster_id` | string | No | unset | Recorded in the `x-source-cluster` header (only with `include_offset_headers`) |
 | `include_internal_topics` | bool | No | `false` | Also back up internal topics listed in `internal_topics` |
 | `internal_topics` | list[string] | No | `[]` | Internal topics to include (e.g. `__consumer_offsets`) when `include_internal_topics` is set |
+| `on_missing_topic` | string | No | `fail` | When a literal (non-glob) `topics.include` entry is absent from the cluster: `fail` errors (default, protects one-shot runs from a zero-record "success"); `warn` logs, records the names in the manifest's `missing_topics`, exposes `kafka_backup_missing_topics`, and continues — the run still fails if nothing is left to back up. Globs that match nothing are always skipped silently |
 | `consumer_group_snapshot` | bool | No | `false` | Write `consumer-groups-snapshot.json` after each cycle for `auto_consumer_groups` restores |
 
 ### Offset-tracking headers
@@ -698,6 +699,7 @@ metrics:
 | `kafka_backup_bytes_total` | Counter | Total bytes backed up |
 | `kafka_backup_offset_gaps_total` | Counter | Offset ranges skipped because the source no longer had the records (see [retention gaps](#retention-deleting-data-before-it-is-fetched)) |
 | `kafka_backup_offsets_skipped_total` | Counter | Source offsets skipped across all recorded gaps |
+| `kafka_backup_missing_topics` | Gauge | Literal include topics absent from the cluster at the last discovery pass (`backup.on_missing_topic: warn`); returns to 0 once they exist |
 | `kafka_backup_segments_pruned_total` | Counter | Segments deliberately deleted by retention (`prune` / `backup.retention`) |
 | `kafka_backup_bytes_pruned_total` | Counter | Compressed bytes deleted by retention |
 | `kafka_backup_compression_ratio` | Gauge | Compression efficiency |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -368,7 +368,6 @@ Run backup continuously to capture all changes:
 ```yaml
 backup:
   continuous: true
-  checkpoint_interval_secs: 5
 ```
 
 ### 3. Consumer Offset Management

--- a/docs/storage_guide.md
+++ b/docs/storage_guide.md
@@ -448,24 +448,36 @@ storage:
   account_name: mystorageaccount
   container_name: kafka-backups
 
-  # Optional - Account key (uses DefaultAzureCredential if omitted)
+  # Optional - Account key (uses the credential chain below if omitted)
   account_key: your-account-key
 
   # Optional - Key prefix for all operations
   prefix: cluster-prod
+
+  # Optional - sovereign cloud endpoint (Azure Government, Azure China)
+  # endpoint: https://mystorageaccount.blob.core.usgovcloudapi.net
+
+  # Optional - other credential types
+  # sas_token: "sv=2023-...&sig=..."
+  # client_id: <app-or-managed-identity-client-id>
+  # tenant_id: <tenant-id>
+  # client_secret: ${AZURE_CLIENT_SECRET}      # service principal
+  # use_workload_identity: true                 # AKS Workload Identity (federated token)
 ```
 
 **Environment Variables:**
 - `AZURE_STORAGE_KEY` - Account key (fallback)
-- `AZURE_TENANT_ID` - Tenant ID for service principal
-- `AZURE_CLIENT_ID` - Client ID for service principal
+- `AZURE_STORAGE_SAS_TOKEN` - SAS token (fallback)
+- `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` - Tenant / client ID (service principal or Workload Identity)
 - `AZURE_CLIENT_SECRET` - Client secret for service principal
+- `AZURE_FEDERATED_TOKEN_FILE` - Projected token file injected by the AKS Workload Identity webhook; when set, Workload Identity is used automatically
 
-**Credential Chain (when account_key omitted):**
-1. Environment variables (service principal)
-2. Managed Identity
-3. Azure CLI credentials
-4. Azure Developer CLI credentials
+**Credential precedence:**
+1. `sas_token`
+2. `account_key`
+3. Service principal (`client_id` + `tenant_id` + `client_secret`)
+4. Workload Identity (`use_workload_identity: true` or `AZURE_FEDERATED_TOKEN_FILE` present) — YAML `client_id`/`tenant_id` override the webhook-injected `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`
+5. `DefaultAzureCredential` chain (environment, managed identity, Azure CLI, Azure Developer CLI)
 
 ### Google Cloud Storage
 
@@ -512,7 +524,7 @@ storage:
 
 | Backend | URL Format |
 |---------|------------|
-| S3 | `s3://bucket?region=us-east-1&endpoint=http://host:9000` |
+| S3 | `s3://bucket/prefix?region=us-east-1&endpoint=http://host:9000&path_style=true&allow_http=true` — an `endpoint=http://…` implies `allow_http=true` (and path-style); pass `allow_http=false` to override |
 | Azure | `azure://account.blob.core.windows.net/container` |
 | GCS | `gcs://bucket` or `gs://bucket` |
 | Filesystem | `file:///path/to/storage` |
@@ -770,9 +782,26 @@ spec:
                 name: kafka-backup-config
 ```
 
-### Azure Kubernetes Service (AKS) with Managed Identity
+### Azure Kubernetes Service (AKS) with Workload Identity
 
-#### Enable Workload Identity
+Works for the CLI running as a plain Kubernetes Job (no operator required). The AKS
+Workload Identity webhook injects `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+`AZURE_AUTHORITY_HOST` and `AZURE_FEDERATED_TOKEN_FILE` into any pod that carries the
+`azure.workload.identity/use: "true"` label and runs under an annotated ServiceAccount.
+
+#### 1. Federated credential (Azure side, once)
+
+```bash
+AKS_OIDC_ISSUER=$(az aks show -g <rg> -n <cluster> --query oidcIssuerProfile.issuerUrl -o tsv)
+az identity federated-credential create \
+  --name kafka-backup --identity-name <managed-identity> -g <rg> \
+  --issuer "$AKS_OIDC_ISSUER" \
+  --subject system:serviceaccount:<namespace>:kafka-backup \
+  --audiences api://AzureADTokenExchange
+# The identity needs "Storage Blob Data Contributor" on the container/account.
+```
+
+#### 2. ServiceAccount + Job
 
 ```yaml
 apiVersion: v1
@@ -782,32 +811,40 @@ metadata:
   annotations:
     azure.workload.identity/client-id: <MANAGED_IDENTITY_CLIENT_ID>
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: kafka-backup
 spec:
   template:
     metadata:
       labels:
-        azure.workload.identity/use: "true"
+        azure.workload.identity/use: "true"   # required: triggers the token injection
     spec:
       serviceAccountName: kafka-backup
+      restartPolicy: OnFailure
       containers:
         - name: kafka-backup
-          image: kafka-backup:latest
+          image: osodevops/kafka-backup:latest
+          args: ["backup", "--config", "/config/backup.yaml"]
           # No credentials needed - uses Workload Identity
 ```
 
-#### Storage Config (No account_key)
+#### 3. Storage config
 
 ```yaml
 storage:
   backend: azure
   account_name: mystorageaccount
   container_name: kafka-backups
-  # account_key omitted - uses Managed Identity
+  use_workload_identity: true
+  # client_id / tenant_id are optional: the webhook-injected AZURE_CLIENT_ID /
+  # AZURE_TENANT_ID are used unless set here.
 ```
+
+Troubleshooting: run with `RUST_LOG=debug` — the backend logs
+`Azure authentication: Workload Identity (client_id=…, tenant_id=…, token_file=…)`;
+a `not set` token file means the pod label or ServiceAccount annotation is missing.
 
 ### Google Kubernetes Engine (GKE) with Workload Identity
 


### PR DESCRIPTION
Squash-merge of the `release/0.22.0` branch (#180, #183, #182, #184, #185) — one tag, one release.

Closes #161, #166, #167, #168.

### Added
- **`backup.on_missing_topic: fail | warn`** (#167): `warn` skips absent literal `topics.include` entries, records them in the manifest's new `missing_topics` field and the `kafka_backup_missing_topics` gauge, and continues; a run with nothing left still fails; globs unaffected. `describe`/`validate` surface it as informational.
- **`describe` / `validate --config`** (#168): parity with `status`/`prune` via one shared resolver (`storage_path::resolve_target`); `--path`+`--backup-id` still work, forms mutually exclusive.
- S3 `access_key_id` / `secret_access_key` accepted as aliases (#166) — the reference documented those nonexistent names, so configs written from it silently dropped credentials.

### Fixed
- S3 `path_style` was discarded by the backend factory (#166).
- YAML `endpoint: http://…` implies `allow_http` (matches the `--path` URL behaviour) — on-prem HTTP stores (Ceph RGW / MinIO) without `AWS_ALLOW_HTTP`.
- Azure Workload Identity: YAML `client_id`/`tenant_id` override the webhook env vars (were ignored).
- `offset_storage.sync_interval_secs` honoured (overrides `backup.sync_interval_secs` for the offset DB) (#161).
- Configuration reference: real S3/Azure option names, Azure precedence + env vars incl. `AZURE_FEDERATED_TOKEN_FILE`, `--path` URL params, AKS Workload Identity Job example.

### Deprecated (warned, no behaviour change)
- `offset_storage.s3_key` (remote copy is always `{backup_id}/offsets.db`), `offset_storage.backend: memory`, `backup.checkpoint_interval_secs` (never had a read site) (#161).

### Breaking (library API) — 0.22.0
`BackupOptions.on_missing_topic`, `BackupManifest.missing_topics`, `OffsetStorageConfig::sync_interval_secs: Option<u64>`, `S3Config.path_style`. The generic kafka-backup-operator builds these by literal — follow-up issue there.

### Verification
- `cargo test` workspace green (core 363 unit + suites, CLI incl. new `issue_167_missing_topics.rs` / `issue_168_config_flag.rs`), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- Docker: `integration_suite::issue_167_on_missing_topic` (warn skips + records + backs up the rest; all-missing fails) and `issue_56_missing_topic` (default still fails) green locally.
- The per-PR "Detect Breaking Changes" failures on the release branch were the expected semver flags for the public-field additions; this PR carries the 0.22.0 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN