### PR TITLE
docs: SECURITY.md — set the reporting address and response targets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,14 +4,14 @@
 
 Please **do not** open a public GitHub issue for a security problem.
 
-Report it to `<<security@oso.sh>>` (or through
+Report it to security@oso.sh (or through
 [GitHub private vulnerability reporting](https://github.com/osodevops/kafka-backup/security/advisories/new)
 on this repository). Include the kafka-backup version, the storage backend and
 Kafka version involved, a description of the issue, and steps to reproduce if
 you have them.
 
-You will receive an acknowledgement within `<<2 business days>>` and a
-severity assessment within `<<5 business days>>`. We follow coordinated
+You will receive an acknowledgement within two business days and a
+severity assessment within five business days. We follow coordinated
 disclosure: we ask for up to 90 days to ship a fix before details are
 published, and we credit reporters in the advisory unless they prefer not to
 be named.


### PR DESCRIPTION
Replaces the `<<placeholders>>` left in #190 with the published values: reports go to security@oso.sh (or GitHub private vulnerability reporting), acknowledged within two business days and assessed within five. Matches the docs site's support page and the operator's SECURITY.md.

Docs-only; no code or version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkonEgED6jayFGkQ9vXnKN